### PR TITLE
Staking in a farm also calls _claim()

### DIFF
--- a/contracts/truefi/TrueFarm.sol
+++ b/contracts/truefi/TrueFarm.sol
@@ -92,6 +92,7 @@ contract TrueFarm is ITrueFarm, Initializable {
      * @param amount Amount of tokens to stake
      */
     function stake(uint256 amount) external override update {
+        _claim();
         staked[msg.sender] = staked[msg.sender].add(amount);
         totalStaked = totalStaked.add(amount);
         require(stakingToken.transferFrom(msg.sender, address(this), amount));

--- a/contracts/truefi/TrueFarm.sol
+++ b/contracts/truefi/TrueFarm.sol
@@ -92,7 +92,9 @@ contract TrueFarm is ITrueFarm, Initializable {
      * @param amount Amount of tokens to stake
      */
     function stake(uint256 amount) external override update {
-        _claim();
+        if (claimableReward[msg.sender] > 0) {
+            _claim();
+        }
         staked[msg.sender] = staked[msg.sender].add(amount);
         totalStaked = totalStaked.add(amount);
         require(stakingToken.transferFrom(msg.sender, address(this), amount));

--- a/contracts/truefi/TrueFarm.sol
+++ b/contracts/truefi/TrueFarm.sol
@@ -68,7 +68,7 @@ contract TrueFarm is ITrueFarm, Initializable {
     event Claim(address indexed who, uint256 amountClaimed);
 
     /**
-     * @dev Initalize staking pool with a Distributor contraxct
+     * @dev Initalize staking pool with a Distributor contract
      * The distributor contract calculates how much TRU rewards this contract
      * gets, and stores TRU for distribution.
      * @param _stakingToken Token to stake
@@ -89,6 +89,7 @@ contract TrueFarm is ITrueFarm, Initializable {
 
     /**
      * @dev Stake tokens for TRU rewards.
+     * Also claims any existing rewards.
      * @param amount Amount of tokens to stake
      */
     function stake(uint256 amount) external override update {

--- a/flatten/TrueFarm.sol
+++ b/flatten/TrueFarm.sol
@@ -454,7 +454,7 @@ contract TrueFarm is ITrueFarm, Initializable {
     event Claim(address indexed who, uint256 amountClaimed);
 
     /**
-     * @dev Initalize staking pool with a Distributor contraxct
+     * @dev Initalize staking pool with a Distributor contract
      * The distributor contract calculates how much TRU rewards this contract
      * gets, and stores TRU for distribution.
      * @param _stakingToken Token to stake
@@ -475,9 +475,13 @@ contract TrueFarm is ITrueFarm, Initializable {
 
     /**
      * @dev Stake tokens for TRU rewards.
+     * Also claims any existing rewards.
      * @param amount Amount of tokens to stake
      */
     function stake(uint256 amount) external override update {
+        if (claimableReward[msg.sender] > 0) {
+            _claim();
+        }
         staked[msg.sender] = staked[msg.sender].add(amount);
         totalStaked = totalStaked.add(amount);
         require(stakingToken.transferFrom(msg.sender, address(this), amount));

--- a/test/truefi/TrueFarm.test.ts
+++ b/test/truefi/TrueFarm.test.ts
@@ -185,7 +185,8 @@ describe('TrueFarm', () => {
     it('claiming clears claimableRewards', async () => {
       await farm.connect(staker1).stake(parseEth(500), txArgs)
       await timeTravel(provider, DAY)
-      await farm.connect(staker1).stake(parseEth(500), txArgs)
+      // force an update to claimableReward:
+      await farm.connect(staker1).unstake(parseEth(1), txArgs)
       expect(await farm.claimableReward(staker1.address)).to.be.gt(0)
 
       await farm.connect(staker1).claim(txArgs)

--- a/test/truefi/TrueFarm.test.ts
+++ b/test/truefi/TrueFarm.test.ts
@@ -182,6 +182,14 @@ describe('TrueFarm', () => {
       expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
     })
 
+    it('staking claims pending rewards', async () => {
+      await farm.connect(staker1).stake(parseEth(500), txArgs)
+      await timeTravel(provider, DAY)
+      await farm.connect(staker1).stake(parseEth(500), txArgs)
+
+      expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
+    })
+
     it('claiming clears claimableRewards', async () => {
       await farm.connect(staker1).stake(parseEth(500), txArgs)
       await timeTravel(provider, DAY)


### PR DESCRIPTION
By far the most (gas-)expensive part of interacting with the farm is the update() modifier, which needs to be called before staking, unstaking, and claiming rewards. Notice that exit() already exists to save on gas by bundling together unstaking and claiming, so that update only needs to be called once. To save on gas, staking and claiming rewards should be similarly bundled.