### PR TITLE
Shortcircuit claimable() calculation when nothing is staked

### DIFF
--- a/contracts/truefi/TrueFarm.sol
+++ b/contracts/truefi/TrueFarm.sol
@@ -150,6 +150,9 @@ contract TrueFarm is ITrueFarm, Initializable {
      * @return claimable rewards for account
      */
     function claimable(address account) external view returns (uint256) {
+        if (staked[account] == 0) {
+            return claimableReward[account];
+        }
         // estimate pending reward from distributor
         uint256 pending = trueDistributor.nextDistribution();
         // calculate total rewards (including pending)

--- a/flatten/ArbitraryDistributor.sol
+++ b/flatten/ArbitraryDistributor.sol
@@ -1,0 +1,538 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Dependency file: contracts/truefi/common/UpgradeableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is Initializable, Context {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function initialize() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Dependency file: contracts/truefi/interface/IArbitraryDistributor.sol
+
+// pragma solidity 0.6.10;
+
+interface IArbitraryDistributor {
+    function amount() external returns (uint256);
+
+    function remaining() external returns (uint256);
+
+    function beneficiary() external returns (address);
+
+    function distribute(uint256 _amount) external;
+
+    function empty() external;
+}
+
+
+// Root file: contracts/truefi/distributors/ArbitraryDistributor.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {Ownable} from "contracts/truefi/common/UpgradeableOwnable.sol";
+// import {IArbitraryDistributor} from "contracts/truefi/interface/IArbitraryDistributor.sol";
+
+/**
+ * @title ArbitraryTrueDistributor
+ * @notice Distribute TRU to a smart contract
+ * @dev Allows for arbitrary claiming of TRU by a farm contract
+ *
+ * Contracts are registered to receive distributions. Once registered,
+ * a farm contract can claim TRU from the distributor.
+ * - Owner can withdraw funds in case distribution need to be re-allocated
+ */
+contract ArbitraryDistributor is IArbitraryDistributor, Ownable {
+    using SafeMath for uint256;
+
+    // ================ WARNING ==================
+    // ===== THIS CONTRACT IS INITIALIZABLE ======
+    // === STORAGE VARIABLES ARE DECLARED BELOW ==
+    // REMOVAL OR REORDER OF VARIABLES WILL RESULT
+    // ========= IN STORAGE CORRUPTION ===========
+
+    IERC20 public trustToken;
+    address public override beneficiary;
+    uint256 public override amount;
+    uint256 public override remaining;
+
+    // ======= STORAGE DECLARATION END ============
+
+    event Distributed(uint256 amount);
+
+    /**
+     * @dev Initialize distributor
+     * @param _beneficiary Address for distribution
+     * @param _trustToken TRU address
+     * @param _amount Amount to distribute
+     */
+    function initialize(
+        address _beneficiary,
+        IERC20 _trustToken,
+        uint256 _amount
+    ) public initializer {
+        Ownable.initialize();
+        trustToken = _trustToken;
+        beneficiary = _beneficiary;
+        amount = _amount;
+        remaining = _amount;
+    }
+
+    /**
+     * @dev Only beneficiary can receive TRU
+     */
+    modifier onlyBeneficiary {
+        // prettier-ignore
+        require(msg.sender == beneficiary,
+            "ArbitraryDistributor: Only beneficiary can receive tokens");
+        _;
+    }
+
+    /**
+     * @dev Distribute arbitrary number of tokens
+     * @param _amount Amount of TRU to distribute
+     */
+    function distribute(uint256 _amount) public override onlyBeneficiary {
+        remaining = remaining.sub(_amount);
+        require(trustToken.transfer(msg.sender, _amount));
+
+        emit Distributed(_amount);
+    }
+
+    /**
+     * @dev Withdraw funds (for instance if owner decides to create a new distribution) and end distribution cycle
+     */
+    function empty() public override onlyOwner {
+        remaining = 0;
+        require(trustToken.transfer(msg.sender, trustToken.balanceOf(address(this))));
+    }
+}

--- a/flatten/AvalancheTokenController.sol
+++ b/flatten/AvalancheTokenController.sol
@@ -1,0 +1,945 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/proxy/interface/IOwnedUpgradeabilityProxy.sol
+
+// pragma solidity 0.6.10;
+
+interface IOwnedUpgradeabilityProxy {
+    function proxyOwner() external view returns (address owner);
+
+    function pendingProxyOwner() external view returns (address pendingOwner);
+
+    function transferProxyOwnership(address newOwner) external;
+
+    function claimProxyOwnership() external;
+
+    function upgradeTo(address implementation) external;
+
+    function implementation() external view returns (address impl);
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IHasOwner.sol
+
+// pragma solidity 0.6.10;
+
+interface IHasOwner {
+    function claimOwnership() external;
+
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IReclaimerToken {
+    function reclaimToken(IERC20 token, address _to) external;
+
+    function reclaimEther(address payable _to) external;
+}
+
+
+// Dependency file: contracts/true-currencies/interface/ITrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IHasOwner} from "contracts/true-currencies/interface/IHasOwner.sol";
+// import {IReclaimerToken} from "contracts/true-currencies/interface/IReclaimerToken.sol";
+
+interface ITrueCurrency is IERC20, IReclaimerToken, IHasOwner {
+    function refundGas(uint256 amount) external;
+
+    function setBlacklisted(address account, bool _isBlacklisted) external;
+
+    function setCanBurn(address account, bool _canBurn) external;
+
+    function setBurnBounds(uint256 _min, uint256 _max) external;
+
+    function mint(address account, uint256 amount) external;
+}
+
+
+// Root file: contracts/avalanche/AvalancheTokenController.sol
+
+pragma solidity 0.6.10;
+
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IOwnedUpgradeabilityProxy as OwnedUpgradeabilityProxy} from "contracts/proxy/interface/IOwnedUpgradeabilityProxy.sol";
+
+// import {IHasOwner as HasOwner} from "contracts/true-currencies/interface/IHasOwner.sol";
+// import {ITrueCurrency as TrueCurrency} from "contracts/true-currencies/interface/ITrueCurrency.sol";
+
+/** @title TokenController
+ * @dev This contract allows us to split ownership of the TrueCurrency contract
+ * into two addresses. One, called the "owner" address, has unfettered control of the TrueCurrency contract -
+ * it can mint new tokens, transfer ownership of the contract, etc. However to make
+ * extra sure that TrueCurrency is never compromised, this owner key will not be used in
+ * day-to-day operations, allowing it to be stored at a heightened level of security.
+ * Instead, the owner appoints an various "admin" address.
+ * There are 3 different types of admin addresses;  MintKey, MintRatifier, and MintPauser.
+ * MintKey can request and revoke mints one at a time.
+ * MintPausers can pause individual mints or pause all mints.
+ * MintRatifiers can approve and finalize mints with enough approval.
+
+ * There are three levels of mints: instant mint, ratified mint, and multiSig mint. Each have a different threshold
+ * and deduct from a different pool.
+ * Instant mint has the lowest threshold and finalizes instantly without any ratifiers. Deduct from instant mint pool,
+ * which can be refilled by one ratifier.
+ * Ratify mint has the second lowest threshold and finalizes with one ratifier approval. Deduct from ratify mint pool,
+ * which can be refilled by three ratifiers.
+ * MultiSig mint has the highest threshold and finalizes with three ratifier approvals. Deduct from multiSig mint pool,
+ * which can only be refilled by the owner.
+*/
+
+contract AvalancheTokenController {
+    using SafeMath for uint256;
+
+    struct MintOperation {
+        address to;
+        uint256 value;
+        uint256 requestedBlock;
+        uint256 numberOfApproval;
+        bool paused;
+        mapping(address => bool) approved;
+    }
+
+    address payable public owner;
+    address payable public pendingOwner;
+
+    uint256 public instantMintThreshold;
+    uint256 public ratifiedMintThreshold;
+    uint256 public multiSigMintThreshold;
+
+    uint256 public instantMintLimit;
+    uint256 public ratifiedMintLimit;
+    uint256 public multiSigMintLimit;
+
+    uint256 public instantMintPool;
+    uint256 public ratifiedMintPool;
+    uint256 public multiSigMintPool;
+    address[2] public ratifiedPoolRefillApprovals;
+
+    uint8 public constant RATIFY_MINT_SIGS = 1; //number of approvals needed to finalize a Ratified Mint
+    uint8 public constant MULTISIG_MINT_SIGS = 3; //number of approvals needed to finalize a MultiSig Mint
+
+    bool public mintPaused;
+    uint256 public mintReqInvalidBeforeThisBlock; //all mint request before this block are invalid
+    address public mintKey;
+    MintOperation[] public mintOperations; //list of a mint requests
+
+    TrueCurrency public token;
+    address public registryAdmin;
+    mapping(address => bool) public isMintPauser;
+    mapping(address => bool) public isMintRatifier;
+
+    bool initialized;
+
+    // paused version of TrueCurrency in Production
+    // pausing the contract upgrades the proxy to this implementation
+    address public constant PAUSED_IMPLEMENTATION = 0x3c8984DCE8f68FCDEEEafD9E0eca3598562eD291;
+
+    modifier onlyMintKeyOrOwner() {
+        require(msg.sender == mintKey || msg.sender == owner, "TokenController: Must be mintKey or owner");
+        _;
+    }
+
+    modifier onlyMintPauserOrOwner() {
+        require(isMintPauser[msg.sender] || msg.sender == owner, "TokenController: Must be pauser or owner");
+        _;
+    }
+
+    modifier onlyMintRatifierOrOwner() {
+        require(isMintRatifier[msg.sender] || msg.sender == owner, "TokenController: Must be ratifier or owner");
+        _;
+    }
+
+    modifier onlyRegistryAdmin() {
+        require(msg.sender == registryAdmin || msg.sender == owner, "TokenController: Must be registry admin or owner");
+        _;
+    }
+
+    //mint operations by the mintkey cannot be processed on when mints are paused
+    modifier mintNotPaused() {
+        if (msg.sender != owner) {
+            require(!mintPaused, "TokenController: Minting is paused");
+        }
+        _;
+    }
+    /// @dev Emitted when ownership of controller was transferred
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    /// @dev Emitted when ownership of controller transfer procedure was started
+    event NewOwnerPending(address indexed currentOwner, address indexed pendingOwner);
+    /// @dev Emitted when owner was transferred for child contract
+    event TransferChild(address indexed child, address indexed newOwner);
+    /// @dev Emitted when child ownership was claimed
+    event RequestReclaimContract(address indexed other);
+    /// @dev Emitted when child token was changed
+    event SetToken(TrueCurrency newContract);
+    /// @dev Emitted when canBurn status of the `burner` was changed to `canBurn`
+    event CanBurn(address burner, bool canBurn);
+
+    /// @dev Emitted when mint was requested
+    event RequestMint(address indexed to, uint256 indexed value, uint256 opIndex, address mintKey);
+    /// @dev Emitted when mint was finalized
+    event FinalizeMint(address indexed to, uint256 indexed value, uint256 opIndex, address mintKey);
+    /// @dev Emitted on instant mint
+    event InstantMint(address indexed to, uint256 indexed value, address indexed mintKey);
+
+    /// @dev Emitted when mint key was replaced
+    event TransferMintKey(address indexed previousMintKey, address indexed newMintKey);
+    /// @dev Emitted when mint was ratified
+    event MintRatified(uint256 indexed opIndex, address indexed ratifier);
+    /// @dev Emitted when mint is revoked
+    event RevokeMint(uint256 opIndex);
+    /// @dev Emitted when all mining is paused (status=true) or unpaused (status=false)
+    event AllMintsPaused(bool status);
+    /// @dev Emitted when opIndex mint is paused (status=true) or unpaused (status=false)
+    event MintPaused(uint256 opIndex, bool status);
+    /// @dev Emitted when mint is approved
+    event MintApproved(address approver, uint256 opIndex);
+    /// @dev Emitted when fast pause contract is changed
+    event FastPauseSet(address _newFastPause);
+
+    /// @dev Emitted when mint threshold changes
+    event MintThresholdChanged(uint256 instant, uint256 ratified, uint256 multiSig);
+    /// @dev Emitted when mint limits change
+    event MintLimitsChanged(uint256 instant, uint256 ratified, uint256 multiSig);
+    /// @dev Emitted when instant mint pool is refilled
+    event InstantPoolRefilled();
+    /// @dev Emitted when instant mint pool is ratified
+    event RatifyPoolRefilled();
+    /// @dev Emitted when multisig mint pool is ratified
+    event MultiSigPoolRefilled();
+
+    /*
+    ========================================
+    Ownership functions
+    ========================================
+    */
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "TokenController: Only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    function initialize() external {
+        require(!initialized, "already initialized");
+        owner = msg.sender;
+        initialized = true;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address payable newOwner) external onlyOwner {
+        pendingOwner = newOwner;
+        emit NewOwnerPending(address(owner), address(pendingOwner));
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() external onlyPendingOwner {
+        emit OwnershipTransferred(address(owner), address(pendingOwner));
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+
+    /*
+    ========================================
+    proxy functions
+    ========================================
+    */
+
+    function transferTrueCurrencyProxyOwnership(address _newOwner) external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).transferProxyOwnership(_newOwner);
+    }
+
+    function claimTrueCurrencyProxyOwnership() external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).claimProxyOwnership();
+    }
+
+    function upgradeTrueCurrencyProxyImplTo(address _implementation) external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(_implementation);
+    }
+
+    /*
+    ========================================
+    Minting functions
+    ========================================
+    */
+
+    /**
+     * @dev set the threshold for a mint to be considered an instant mint,
+     * ratify mint and multiSig mint. Instant mint requires no approval,
+     * ratify mint requires 1 approval and multiSig mint requires 3 approvals
+     */
+    function setMintThresholds(
+        uint256 _instant,
+        uint256 _ratified,
+        uint256 _multiSig
+    ) external onlyOwner {
+        require(_instant <= _ratified && _ratified <= _multiSig);
+        instantMintThreshold = _instant;
+        ratifiedMintThreshold = _ratified;
+        multiSigMintThreshold = _multiSig;
+        emit MintThresholdChanged(_instant, _ratified, _multiSig);
+    }
+
+    /**
+     * @dev set the limit of each mint pool. For example can only instant mint up to the instant mint pool limit
+     * before needing to refill
+     */
+    function setMintLimits(
+        uint256 _instant,
+        uint256 _ratified,
+        uint256 _multiSig
+    ) external onlyOwner {
+        require(_instant <= _ratified && _ratified <= _multiSig);
+        instantMintLimit = _instant;
+        if (instantMintPool > instantMintLimit) {
+            instantMintPool = instantMintLimit;
+        }
+        ratifiedMintLimit = _ratified;
+        if (ratifiedMintPool > ratifiedMintLimit) {
+            ratifiedMintPool = ratifiedMintLimit;
+        }
+        multiSigMintLimit = _multiSig;
+        if (multiSigMintPool > multiSigMintLimit) {
+            multiSigMintPool = multiSigMintLimit;
+        }
+        emit MintLimitsChanged(_instant, _ratified, _multiSig);
+    }
+
+    /**
+     * @dev Ratifier can refill instant mint pool
+     */
+    function refillInstantMintPool() external onlyMintRatifierOrOwner {
+        ratifiedMintPool = ratifiedMintPool.sub(instantMintLimit.sub(instantMintPool));
+        instantMintPool = instantMintLimit;
+        emit InstantPoolRefilled();
+    }
+
+    /**
+     * @dev Owner or 3 ratifiers can refill Ratified Mint Pool
+     */
+    function refillRatifiedMintPool() external onlyMintRatifierOrOwner {
+        if (msg.sender != owner) {
+            address[2] memory refillApprovals = ratifiedPoolRefillApprovals;
+            require(msg.sender != refillApprovals[0] && msg.sender != refillApprovals[1]);
+            if (refillApprovals[0] == address(0)) {
+                ratifiedPoolRefillApprovals[0] = msg.sender;
+                return;
+            }
+            if (refillApprovals[1] == address(0)) {
+                ratifiedPoolRefillApprovals[1] = msg.sender;
+                return;
+            }
+        }
+        delete ratifiedPoolRefillApprovals; // clears the whole array
+        multiSigMintPool = multiSigMintPool.sub(ratifiedMintLimit.sub(ratifiedMintPool));
+        ratifiedMintPool = ratifiedMintLimit;
+        emit RatifyPoolRefilled();
+    }
+
+    /**
+     * @dev Owner can refill MultiSig Mint Pool
+     */
+    function refillMultiSigMintPool() external onlyOwner {
+        multiSigMintPool = multiSigMintLimit;
+        emit MultiSigPoolRefilled();
+    }
+
+    /**
+     * @dev mintKey initiates a request to mint _value for account _to
+     * @param _to the address to mint to
+     * @param _value the amount requested
+     */
+    function requestMint(address _to, uint256 _value) external mintNotPaused onlyMintKeyOrOwner {
+        MintOperation memory op = MintOperation(_to, _value, block.number, 0, false);
+        emit RequestMint(_to, _value, mintOperations.length, msg.sender);
+        mintOperations.push(op);
+    }
+
+    /**
+     * @dev Instant mint without ratification if the amount is less
+     * than instantMintThreshold and instantMintPool
+     * @param _to the address to mint to
+     * @param _value the amount minted
+     */
+    function instantMint(address _to, uint256 _value) external mintNotPaused onlyMintKeyOrOwner {
+        require(_value <= instantMintThreshold, "TokenController: Over the instant mint threshold");
+        require(_value <= instantMintPool, "TokenController: Instant mint pool is dry");
+        instantMintPool = instantMintPool.sub(_value);
+        emit InstantMint(_to, _value, msg.sender);
+        token.mint(_to, _value);
+    }
+
+    /**
+     * @dev ratifier ratifies a request mint. If the number of
+     * ratifiers that signed off is greater than the number of
+     * approvals required, the request is finalized
+     * @param _index the index of the requestMint to ratify
+     * @param _to the address to mint to
+     * @param _value the amount requested
+     */
+    function ratifyMint(
+        uint256 _index,
+        address _to,
+        uint256 _value
+    ) external mintNotPaused onlyMintRatifierOrOwner {
+        MintOperation memory op = mintOperations[_index];
+        require(op.to == _to, "TokenController: To address does not match");
+        require(op.value == _value, "TokenController: Amount does not match");
+        require(!mintOperations[_index].approved[msg.sender], "TokenController: Already approved");
+        mintOperations[_index].approved[msg.sender] = true;
+        mintOperations[_index].numberOfApproval = mintOperations[_index].numberOfApproval.add(1);
+        emit MintRatified(_index, msg.sender);
+        if (hasEnoughApproval(mintOperations[_index].numberOfApproval, _value)) {
+            finalizeMint(_index);
+        }
+    }
+
+    /**
+     * @dev finalize a mint request, mint the amount requested to the specified address
+     * @param _index of the request (visible in the RequestMint event accompanying the original request)
+     */
+    function finalizeMint(uint256 _index) public mintNotPaused {
+        MintOperation memory op = mintOperations[_index];
+        address to = op.to;
+        uint256 value = op.value;
+        if (msg.sender != owner) {
+            require(canFinalize(_index));
+            _subtractFromMintPool(value);
+        }
+        delete mintOperations[_index];
+        token.mint(to, value);
+        emit FinalizeMint(to, value, _index, msg.sender);
+    }
+
+    /**
+     * assumption: only invoked when canFinalize
+     */
+    function _subtractFromMintPool(uint256 _value) internal {
+        if (_value <= ratifiedMintPool && _value <= ratifiedMintThreshold) {
+            ratifiedMintPool = ratifiedMintPool.sub(_value);
+        } else {
+            multiSigMintPool = multiSigMintPool.sub(_value);
+        }
+    }
+
+    /**
+     * @dev compute if the number of approvals is enough for a given mint amount
+     */
+    function hasEnoughApproval(uint256 _numberOfApproval, uint256 _value) public view returns (bool) {
+        if (_value <= ratifiedMintPool && _value <= ratifiedMintThreshold) {
+            if (_numberOfApproval >= RATIFY_MINT_SIGS) {
+                return true;
+            }
+        }
+        if (_value <= multiSigMintPool && _value <= multiSigMintThreshold) {
+            if (_numberOfApproval >= MULTISIG_MINT_SIGS) {
+                return true;
+            }
+        }
+        if (msg.sender == owner) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @dev compute if a mint request meets all the requirements to be finalized
+     * utility function for a front end
+     */
+    function canFinalize(uint256 _index) public view returns (bool) {
+        MintOperation memory op = mintOperations[_index];
+        require(op.requestedBlock > mintReqInvalidBeforeThisBlock, "TokenController: This mint is invalid"); //also checks if request still exists
+        require(!op.paused, "TokenController: This mint is paused");
+        require(hasEnoughApproval(op.numberOfApproval, op.value), "TokenController: Not enough approvals");
+        return true;
+    }
+
+    /**
+     * @dev revoke a mint request, Delete the mintOperation
+     * @param _index of the request (visible in the RequestMint event accompanying the original request)
+     */
+    function revokeMint(uint256 _index) external onlyMintKeyOrOwner {
+        delete mintOperations[_index];
+        emit RevokeMint(_index);
+    }
+
+    /**
+     * @dev get mint operatino count
+     * @return mint operation count
+     */
+    function mintOperationCount() public view returns (uint256) {
+        return mintOperations.length;
+    }
+
+    /*
+    ========================================
+    Key management
+    ========================================
+    */
+
+    /**
+     * @dev Replace the current mintkey with new mintkey
+     * @param _newMintKey address of the new mintKey
+     */
+    function transferMintKey(address _newMintKey) external onlyOwner {
+        require(_newMintKey != address(0), "TokenController: New mint key cannot be 0x0");
+        emit TransferMintKey(mintKey, _newMintKey);
+        mintKey = _newMintKey;
+    }
+
+    function setRegistryAdmin(address admin) external onlyOwner {
+        registryAdmin = admin;
+    }
+
+    function setIsMintPauser(address account, bool status) external onlyRegistryAdmin {
+        isMintPauser[account] = status;
+    }
+
+    function setIsMintRatifier(address account, bool status) external onlyRegistryAdmin {
+        isMintRatifier[account] = status;
+    }
+
+    /*
+    ========================================
+    Mint Pausing
+    ========================================
+    */
+
+    /**
+     * @dev invalidates all mint request initiated before the current block
+     */
+    function invalidateAllPendingMints() external onlyOwner {
+        mintReqInvalidBeforeThisBlock = block.number;
+    }
+
+    /**
+     * @dev pause any further mint request and mint finalizations
+     */
+    function pauseMints() external onlyMintPauserOrOwner {
+        mintPaused = true;
+        emit AllMintsPaused(true);
+    }
+
+    /**
+     * @dev unpause any further mint request and mint finalizations
+     */
+    function unpauseMints() external onlyOwner {
+        mintPaused = false;
+        emit AllMintsPaused(false);
+    }
+
+    /**
+     * @dev pause a specific mint request
+     * @param  _opIndex the index of the mint request the caller wants to pause
+     */
+    function pauseMint(uint256 _opIndex) external onlyMintPauserOrOwner {
+        mintOperations[_opIndex].paused = true;
+        emit MintPaused(_opIndex, true);
+    }
+
+    /**
+     * @dev unpause a specific mint request
+     * @param  _opIndex the index of the mint request the caller wants to unpause
+     */
+    function unpauseMint(uint256 _opIndex) external onlyOwner {
+        mintOperations[_opIndex].paused = false;
+        emit MintPaused(_opIndex, false);
+    }
+
+    /*
+    ========================================
+    set and claim contracts, administrative
+    ========================================
+    */
+
+    /**
+     * @dev Update this contract's token pointer to newContract (e.g. if the
+     * contract is upgraded)
+     */
+    function setToken(TrueCurrency _newContract) external onlyOwner {
+        token = _newContract;
+        emit SetToken(_newContract);
+    }
+
+    /**
+     * @dev Claim ownership of an arbitrary HasOwner contract
+     */
+    function issueClaimOwnership(address _other) public onlyOwner {
+        HasOwner other = HasOwner(_other);
+        other.claimOwnership();
+    }
+
+    /**
+     * @dev Transfer ownership of _child to _newOwner.
+     * Can be used e.g. to upgrade this TokenController contract.
+     * @param _child contract that tokenController currently Owns
+     * @param _newOwner new owner/pending owner of _child
+     */
+    function transferChild(HasOwner _child, address _newOwner) external onlyOwner {
+        _child.transferOwnership(_newOwner);
+        emit TransferChild(address(_child), _newOwner);
+    }
+
+    /**
+     * @dev send all ether in token address to the owner of tokenController
+     */
+    function requestReclaimEther() external onlyOwner {
+        token.reclaimEther(owner);
+    }
+
+    /**
+     * @dev transfer all tokens of a particular type in token address to the
+     * owner of tokenController
+     * @param _token token address of the token to transfer
+     */
+    function requestReclaimToken(IERC20 _token) external onlyOwner {
+        token.reclaimToken(_token, owner);
+    }
+
+    /**
+     * @dev pause all pausable actions on TrueCurrency, mints/burn/transfer/approve
+     */
+    function pauseToken() external virtual onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(PAUSED_IMPLEMENTATION);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amounts that TrueCurrency users can
+     * burn to newMin and newMax
+     * @param _min minimum amount user can burn at a time
+     * @param _max maximum amount user can burn at a time
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        token.setBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Owner can send ether balance in contract address
+     * @param _to address to which the funds will be send to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev Owner can send erc20 token balance in contract address
+     * @param _token address of the token to send
+     * @param _to address to which the funds will be send to
+     */
+    function reclaimToken(IERC20 _token, address _to) external onlyOwner {
+        uint256 balance = _token.balanceOf(address(this));
+        _token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Owner can allow address to burn tokens
+     * @param burner address of the token that can burn
+     * @param canBurn true if account is allowed to burn, false otherwise
+     */
+    function setCanBurn(address burner, bool canBurn) external onlyRegistryAdmin {
+        token.setCanBurn(burner, canBurn);
+        emit CanBurn(burner, canBurn);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param isBlacklisted blacklist flag value
+     */
+    function setBlacklisted(address account, bool isBlacklisted) external onlyRegistryAdmin {
+        token.setBlacklisted(account, isBlacklisted);
+    }
+}

--- a/flatten/AvalancheTrueUSD.sol
+++ b/flatten/AvalancheTrueUSD.sol
@@ -1,0 +1,1197 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Root file: contracts/avalanche/AvalancheTrueUSD.sol
+
+pragma solidity 0.6.10;
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+/**
+ * @title TrueUSD
+ * @dev This is the top-level ERC20 contract, but most of the interesting functionality is
+ * inherited - see the documentation on the corresponding contracts.
+ */
+contract AvalancheTrueUSD is TrueCurrency {
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function initialize() external {
+        require(!initialized);
+        owner = msg.sender;
+        initialized = true;
+    }
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueUSD";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TUSD";
+    }
+}

--- a/flatten/BurnableTokenWithBounds.sol
+++ b/flatten/BurnableTokenWithBounds.sol
@@ -1,0 +1,984 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Root file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}

--- a/flatten/ClaimableContract.sol
+++ b/flatten/ClaimableContract.sol
@@ -1,0 +1,96 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Root file: contracts/governance/common/ClaimableContract.sol
+
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+/**
+ * @title ClaimableContract
+ * @dev The ClaimableContract contract is a copy of Claimable Contract by Zeppelin.
+ and provides basic authorization control functions. Inherits storage layout of
+ ProxyStorage.
+ */
+contract ClaimableContract  {
+    address owner_;
+    address pendingOwner_;
+    bool initalized;
+
+
+    function owner() public view returns (address) {
+        return owner_;
+    }
+
+    function pendingOwner() public view returns (address) {
+        return pendingOwner_;
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner_ = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner_, "only owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner_);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner_ = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        address _pendingOwner = pendingOwner_;
+        emit OwnershipTransferred(owner_, _pendingOwner);
+        owner_ = _pendingOwner;
+        pendingOwner_ = address(0);
+    }
+}

--- a/flatten/ClaimableOwnable.sol
+++ b/flatten/ClaimableOwnable.sol
@@ -1,0 +1,168 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Root file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}

--- a/flatten/DelegateERC20.sol
+++ b/flatten/DelegateERC20.sol
@@ -1,0 +1,1302 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Root file: contracts/true-currencies/DelegateERC20.sol
+
+pragma solidity 0.6.10;
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+/**
+ * @title DelegateERC20
+ * Accept forwarding delegation calls from the old TrueUSD (V1) contract.
+ * This way the all the ERC20 functions in the old contract still works
+ * (except Burn).
+ *
+ * The original contract is at 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E.
+ * Lines 497-574 on-chain call these delegate functions to forward calls
+ * This gives the delegate contract the power to change the state of the TrueUSD
+ * contract. The owner of this contract is the TrueUSD TokenController
+ * at 0x0000000000075efbee23fe2de1bd0b7690883cc9.
+ *
+ * Our audits for TrueCurrency can be found here: github.com/trusttoken/audits
+ */
+abstract contract DelegateERC20 is TrueCurrency {
+    address constant DELEGATE_FROM = 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E;
+
+    // require msg.sender is the delegate smart contract
+    modifier onlyDelegateFrom() {
+        require(msg.sender == DELEGATE_FROM);
+        _;
+    }
+
+    /**
+     * @dev Delegate call to get total supply
+     * @return Total supply
+     */
+    function delegateTotalSupply() public view returns (uint256) {
+        return totalSupply();
+    }
+
+    /**
+     * @dev Delegate call to get balance
+     * @param who Address to get balance for
+     * @return balance of account
+     */
+    function delegateBalanceOf(address who) public view returns (uint256) {
+        return balanceOf(who);
+    }
+
+    /**
+     * @dev Delegate call to transfer
+     * @param to address to transfer to
+     * @param value amount to transfer
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateTransfer(
+        address to,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        _transfer(origSender, to, value);
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to get allowance
+     * @param owner account owner
+     * @param spender account to check allowance for
+     * @return allowance
+     */
+    function delegateAllowance(address owner, address spender) public view returns (uint256) {
+        return allowance(owner, spender);
+    }
+
+    /**
+     * @dev Delegate call to transfer from
+     * @param from account to transfer funds from
+     * @param to account to transfer funds to
+     * @param value value to transfer
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateTransferFrom(
+        address from,
+        address to,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 transferFrom with _msgSender() replaced by origSender
+        _transfer(from, to, value);
+        _approve(from, origSender, _allowances[from][origSender].sub(value, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to approve
+     * @param spender account to approve for
+     * @param value amount to approve
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateApprove(
+        address spender,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        _approve(origSender, spender, value);
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to increase approval
+     * @param spender account to increase approval for
+     * @param addedValue amount of approval to add
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateIncreaseApproval(
+        address spender,
+        uint256 addedValue,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 increaseAllowance() with _msgSender() replaced by origSender
+        _approve(origSender, spender, _allowances[origSender][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to decrease approval
+     * @param spender spender to decrease approval for
+     * @param subtractedValue value to subtract from approval
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateDecreaseApproval(
+        address spender,
+        uint256 subtractedValue,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 decreaseAllowance() with _msgSender() replaced by origSender
+        _approve(origSender, spender, _allowances[origSender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+}

--- a/flatten/ERC20.sol
+++ b/flatten/ERC20.sol
@@ -1,0 +1,868 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Root file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}

--- a/flatten/ERC20Burnable.sol
+++ b/flatten/ERC20Burnable.sol
@@ -1,0 +1,749 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+contract ProxyStorage {
+    // Initializable.sol
+    bool _initialized;
+    bool _initializing;
+
+    // Ownable.sol
+    address _owner;
+
+    // ERC20.sol
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    uint256 _totalSupply;
+
+    // TrueMintableBurnable.sol
+    uint256 _minBurnAmount;
+    uint256 _maxBurnAmount;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 20         "trueGold.proxy.owner"                                        Proxy Owner
+     ** 28         "trueGold.pending.proxy.owner"                                Pending Proxy Owner
+     ** 29         "trueGold.proxy.implementation"                               Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   _balances
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       _allowances
+     **/
+}
+
+
+// Dependency file: contracts/true-gold/common/ERC20.sol
+
+// pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+// import "@openzeppelin/contracts/utils/Address.sol";
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20MinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ProxyStorage, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    // mapping (address => uint256) private _balances;
+    // mapping (address => mapping (address => uint256)) private _allowances;
+    // uint256 private _totalSupply;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8);
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public override view returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public override view returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(msg.sender, recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public virtual override view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(msg.sender, spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+}
+
+
+// Root file: contracts/true-gold/common/ERC20Burnable.sol
+
+pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ERC20.sol";
+
+/**
+ * @dev Extension of {ERC20} that allows token holders to destroy both their own
+ * tokens and those that they have an allowance for, in a way that can be
+ * recognized off-chain (via event analysis).
+ */
+abstract contract ERC20Burnable is ERC20 {
+    /**
+     * @dev Destroys `amount` tokens from the caller.
+     *
+     * See {ERC20-_burn}.
+     */
+    function burn(uint256 amount) public virtual {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, deducting from the caller's
+     * allowance.
+     *
+     * See {ERC20-_burn} and {ERC20-allowance}.
+     *
+     * Requirements:
+     *
+     * - the caller must have allowance for ``accounts``'s tokens of at least
+     * `amount`.
+     */
+    function burnFrom(address account, uint256 amount) public virtual {
+        uint256 decreasedAllowance = allowance(account, msg.sender).sub(amount, "ERC20Burnable: burn amount exceeds allowance");
+
+        _approve(account, msg.sender, decreasedAllowance);
+        _burn(account, amount);
+    }
+}

--- a/flatten/ERC20Mock.sol
+++ b/flatten/ERC20Mock.sol
@@ -1,0 +1,786 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/ERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+// import "@openzeppelin/contracts/GSN/Context.sol";
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+// import "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20 is Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    mapping (address => uint256) private _balances;
+
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    constructor (string memory name, string memory symbol) public {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Root file: contracts/true-gold/mocks/ERC20Mock.sol
+
+pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+// mock class using ERC20
+contract ERC20Mock is ERC20 {
+    constructor(address initialAccount, uint256 initialBalance) public payable ERC20("Mock Token", "MOCK") {
+        _mint(initialAccount, initialBalance);
+    }
+
+    function mint(address account, uint256 amount) public {
+        _mint(account, amount);
+    }
+
+    function burn(address account, uint256 amount) public {
+        _burn(account, amount);
+    }
+
+    function transferInternal(
+        address from,
+        address to,
+        uint256 value
+    ) public {
+        _transfer(from, to, value);
+    }
+
+    function approveInternal(
+        address owner,
+        address spender,
+        uint256 value
+    ) public {
+        _approve(owner, spender, value);
+    }
+}

--- a/flatten/ForceEther.sol
+++ b/flatten/ForceEther.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,22 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/true-currencies/mocks/ForceEther.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+// Source: @openzeppelin/contracts/mocks/ForceEther.sol
+// @title Force Ether into a contract.
+// @notice  even
+// if the contract is not payable.
+// @notice To use, construct the contract with the target as argument.
+// @author Remco Bloemen <remco@neufund.org>
+contract ForceEther {
+    // solhint-disable-next-line no-empty-blocks
+    constructor() public payable {}
+
+    function destroyAndSend(address _recipient) public {
+        selfdestruct(address(uint160(_recipient)));
+    }
+}

--- a/flatten/GasRefund.sol
+++ b/flatten/GasRefund.sol
@@ -1,0 +1,134 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Root file: contracts/true-currencies/common/GasRefund.sol
+
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+/**
+ * @title Gas Reclaim Legacy
+ *
+ * Note: this contract does not affect any of the token logic. It merely
+ * exists so the TokenController (owner) can reclaim the sponsored gas
+ *
+ * Previously TrueCurrency has a feature called "gas boost" which allowed
+ * us to sponsor gas by setting non-empty storage slots to 1.
+ * We are depricating this feature, but there is a bunch of gas saved
+ * from years of sponsoring gas. This contract is meant to allow the owner
+ * to take advantage of this leftover gas. Once all the slots are used,
+ * this contract can be removed from TrueCurrency.
+ *
+ * Utilitzes the gas refund mechanism in EVM. Each time an non-empty
+ * storage slot is set to 0, evm will refund 15,000 to the sender.
+ * Also utilized the refund for selfdestruct, see gasRefund39
+ */
+abstract contract GasRefund {
+    /**
+     * @dev Refund 15,000 gas per slot.
+     * @param amount number of slots to free
+     */
+    function gasRefund15(uint256 amount) internal {
+        assembly {
+            // get number of free slots
+            let offset := sload(0xfffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // get location of first slot
+            let location := add(offset, 0xfffff)
+            // loop until end is reached
+            for {
+                let end := sub(location, amount)
+            } gt(location, end) {
+                location := sub(location, 1)
+            } {
+                // set storage location to zero
+                // this refunds 15,000 gas
+                sstore(location, 0)
+            }
+            // store new number of free slots
+            sstore(0xfffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev use smart contract self-destruct to refund gas
+     * will refund 39,000 * amount gas
+     */
+    function gasRefund39(uint256 amount) internal {
+        assembly {
+            // get amount of gas slots
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // first sheep pointer
+            let location := sub(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, offset)
+            // loop from location to end
+            for {
+                let end := add(location, amount)
+            } lt(location, end) {
+                location := add(location, 1)
+            } {
+                // load sheep address
+                let sheep := sload(location)
+                // call selfdestruct on sheep
+                pop(call(gas(), sheep, 0, 0, 0, 0, 0))
+                // clear sheep address
+                sstore(location, 0)
+            }
+            // store new number of sheep
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev Return the remaining sponsored gas slots
+     */
+    function remainingGasRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xfffff)
+        }
+    }
+
+    /**
+     * @dev Return the remaining sheep slots
+     */
+    function remainingSheepRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}

--- a/flatten/GovernorAlpha.sol
+++ b/flatten/GovernorAlpha.sol
@@ -1,0 +1,585 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/governance/common/ClaimableContract.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+/**
+ * @title ClaimableContract
+ * @dev The ClaimableContract contract is a copy of Claimable Contract by Zeppelin.
+ and provides basic authorization control functions. Inherits storage layout of
+ ProxyStorage.
+ */
+contract ClaimableContract  {
+    address owner_;
+    address pendingOwner_;
+    bool initalized;
+
+
+    function owner() public view returns (address) {
+        return owner_;
+    }
+
+    function pendingOwner() public view returns (address) {
+        return pendingOwner_;
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner_ = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner_, "only owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner_);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner_ = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        address _pendingOwner = pendingOwner_;
+        emit OwnershipTransferred(owner_, _pendingOwner);
+        owner_ = _pendingOwner;
+        pendingOwner_ = address(0);
+    }
+}
+
+
+// Dependency file: contracts/governance/interface/ITimelock.sol
+
+
+// pragma solidity ^0.6.10;
+
+interface ITimelock {
+    function delay() external view returns (uint);
+    function GRACE_PERIOD() external view returns (uint);
+    function acceptAdmin() external;
+    function queuedTransactions(bytes32 hash) external view returns (bool);
+    function queueTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external returns (bytes32);
+    function cancelTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external;
+    function executeTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external payable returns (bytes memory);
+}
+
+// Dependency file: contracts/governance/interface/IVoteToken.sol
+
+
+// pragma solidity ^0.6.10;
+
+interface IVoteToken {
+    function delegate(address delegatee) external;
+    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s) external;
+    function getCurrentVotes(address account) external view returns (uint96);
+    function getPriorVotes(address account, uint blockNumber) external view returns (uint96);
+}
+
+// Root file: contracts/governance/GovernorAlpha.sol
+
+// AND COPIED FROM https://github.com/compound-finance/compound-protocol/blob/master/contracts/Governance/GovernorAlpha.sol
+// Copyright 2020 Compound Labs, Inc.
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Ctrl+f for OLD to see all the modifications.
+
+// OLD: pragma solidity ^0.5.16;
+pragma solidity ^0.6.10;
+pragma experimental ABIEncoderV2;
+
+// import {ClaimableContract} from "contracts/governance/common/ClaimableContract.sol";
+// import {ITimelock} from "contracts/governance/interface/ITimelock.sol";
+// import {IVoteToken} from "contracts/governance/interface/IVoteToken.sol";
+
+contract GovernorAlpha is ClaimableContract {
+    // @notice The name of this contract
+    // OLD: string public constant name = "Compound Governor Alpha";
+    string public constant name = "TrustToken Governor Alpha";
+
+    // @notice The number of votes in support of a proposal required in order for a quorum to be reached and for a vote to succeed
+    // OLD: function quorumVotes() public pure returns (uint) { return 400000e18; } // 400,000 = 4% of Comp
+    function quorumVotes() public pure returns (uint) { return 10000000e8; } // 10,000,000 Tru
+
+    // @notice The number of votes required in order for a voter to become a proposer
+    // OLD: function proposalThreshold() public pure returns (uint) { return 100000e18; } // 100,000 = 1% of Comp
+    function proposalThreshold() public pure returns (uint) { return 100000e8; } // 100,000 TRU
+
+    // @notice The maximum number of actions that can be included in a proposal
+    function proposalMaxOperations() public pure returns (uint) { return 10; } // 10 actions
+
+    // @notice The delay before voting on a proposal may take place, once proposed
+    function votingDelay() public pure returns (uint) { return 1; } // 1 block
+
+    // @notice The duration of voting on a proposal, in blocks
+    // OLD: function votingPeriod() public pure returns (uint) { return 17280; } // ~3 days in blocks (assuming 15s blocks)
+    uint public votingPeriod;
+
+    // @notice The address of the TrustToken Protocol Timelock
+    ITimelock public timelock;
+
+    // @notice The address of the TrustToken governance token
+    // OLD: CompInterface public comp;
+    IVoteToken public trustToken;
+
+    // @notice The address of the stkTRU voting token
+    IVoteToken public stkTRU;
+
+    // @notice The address of the Governor Guardian
+    address public guardian;
+
+    // @notice The total number of proposals
+    uint public proposalCount;
+
+    struct Proposal {
+        // @notice Unique id for looking up a proposal
+        uint id;
+
+        // @notice Creator of the proposal
+        address proposer;
+
+        // @notice The timestamp that the proposal will be available for execution, set once the vote succeeds
+        uint eta;
+
+        // @notice the ordered list of target addresses for calls to be made
+        address[] targets;
+
+        // @notice The ordered list of values (i.e. msg.value) to be passed to the calls to be made
+        uint[] values;
+
+        // @notice The ordered list of function signatures to be called
+        string[] signatures;
+
+        // @notice The ordered list of calldata to be passed to each call
+        bytes[] calldatas;
+
+        // @notice The block at which voting begins: holders must delegate their votes prior to this block
+        uint startBlock;
+
+        // @notice The block at which voting ends: votes must be cast prior to this block
+        uint endBlock;
+
+        // @notice Current number of votes in favor of this proposal
+        uint forVotes;
+
+        // @notice Current number of votes in opposition to this proposal
+        uint againstVotes;
+
+        // @notice Flag marking whether the proposal has been canceled
+        bool canceled;
+
+        // @notice Flag marking whether the proposal has been executed
+        bool executed;
+
+        // @notice Receipts of ballots for the entire set of voters
+        mapping (address => Receipt) receipts;
+    }
+
+    // @notice Ballot receipt record for a voter
+    struct Receipt {
+        // @notice Whether or not a vote has been cast
+        bool hasVoted;
+
+        // @notice Whether or not the voter supports the proposal
+        bool support;
+
+        // @notice The number of votes the voter had, which were cast
+        uint96 votes;
+    }
+
+    // @notice Possible states that a proposal may be in
+    enum ProposalState {
+        Pending,
+        Active,
+        Canceled,
+        Defeated,
+        Succeeded,
+        Queued,
+        Expired,
+        Executed
+    }
+
+    // @notice The official record of all proposals ever proposed
+    mapping (uint => Proposal) public proposals;
+
+    // @notice The latest proposal for each proposer
+    mapping (address => uint) public latestProposalIds;
+
+    // @notice The EIP-712 typehash for the contract's domain
+    bytes32 public constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+
+    // @notice The EIP-712 typehash for the ballot struct used by the contract
+    bytes32 public constant BALLOT_TYPEHASH = keccak256("Ballot(uint256 proposalId,bool support)");
+
+    // @notice An event emitted when a new proposal is created
+    event ProposalCreated(uint id, address proposer, address[] targets, uint[] values, string[] signatures, bytes[] calldatas, uint startBlock, uint endBlock, string description);
+
+    // @notice An event emitted when a vote has been cast on a proposal
+    event VoteCast(address voter, uint proposalId, bool support, uint votes);
+
+    // @notice An event emitted when a proposal has been canceled
+    event ProposalCanceled(uint id);
+
+    // @notice An event emitted when a proposal has been queued in the Timelock
+    event ProposalQueued(uint id, uint eta);
+
+    // @notice An event emitted when a proposal has been executed in the Timelock
+    event ProposalExecuted(uint id);
+
+    /**
+     * @dev Initialize sets the addresses of timelock contract, trusttoken contract, and guardian
+     */
+    function initialize(ITimelock _timelock, IVoteToken _trustToken, address _guardian, IVoteToken _stkTRU, uint256 _votingPeriod) external {
+        timelock = _timelock;
+        trustToken = _trustToken;
+        stkTRU = _stkTRU;
+        guardian = _guardian;
+        votingPeriod = _votingPeriod;
+
+        owner_ = msg.sender;
+        initalized = true;
+    }
+
+    /**
+     * @dev Create a proposal to change the protocol
+     * @param targets The ordered list of target addresses for calls to be made during proposal execution
+     * @param values The ordered list of values to be passed to the calls made during proposal execution
+     * @param signatures The ordered list of function signatures to be passed during execution
+     * @param calldatas The ordered list of data to be passed to each individual function call
+     * @param description A human readable description of the proposal and changes it will enact
+     * @return The ID of the newly created proposal
+     */
+    function propose(address[] memory targets, uint[] memory values, string[] memory signatures, bytes[] memory calldatas, string memory description) public returns (uint) {
+        require(countVotes(msg.sender, sub256(block.number, 1)) > proposalThreshold(), "GovernorAlpha::propose: proposer votes below proposal threshold");
+        require(targets.length == values.length && targets.length == signatures.length && targets.length == calldatas.length, "GovernorAlpha::propose: proposal function information arity mismatch");
+        require(targets.length != 0, "GovernorAlpha::propose: must provide actions");
+        require(targets.length <= proposalMaxOperations(), "GovernorAlpha::propose: too many actions");
+
+        uint latestProposalId = latestProposalIds[msg.sender];
+        if (latestProposalId != 0) {
+          ProposalState proposersLatestProposalState = state(latestProposalId);
+          require(proposersLatestProposalState != ProposalState.Active, "GovernorAlpha::propose: one live proposal per proposer, found an already active proposal");
+          require(proposersLatestProposalState != ProposalState.Pending, "GovernorAlpha::propose: one live proposal per proposer, found an already pending proposal");
+        }
+
+        uint startBlock = add256(block.number, votingDelay());
+        // OLD: uint endBlock = add256(startBlock, votingPeriod());
+        uint endBlock = add256(startBlock, votingPeriod);
+
+        proposalCount++;
+        Proposal memory newProposal = Proposal({
+            id: proposalCount,
+            proposer: msg.sender,
+            eta: 0,
+            targets: targets,
+            values: values,
+            signatures: signatures,
+            calldatas: calldatas,
+            startBlock: startBlock,
+            endBlock: endBlock,
+            forVotes: 0,
+            againstVotes: 0,
+            canceled: false,
+            executed: false
+        });
+
+        proposals[newProposal.id] = newProposal;
+        latestProposalIds[newProposal.proposer] = newProposal.id;
+
+        emit ProposalCreated(newProposal.id, msg.sender, targets, values, signatures, calldatas, startBlock, endBlock, description);
+        return newProposal.id;
+    }
+
+    /**
+     * @dev Queue a proposal after a proposal has succeeded
+     * @param proposalId ID of a proposal that has succeeded
+     */
+    function queue(uint proposalId) public {
+        require(state(proposalId) == ProposalState.Succeeded, "GovernorAlpha::queue: proposal can only be queued if it is succeeded");
+        Proposal storage proposal = proposals[proposalId];
+        uint eta = add256(block.timestamp, timelock.delay());
+        for (uint i = 0; i < proposal.targets.length; i++) {
+            _queueOrRevert(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], eta);
+        }
+        proposal.eta = eta;
+        emit ProposalQueued(proposalId, eta);
+    }
+
+    /**
+     * @dev Queue one single proposal transaction to timelock contract
+     * @param target The target address for call to be made during proposal execution
+     * @param value The value to be passed to the calls made during proposal execution
+     * @param signature The function signature to be passed during execution
+     * @param data The data to be passed to the individual function call
+     * @param eta The current timestamp plus the timelock delay
+     */
+    function _queueOrRevert(address target, uint value, string memory signature, bytes memory data, uint eta) internal {
+        require(!timelock.queuedTransactions(keccak256(abi.encode(target, value, signature, data, eta))), "GovernorAlpha::_queueOrRevert: proposal action already queued at eta");
+        timelock.queueTransaction(target, value, signature, data, eta);
+    }
+
+    /**
+     * @dev Execute a proposal after a proposal has queued and invoke each of the actions in the proposal
+     * @param proposalId ID of a proposal that has queued
+     */
+    function execute(uint proposalId) public payable {
+        require(state(proposalId) == ProposalState.Queued, "GovernorAlpha::execute: proposal can only be executed if it is queued");
+        Proposal storage proposal = proposals[proposalId];
+        proposal.executed = true;
+        for (uint i = 0; i < proposal.targets.length; i++) {
+            //OLD: timelock.executeTransaction.value(proposal.values[i])(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
+            timelock.executeTransaction{value: proposal.values[i]}(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
+        }
+        emit ProposalExecuted(proposalId);
+    }
+
+    /**
+     * @dev Cancel a proposal that has not yet been executed
+     * @param proposalId ID of a proposal that wished to be canceled
+     */
+    function cancel(uint proposalId) public {
+        ProposalState state = state(proposalId);
+        require(state != ProposalState.Executed, "GovernorAlpha::cancel: cannot cancel executed proposal");
+
+        Proposal storage proposal = proposals[proposalId];
+        require(msg.sender == guardian || countVotes(proposal.proposer, sub256(block.number, 1)) < proposalThreshold(), "GovernorAlpha::cancel: proposer above threshold");
+
+        proposal.canceled = true;
+        for (uint i = 0; i < proposal.targets.length; i++) {
+            timelock.cancelTransaction(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
+        }
+
+        emit ProposalCanceled(proposalId);
+    }
+
+    /**
+     * @dev Get the actions of a selected proposal
+     * @param proposalId ID of a proposal
+     * return An array of target addresses, an array of proposal values, an array of proposal singatures, and an array of calldata
+     */
+    function getActions(uint proposalId) public view returns (address[] memory targets, uint[] memory values, string[] memory signatures, bytes[] memory calldatas) {
+        Proposal storage p = proposals[proposalId];
+        return (p.targets, p.values, p.signatures, p.calldatas);
+    }
+
+    /**
+     * @dev Get a proposal ballot receipt of the indicated voter
+     * @param proposalId ID of a proposal in which to get voter's ballot receipt
+     * @return the Ballot receipt record for a voter
+     */
+    function getReceipt(uint proposalId, address voter) public view returns (Receipt memory) {
+        return proposals[proposalId].receipts[voter];
+    }
+
+    /**
+     * @dev Get the proposal state for the specified proposal
+     * @param proposalId ID of a proposal in which to get its state
+     * @return Enumerated type of ProposalState
+     */
+    function state(uint proposalId) public view returns (ProposalState) {
+        require(proposalCount >= proposalId && proposalId > 0, "GovernorAlpha::state: invalid proposal id");
+        Proposal storage proposal = proposals[proposalId];
+        if (proposal.canceled) {
+            return ProposalState.Canceled;
+        } else if (block.number <= proposal.startBlock) {
+            return ProposalState.Pending;
+        } else if (block.number <= proposal.endBlock) {
+            return ProposalState.Active;
+        } else if (proposal.forVotes <= proposal.againstVotes || proposal.forVotes < quorumVotes()) {
+            return ProposalState.Defeated;
+        } else if (proposal.eta == 0) {
+            return ProposalState.Succeeded;
+        } else if (proposal.executed) {
+            return ProposalState.Executed;
+        } else if (block.timestamp >= add256(proposal.eta, timelock.GRACE_PERIOD())) {
+            return ProposalState.Expired;
+        } else {
+            return ProposalState.Queued;
+        }
+    }
+
+    /**
+     * @dev Cast a vote on a proposal
+     * @param proposalId ID of a proposal in which to cast a vote
+     * @param support A boolean of true for 'for' or false for 'against' vote
+     */
+    function castVote(uint proposalId, bool support) public {
+        return _castVote(msg.sender, proposalId, support);
+    }
+
+    /**
+     * @dev Cast a vote on a proposal by offline signatures
+     * @param proposalId ID of a proposal in which to cast a vote
+     * @param support A boolean of true for 'for' or false for 'against' vote
+     * @param v The recovery byte of the signature
+     * @param r Half of the ECDSA signature pair
+     * @param s Half of the ECDSA signature pair
+     */
+    function castVoteBySig(uint proposalId, bool support, uint8 v, bytes32 r, bytes32 s) public {
+        bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name)), getChainId(), address(this)));
+        bytes32 structHash = keccak256(abi.encode(BALLOT_TYPEHASH, proposalId, support));
+        bytes32 digest = keccak256(abi.encodePacked("", domainSeparator, structHash));
+        address signatory = ecrecover(digest, v, r, s);
+        require(signatory != address(0), "GovernorAlpha::castVoteBySig: invalid signature");
+        return _castVote(signatory, proposalId, support);
+    }
+
+    /**
+     * @dev Cast a vote on a proposal internal function
+     * @param voter The address of the voter
+     * @param proposalId ID of a proposal in which to cast a vote
+     * @param support A boolean of true for 'for' or false for 'against' vote
+     */
+    function _castVote(address voter, uint proposalId, bool support) internal {
+        require(state(proposalId) == ProposalState.Active, "GovernorAlpha::_castVote: voting is closed");
+        Proposal storage proposal = proposals[proposalId];
+        Receipt storage receipt = proposal.receipts[voter];
+        require(receipt.hasVoted == false, "GovernorAlpha::_castVote: voter already voted");
+        uint96 votes = countVotes(voter, proposal.startBlock);
+
+        if (support) {
+            proposal.forVotes = add256(proposal.forVotes, votes);
+        } else {
+            proposal.againstVotes = add256(proposal.againstVotes, votes);
+        }
+
+        receipt.hasVoted = true;
+        receipt.support = support;
+        receipt.votes = votes;
+
+        emit VoteCast(voter, proposalId, support, votes);
+    }
+
+    /**
+     * @dev Accept the pending admin as the admin in timelock contract
+     */
+    function __acceptAdmin() public {
+        require(msg.sender == guardian, "GovernorAlpha::__acceptAdmin: sender must be gov guardian");
+        timelock.acceptAdmin();
+    }
+
+    /**
+     * @dev Abdicate the guardian address to address(0)
+     */
+    function __abdicate() public {
+        require(msg.sender == guardian, "GovernorAlpha::__abdicate: sender must be gov guardian");
+        guardian = address(0);
+    }
+
+    /**
+     * @dev Queue a setTimeLockPendingAdmin transaction to timelock contract
+     * @param newPendingAdmin The address of desired pending admin
+     * @param eta The current block timestamp plus the timelock.delay() timestamp
+     */
+    function __queueSetTimelockPendingAdmin(address newPendingAdmin, uint eta) public {
+        require(msg.sender == guardian, "GovernorAlpha::__queueSetTimelockPendingAdmin: sender must be gov guardian");
+        timelock.queueTransaction(address(timelock), 0, "setPendingAdmin(address)", abi.encode(newPendingAdmin), eta);
+    }
+
+    /**
+     * @dev Execute a setTimeLockPendingAdmin transaction to timelock contract
+     * @param newPendingAdmin The address of desired pending admin
+     * @param eta The current block timestamp plus the timelock.delay() timestamp
+     */
+    function __executeSetTimelockPendingAdmin(address newPendingAdmin, uint eta) public {
+        require(msg.sender == guardian, "GovernorAlpha::__executeSetTimelockPendingAdmin: sender must be gov guardian");
+        timelock.executeTransaction(address(timelock), 0, "setPendingAdmin(address)", abi.encode(newPendingAdmin), eta);
+    }
+
+    /**
+     * @dev safe addition function for uint256
+     */
+    function add256(uint256 a, uint256 b) internal pure returns (uint) {
+        uint c = a + b;
+        require(c >= a, "addition overflow");
+        return c;
+    }
+
+    /**
+     * @dev safe subtraction function for uint256
+     */
+    function sub256(uint256 a, uint256 b) internal pure returns (uint) {
+        require(b <= a, "subtraction underflow");
+        return a - b;
+    }
+
+    /**
+     * @dev Get the chain ID
+     * @return The ID of chain
+     */
+    function getChainId() internal pure returns (uint) {
+        uint chainId;
+        assembly { chainId := chainid() }
+        return chainId;
+    }
+
+    /**
+     * @dev Count the total PriorVotes from TRU and stkTRU
+     * @param account The address to check the total votes
+     * @param blockNumber The block number at which the getPriorVotes() check
+     * @return The sum of PriorVotes from TRU and stkTRU
+     */
+    function countVotes(address account, uint blockNumber) internal view returns (uint96) {
+        uint96 truVote = trustToken.getPriorVotes(account, blockNumber);
+        uint96 stkTRUVote = stkTRU.getPriorVotes(account, blockNumber);
+        uint96 totalVote = add96(truVote, stkTRUVote, "GovernorAlpha: countVotes addition overflow");
+        return totalVote;
+    }
+
+    function add96(uint96 a, uint96 b, string memory errorMessage) internal pure returns (uint96) {
+        uint96 c = a + b;
+        require(c >= a, errorMessage);
+        return c;
+    }
+}

--- a/flatten/IArbitraryDistributor.sol
+++ b/flatten/IArbitraryDistributor.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,19 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/truefi/interface/IArbitraryDistributor.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+interface IArbitraryDistributor {
+    function amount() external returns (uint256);
+
+    function remaining() external returns (uint256);
+
+    function beneficiary() external returns (address);
+
+    function distribute(uint256 _amount) external;
+
+    function empty() external;
+}

--- a/flatten/IBurnableERC20.sol
+++ b/flatten/IBurnableERC20.sol
@@ -1,0 +1,116 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Root file: contracts/trusttoken/interface/IBurnableERC20.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IBurnableERC20 is IERC20 {
+    function burn(uint256 amount) external;
+}

--- a/flatten/ICurve.sol
+++ b/flatten/ICurve.sol
@@ -1,0 +1,166 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/truefi/interface/IYToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IYToken is IERC20 {
+    function getPricePerFullShare() external view returns (uint256);
+}
+
+
+// Root file: contracts/truefi/interface/ICurve.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IYToken} from "contracts/truefi/interface/IYToken.sol";
+
+interface ICurve {
+    function calc_token_amount(uint256[4] memory amounts, bool deposit) external view returns (uint256);
+
+    function get_virtual_price() external view returns (uint256);
+}
+
+interface ICurveGauge {
+    function balanceOf(address depositor) external view returns (uint256);
+
+    function minter() external returns (ICurveMinter);
+
+    function deposit(uint256 amount) external;
+
+    function withdraw(uint256 amount) external;
+}
+
+interface ICurveMinter {
+    function mint(address gauge) external;
+
+    function token() external view returns (IERC20);
+}
+
+interface ICurvePool {
+    function add_liquidity(uint256[4] memory amounts, uint256 min_mint_amount) external;
+
+    function remove_liquidity_one_coin(
+        uint256 _token_amount,
+        int128 i,
+        uint256 min_amount,
+        bool donate_dust
+    ) external;
+
+    function calc_withdraw_one_coin(uint256 _token_amount, int128 i) external view returns (uint256);
+
+    function token() external view returns (IERC20);
+
+    function curve() external view returns (ICurve);
+
+    function coins(int128 id) external view returns (IYToken);
+}

--- a/flatten/IHasOwner.sol
+++ b/flatten/IHasOwner.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,13 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/registry/interface/IHasOwner.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+interface IHasOwner {
+    function claimOwnership() external;
+
+    function transferOwnership(address newOwner) external;
+}

--- a/flatten/IHook.sol
+++ b/flatten/IHook.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,11 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/true-currencies/interface/IHook.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+interface IHook {
+    function hook() external;
+}

--- a/flatten/ILoanFactory.sol
+++ b/flatten/ILoanFactory.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,17 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/truefi/interface/ILoanFactory.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+interface ILoanFactory {
+    function createLoanToken(
+        uint256 _amount,
+        uint256 _term,
+        uint256 _apy
+    ) external;
+
+    function isLoanToken(address) external view returns (bool);
+}

--- a/flatten/ILoanToken.sol
+++ b/flatten/ILoanToken.sol
@@ -1,0 +1,173 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Root file: contracts/truefi/interface/ILoanToken.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ILoanToken is IERC20 {
+    enum Status {Awaiting, Funded, Withdrawn, Settled, Defaulted}
+
+    function borrower() external view returns (address);
+
+    function amount() external view returns (uint256);
+
+    function term() external view returns (uint256);
+
+    function apy() external view returns (uint256);
+
+    function start() external view returns (uint256);
+
+    function lender() external view returns (address);
+
+    function debt() external view returns (uint256);
+
+    function profit() external view returns (uint256);
+
+    function status() external view returns (Status);
+
+    function borrowerFee() external view returns (uint256);
+
+    function receivedAmount() external view returns (uint256);
+
+    function isLoanToken() external pure returns (bool);
+
+    function getParameters()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function fund() external;
+
+    function withdraw(address _beneficiary) external;
+
+    function close() external;
+
+    function redeem(uint256 _amount) external;
+
+    function repay(address _sender, uint256 _amount) external;
+
+    function reclaim() external;
+
+    function allowTransfer(address account, bool _status) external;
+
+    function repaid() external view returns (uint256);
+
+    function balance() external view returns (uint256);
+
+    function value(uint256 _balance) external view returns (uint256);
+
+    function currencyToken() external view returns (IERC20);
+
+    function version() external pure returns (uint8);
+}

--- a/flatten/IOwnable.sol
+++ b/flatten/IOwnable.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,11 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/true-gold/interface/IOwnable.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.6.10;
+
+interface IOwnable {
+    function transferOwnership(address newOwner) external;
+}

--- a/flatten/IOwnedUpgradeabilityProxy.sol
+++ b/flatten/IOwnedUpgradeabilityProxy.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,21 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/proxy/interface/IOwnedUpgradeabilityProxy.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+interface IOwnedUpgradeabilityProxy {
+    function proxyOwner() external view returns (address owner);
+
+    function pendingProxyOwner() external view returns (address pendingOwner);
+
+    function transferProxyOwnership(address newOwner) external;
+
+    function claimProxyOwnership() external;
+
+    function upgradeTo(address implementation) external;
+
+    function implementation() external view returns (address impl);
+}

--- a/flatten/IReclaimerToken.sol
+++ b/flatten/IReclaimerToken.sol
@@ -1,0 +1,118 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Root file: contracts/true-currencies/interface/IReclaimerToken.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IReclaimerToken {
+    function reclaimToken(IERC20 token, address _to) external;
+
+    function reclaimEther(address payable _to) external;
+}

--- a/flatten/IRegistry.sol
+++ b/flatten/IRegistry.sol
@@ -1,0 +1,197 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/registry/interface/IHasOwner.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+interface IHasOwner {
+    function claimOwnership() external;
+
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IReclaimerToken {
+    function reclaimToken(IERC20 token, address _to) external;
+
+    function reclaimEther(address payable _to) external;
+}
+
+
+// Root file: contracts/registry/interface/IRegistry.sol
+
+pragma solidity 0.6.10;
+
+// import {IHasOwner} from "contracts/registry/interface/IHasOwner.sol";
+// import {IRegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+// import {IReclaimerToken} from "contracts/true-currencies/interface/IReclaimerToken.sol";
+
+interface IRegistry is IHasOwner, IReclaimerToken {
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) external;
+
+    function subscribe(bytes32 _attribute, IRegistryClone _syncer) external;
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external;
+
+    function subscriberCount(bytes32 _attribute) external view returns (uint256);
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+
+    function hasAttribute(address _who, bytes32 _attribute) external view returns (bool);
+
+    function getAttribute(address _who, bytes32 _attribute)
+        external
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        );
+
+    function getAttributeValue(address _who, bytes32 _attribute) external view returns (uint256);
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) external view returns (address);
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) external view returns (uint256);
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external;
+}

--- a/flatten/IRegistryClone.sol
+++ b/flatten/IRegistryClone.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,15 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/registry/interface/IRegistryClone.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}

--- a/flatten/ITimelock.sol
+++ b/flatten/ITimelock.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,18 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/governance/interface/ITimelock.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT 
+
+pragma solidity ^0.6.10;
+
+interface ITimelock {
+    function delay() external view returns (uint);
+    function GRACE_PERIOD() external view returns (uint);
+    function acceptAdmin() external;
+    function queuedTransactions(bytes32 hash) external view returns (bool);
+    function queueTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external returns (bytes32);
+    function cancelTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external;
+    function executeTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external payable returns (bytes memory);
+}

--- a/flatten/ITrueCurrency.sol
+++ b/flatten/ITrueCurrency.sol
@@ -1,0 +1,151 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IHasOwner.sol
+
+// pragma solidity 0.6.10;
+
+interface IHasOwner {
+    function claimOwnership() external;
+
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IReclaimerToken {
+    function reclaimToken(IERC20 token, address _to) external;
+
+    function reclaimEther(address payable _to) external;
+}
+
+
+// Root file: contracts/true-currencies/interface/ITrueCurrency.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IHasOwner} from "contracts/true-currencies/interface/IHasOwner.sol";
+// import {IReclaimerToken} from "contracts/true-currencies/interface/IReclaimerToken.sol";
+
+interface ITrueCurrency is IERC20, IReclaimerToken, IHasOwner {
+    function refundGas(uint256 amount) external;
+
+    function setBlacklisted(address account, bool _isBlacklisted) external;
+
+    function setCanBurn(address account, bool _canBurn) external;
+
+    function setBurnBounds(uint256 _min, uint256 _max) external;
+
+    function mint(address account, uint256 amount) external;
+}

--- a/flatten/ITrueDistributor.sol
+++ b/flatten/ITrueDistributor.sol
@@ -1,0 +1,124 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Root file: contracts/truefi/interface/ITrueDistributor.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ITrueDistributor {
+    function trustToken() external view returns (IERC20);
+
+    function farm() external view returns (address);
+
+    function distribute() external;
+
+    function nextDistribution() external view returns (uint256);
+
+    function empty() external;
+}

--- a/flatten/ITrueFarm.sol
+++ b/flatten/ITrueFarm.sol
@@ -1,0 +1,153 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueDistributor.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ITrueDistributor {
+    function trustToken() external view returns (IERC20);
+
+    function farm() external view returns (address);
+
+    function distribute() external;
+
+    function nextDistribution() external view returns (uint256);
+
+    function empty() external;
+}
+
+
+// Root file: contracts/truefi/interface/ITrueFarm.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ITrueDistributor} from "contracts/truefi/interface/ITrueDistributor.sol";
+
+interface ITrueFarm {
+    function stakingToken() external view returns (IERC20);
+
+    function trustToken() external view returns (IERC20);
+
+    function trueDistributor() external view returns (ITrueDistributor);
+
+    function name() external view returns (string memory);
+
+    function totalStaked() external view returns (uint256);
+
+    function stake(uint256 amount) external;
+
+    function unstake(uint256 amount) external;
+
+    function claim() external;
+
+    function exit(uint256 amount) external;
+}

--- a/flatten/ITrueFiPool.sol
+++ b/flatten/ITrueFiPool.sol
@@ -1,0 +1,157 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Root file: contracts/truefi/interface/ITrueFiPool.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * TruePool is an ERC20 which represents a share of a pool
+ *
+ * This contract can be used to wrap opportunities to be compatible
+ * with TrueFi and allow users to directly opt-in through the TUSD contract
+ *
+ * Each TruePool is also a staking opportunity for TRU
+ */
+interface ITrueFiPool is IERC20 {
+    /// @dev pool token (TUSD)
+    function currencyToken() external view returns (IERC20);
+
+    /// @dev stake token (TRU)
+    function stakeToken() external view returns (IERC20);
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Mint pool tokens based on value to sender
+     */
+    function join(uint256 amount) external;
+
+    /**
+     * @dev exit pool
+     * 1. Transfer pool tokens from sender
+     * 2. Burn pool tokens
+     * 3. Transfer value of pool tokens in TUSD to sender
+     */
+    function exit(uint256 amount) external;
+
+    /**
+     * @dev borrow from pool
+     * 1. Transfer TUSD to sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function borrow(uint256 amount, uint256 amountWithoutFee) external;
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function repay(uint256 amount) external;
+}

--- a/flatten/ITrueLender.sol
+++ b/flatten/ITrueLender.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,17 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/truefi/interface/ITrueLender.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+interface ITrueLender {
+    function value() external view returns (uint256);
+
+    function distribute(
+        address recipient,
+        uint256 numerator,
+        uint256 denominator
+    ) external;
+}

--- a/flatten/ITrueRatingAgency.sol
+++ b/flatten/ITrueRatingAgency.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,30 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/truefi/interface/ITrueRatingAgency.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+interface ITrueRatingAgency {
+    function getResults(address id)
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function submit(address id) external;
+
+    function retract(address id) external;
+
+    function yes(address id, uint256 stake) external;
+
+    function no(address id, uint256 stake) external;
+
+    function withdraw(address id, uint256 stake) external;
+
+    function claim(address id, address voter) external;
+}

--- a/flatten/IUniswapRouter.sol
+++ b/flatten/IUniswapRouter.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,17 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/truefi/interface/IUniswapRouter.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+interface IUniswapRouter {
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+}

--- a/flatten/IVoteToken.sol
+++ b/flatten/IVoteToken.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,15 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/governance/interface/IVoteToken.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT 
+
+pragma solidity ^0.6.10;
+
+interface IVoteToken {
+    function delegate(address delegatee) external;
+    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s) external;
+    function getCurrentVotes(address account) external view returns (uint96);
+    function getPriorVotes(address account, uint blockNumber) external view returns (uint96);
+}

--- a/flatten/IYToken.sol
+++ b/flatten/IYToken.sol
@@ -1,0 +1,116 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Root file: contracts/truefi/interface/IYToken.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IYToken is IERC20 {
+    function getPricePerFullShare() external view returns (uint256);
+}

--- a/flatten/Initializable.sol
+++ b/flatten/Initializable.sol
@@ -1,0 +1,130 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-gold/common/ProxyStorage.sol
+
+// SPDX-License-Identifier: UNLICENSED
+// pragma solidity 0.6.10;
+
+contract ProxyStorage {
+    // Initializable.sol
+    bool _initialized;
+    bool _initializing;
+
+    // Ownable.sol
+    address _owner;
+
+    // ERC20.sol
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    uint256 _totalSupply;
+
+    // TrueMintableBurnable.sol
+    uint256 _minBurnAmount;
+    uint256 _maxBurnAmount;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 20         "trueGold.proxy.owner"                                        Proxy Owner
+     ** 28         "trueGold.pending.proxy.owner"                                Pending Proxy Owner
+     ** 29         "trueGold.proxy.implementation"                               Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   _balances
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       _allowances
+     **/
+}
+
+
+// Root file: contracts/true-gold/common/Initializable.sol
+
+pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable is ProxyStorage {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    // bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    // bool private _initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(_initializing || isConstructor() || !_initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+}

--- a/flatten/LinearTrueDistributor.sol
+++ b/flatten/LinearTrueDistributor.sol
@@ -1,0 +1,612 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Dependency file: contracts/truefi/common/UpgradeableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is Initializable, Context {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function initialize() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueDistributor.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ITrueDistributor {
+    function trustToken() external view returns (IERC20);
+
+    function farm() external view returns (address);
+
+    function distribute() external;
+
+    function nextDistribution() external view returns (uint256);
+
+    function empty() external;
+}
+
+
+// Root file: contracts/truefi/distributors/LinearTrueDistributor.sol
+
+pragma solidity 0.6.10;
+
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {Ownable} from "contracts/truefi/common/UpgradeableOwnable.sol";
+// import {ITrueDistributor, IERC20} from "contracts/truefi/interface/ITrueDistributor.sol";
+
+/**
+ * @title LinearTrueDistributor
+ * @notice Distribute TRU in a linear fashion
+ * @dev Distributor contract which uses a linear distribution
+ *
+ * Contracts are registered to receive distributions. Once registered,
+ * a farm contract can claim TRU from the distributor.
+ * - Distributions are based on time.
+ * - Owner can withdraw funds in case distribution need to be re-allocated
+ */
+contract LinearTrueDistributor is ITrueDistributor, Ownable {
+    using SafeMath for uint256;
+
+    // ================ WARNING ==================
+    // ===== THIS CONTRACT IS INITIALIZABLE ======
+    // === STORAGE VARIABLES ARE DECLARED BELOW ==
+    // REMOVAL OR REORDER OF VARIABLES WILL RESULT
+    // ========= IN STORAGE CORRUPTION ===========
+
+    IERC20 public override trustToken;
+    uint256 public distributionStart;
+    uint256 public duration;
+    uint256 public totalAmount;
+    uint256 public lastDistribution;
+    uint256 public distributed;
+
+    // contract which claim tokens from distributor
+    address public override farm;
+
+    // ======= STORAGE DECLARATION END ============
+
+    /**
+     * @dev Emitted when the farm address is changed
+     * @param newFarm new farm contract
+     */
+    event FarmChanged(address newFarm);
+
+    /**
+     * @dev Emitted when the total distributed amount is changed
+     * @param newTotalAmount new totalAmount value
+     */
+    event TotalAmountChanged(uint256 newTotalAmount);
+
+    /**
+     * @dev Emitted when a distribution occurs
+     * @param amount Amount of TRU distributed to farm
+     */
+    event Distributed(uint256 amount);
+
+    /**
+     * @dev Initialize distributor
+     * @param _distributionStart Start time for distribution
+     * @param _duration Length of distribution
+     * @param _amount Amount to distribute
+     * @param _trustToken TRU address
+     */
+    function initialize(
+        uint256 _distributionStart,
+        uint256 _duration,
+        uint256 _amount,
+        IERC20 _trustToken
+    ) public initializer {
+        Ownable.initialize();
+        distributionStart = _distributionStart;
+        lastDistribution = _distributionStart;
+        duration = _duration;
+        totalAmount = _amount;
+        trustToken = _trustToken;
+    }
+
+    /**
+     * @dev Set contract to receive distributions
+     * Will distribute to previous contract if farm already exists
+     * @param newFarm New farm for distribution
+     */
+    function setFarm(address newFarm) external onlyOwner {
+        distribute();
+        farm = newFarm;
+        emit FarmChanged(newFarm);
+    }
+
+    /**
+     * @dev Distribute tokens to farm in linear fashion based on time
+     */
+    function distribute() public override {
+        // cannot distribute until distribution start
+        uint256 amount = nextDistribution();
+
+        if (amount == 0) {
+            return;
+        }
+
+        // transfer tokens & update state
+        lastDistribution = block.timestamp;
+        distributed = distributed.add(amount);
+        require(trustToken.transfer(farm, amount));
+
+        emit Distributed(amount);
+    }
+
+    /**
+     * @dev Calculate next distribution amount
+     * @return amount of tokens for next distribution
+     */
+    function nextDistribution() public override view returns (uint256) {
+        // return 0 if before distribution or farm is not set
+        if (block.timestamp < distributionStart || farm == address(0)) {
+            return 0;
+        }
+
+        // calculate distribution amount
+        uint256 amount = totalAmount.sub(distributed);
+        if (block.timestamp < distributionStart.add(duration)) {
+            amount = block.timestamp.sub(lastDistribution).mul(totalAmount).div(duration);
+        }
+        return amount;
+    }
+
+    /**
+     * @dev Withdraw funds (for instance if owner decides to create a new distribution)
+     * Distributes remaining funds before withdrawing
+     * Ends current distribution
+     */
+    function empty() public override onlyOwner {
+        distribute();
+        distributed = 0;
+        totalAmount = 0;
+        require(trustToken.transfer(msg.sender, trustToken.balanceOf(address(this))));
+    }
+
+    /**
+     * @dev Change amount of tokens distributed daily by changing total distributed amount
+     */
+    function setDailyDistribution(uint256 dailyDistribution) public onlyOwner {
+        distribute();
+        uint256 timeLeft = distributionStart.add(duration).sub(block.timestamp);
+        if (timeLeft > duration) {
+            timeLeft = duration;
+        } else {
+            distributionStart = block.timestamp;
+            duration = timeLeft;
+        }
+        totalAmount = dailyDistribution.mul(timeLeft).div(1 days);
+        distributed = 0;
+        emit TotalAmountChanged(totalAmount);
+    }
+}

--- a/flatten/LoanFactory.sol
+++ b/flatten/LoanFactory.sol
@@ -1,0 +1,1376 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Dependency file: contracts/truefi/interface/ILoanFactory.sol
+
+// pragma solidity 0.6.10;
+
+interface ILoanFactory {
+    function createLoanToken(
+        uint256 _amount,
+        uint256 _term,
+        uint256 _apy
+    ) external;
+
+    function isLoanToken(address) external view returns (bool);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/ERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+// import "@openzeppelin/contracts/GSN/Context.sol";
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+// import "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20 is Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    mapping (address => uint256) private _balances;
+
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    constructor (string memory name, string memory symbol) public {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/truefi/interface/ILoanToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ILoanToken is IERC20 {
+    enum Status {Awaiting, Funded, Withdrawn, Settled, Defaulted}
+
+    function borrower() external view returns (address);
+
+    function amount() external view returns (uint256);
+
+    function term() external view returns (uint256);
+
+    function apy() external view returns (uint256);
+
+    function start() external view returns (uint256);
+
+    function lender() external view returns (address);
+
+    function debt() external view returns (uint256);
+
+    function profit() external view returns (uint256);
+
+    function status() external view returns (Status);
+
+    function borrowerFee() external view returns (uint256);
+
+    function receivedAmount() external view returns (uint256);
+
+    function isLoanToken() external pure returns (bool);
+
+    function getParameters()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function fund() external;
+
+    function withdraw(address _beneficiary) external;
+
+    function close() external;
+
+    function redeem(uint256 _amount) external;
+
+    function repay(address _sender, uint256 _amount) external;
+
+    function reclaim() external;
+
+    function allowTransfer(address account, bool _status) external;
+
+    function repaid() external view returns (uint256);
+
+    function balance() external view returns (uint256);
+
+    function value(uint256 _balance) external view returns (uint256);
+
+    function currencyToken() external view returns (IERC20);
+
+    function version() external pure returns (uint8);
+}
+
+
+// Dependency file: contracts/truefi/LoanToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {ILoanToken} from "contracts/truefi/interface/ILoanToken.sol";
+
+/**
+ * @title LoanToken
+ * @dev A token which represents share of a debt obligation
+ *
+ * Each LoanToken has:
+ * - borrower address
+ * - borrow amount
+ * - loan term
+ * - loan APY
+ *
+ * Loan progresses through the following states:
+ * Awaiting:    Waiting for funding to meet capital requirements
+ * Funded:      Capital requirements met, borrower can withdraw
+ * Withdrawn:   Borrower withdraws money, loan waiting to be repaid
+ * Settled:     Loan has been paid back in full with interest
+ * Defaulted:   Loan has not been paid back in full
+ *
+ * - LoanTokens are non-transferable except for whitelisted addresses
+ * - This version of LoanToken only supports a single funder
+ */
+contract LoanToken is ILoanToken, ERC20 {
+    using SafeMath for uint256;
+
+    uint128 public constant lastMinutePaybackDuration = 1 days;
+    uint8 public constant override version = 2;
+
+    address public override borrower;
+    uint256 public override amount;
+    uint256 public override term;
+    uint256 public override apy;
+
+    uint256 public override start;
+    address public override lender;
+    uint256 public override debt;
+
+    uint256 public redeemed;
+
+    // borrow fee -> 25 = 0.25%
+    uint256 public override borrowerFee = 25;
+
+    // whitelist for transfers
+    mapping(address => bool) public canTransfer;
+
+    Status public override status;
+
+    IERC20 public override currencyToken;
+
+    /**
+     * @dev Emitted when the loan is funded
+     * @param lender Address which funded the loan
+     */
+    event Funded(address lender);
+
+    /**
+     * @dev Emitted when transfer whitelist is updated
+     * @param account Account to whitelist for transfers
+     * @param status New whitelist status
+     */
+    event TransferAllowanceChanged(address account, bool status);
+
+    /**
+     * @dev Emitted when borrower withdraws funds
+     * @param beneficiary Account which will receive funds
+     */
+    event Withdrawn(address beneficiary);
+
+    /**
+     * @dev Emitted when term is over
+     * @param status Final loan status
+     * @param returnedAmount Amount that was retured before expiry
+     */
+    event Closed(Status status, uint256 returnedAmount);
+
+    /**
+     * @dev Emitted when a LoanToken is redeemed for underlying currencyTokens
+     * @param receiver Receiver of currencyTokens
+     * @param burnedAmount Amount of LoanTokens burned
+     * @param redeemedAmound Amount of currencyToken received
+     */
+    event Redeemed(address receiver, uint256 burnedAmount, uint256 redeemedAmound);
+
+    /**
+     * @dev Emitted when a LoanToken is repaid by the borrower in underlying currencyTokens
+     * @param repayer Sender of currencyTokens
+     * @param repaidAmound Amount of currencyToken repaid
+     */
+    event Repaid(address repayer, uint256 repaidAmound);
+
+    /**
+     * @dev Emitted when borrower reclaims remaining currencyTokens
+     * @param borrower Reveiver of remaining currencyTokens
+     * @param reclaimedAmount Amount of currencyTokens repaid
+     */
+    event Reclaimed(address borrower, uint256 reclaimedAmount);
+
+    /**
+     * @dev Create a Loan
+     * @param _currencyToken Token to lend
+     * @param _borrower Borrwer addresss
+     * @param _amount Borrow amount of currency tokens
+     * @param _term Loan length
+     * @param _apy Loan APY
+     */
+    constructor(
+        IERC20 _currencyToken,
+        address _borrower,
+        address _lender,
+        uint256 _amount,
+        uint256 _term,
+        uint256 _apy
+    ) public ERC20("Loan Token", "LOAN") {
+        require(_lender != address(0), "LoanToken: Lender is not set");
+
+        currencyToken = _currencyToken;
+        borrower = _borrower;
+        amount = _amount;
+        term = _term;
+        apy = _apy;
+        lender = _lender;
+        debt = interest(amount);
+    }
+
+    /**
+     * @dev Only borrower can withdraw & repay loan
+     */
+    modifier onlyBorrower() {
+        require(msg.sender == borrower, "LoanToken: Caller is not the borrower");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Settled
+     */
+    modifier onlyClosed() {
+        require(status == Status.Settled || status == Status.Defaulted, "LoanToken: Current status should be Settled or Defaulted");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Funded
+     */
+    modifier onlyOngoing() {
+        require(status == Status.Funded || status == Status.Withdrawn, "LoanToken: Current status should be Funded or Withdrawn");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Funded
+     */
+    modifier onlyFunded() {
+        require(status == Status.Funded, "LoanToken: Current status should be Funded");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Withdrawn
+     */
+    modifier onlyAfterWithdraw() {
+        require(status >= Status.Withdrawn, "LoanToken: Only after loan has been withdrawn");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Awaiting
+     */
+    modifier onlyAwaiting() {
+        require(status == Status.Awaiting, "LoanToken: Current status should be Awaiting");
+        _;
+    }
+
+    /**
+     * @dev Only whitelisted accounts or lender
+     */
+    modifier onlyWhoCanTransfer(address sender) {
+        require(
+            sender == lender || canTransfer[sender],
+            "LoanToken: This can be performed only by lender or accounts allowed to transfer"
+        );
+        _;
+    }
+
+    /**
+     * @dev Only lender can perform certain actions
+     */
+    modifier onlyLender() {
+        require(msg.sender == lender, "LoanToken: This can be performed only by lender");
+        _;
+    }
+
+    /**
+     * @dev Return true if this contract is a LoanToken
+     * @return True if this contract is a LoanToken
+     */
+    function isLoanToken() external override pure returns (bool) {
+        return true;
+    }
+
+    /**
+     * @dev Get loan parameters
+     * @return amount, term, apy
+     */
+    function getParameters()
+        external
+        override
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        )
+    {
+        return (amount, apy, term);
+    }
+
+    /**
+     * @dev Get coupon value of this loan token in currencyToken
+     * This assumes the loan will be paid back on time, with interest
+     * @param _balance number of LoanTokens to get value for
+     * @return coupon value of _balance LoanTokens in currencyTokens
+     */
+    function value(uint256 _balance) external override view returns (uint256) {
+        if (_balance == 0) {
+            return 0;
+        }
+
+        uint256 passed = block.timestamp.sub(start);
+        if (passed > term) {
+            passed = term;
+        }
+
+        // assume year is 365 days
+        uint256 interest = amount.mul(apy).mul(passed).div(365 days).div(10000);
+
+        return amount.add(interest).mul(_balance).div(debt);
+    }
+
+    /**
+     * @dev Fund a loan
+     * Set status, start time, lender
+     */
+    function fund() external override onlyAwaiting onlyLender {
+        status = Status.Funded;
+        start = block.timestamp;
+        _mint(msg.sender, debt);
+        require(currencyToken.transferFrom(msg.sender, address(this), receivedAmount()));
+
+        emit Funded(msg.sender);
+    }
+
+    /**
+     * @dev Whitelist accounts to transfer
+     * @param account address to allow transfers for
+     * @param _status true allows transfers, false disables transfers
+     */
+    function allowTransfer(address account, bool _status) external override onlyLender {
+        canTransfer[account] = _status;
+        emit TransferAllowanceChanged(account, _status);
+    }
+
+    /**
+     * @dev Borrower calls this function to withdraw funds
+     * Sets the status of the loan to Withdrawn
+     * @param _beneficiary address to send funds to
+     */
+    function withdraw(address _beneficiary) external override onlyBorrower onlyFunded {
+        status = Status.Withdrawn;
+        require(currencyToken.transfer(_beneficiary, receivedAmount()));
+
+        emit Withdrawn(_beneficiary);
+    }
+
+    /**
+     * @dev Close the loan and check if it has been repaid
+     */
+    function close() external override onlyOngoing {
+        require(start.add(term) <= block.timestamp, "LoanToken: Loan cannot be closed yet");
+        if (_balance() >= debt) {
+            status = Status.Settled;
+        } else {
+            require(
+                start.add(term).add(lastMinutePaybackDuration) <= block.timestamp,
+                "LoanToken: Borrower can still pay the loan back"
+            );
+            status = Status.Defaulted;
+        }
+
+        emit Closed(status, _balance());
+    }
+
+    /**
+     * @dev Redeem LoanToken balances for underlying currencyToken
+     * Can only call this function after the loan is Closed
+     * @param _amount amount to redeem
+     */
+    function redeem(uint256 _amount) external override onlyClosed {
+        uint256 amountToReturn = _amount.mul(_balance()).div(totalSupply());
+        redeemed = redeemed.add(amountToReturn);
+        _burn(msg.sender, _amount);
+        require(currencyToken.transfer(msg.sender, amountToReturn));
+
+        emit Redeemed(msg.sender, _amount, amountToReturn);
+    }
+
+    /**
+     * @dev Function for borrower to repay the loan
+     * Borrower can repay at any time
+     * @param _sender account sending currencyToken to repay
+     * @param _amount amount of currencyToken to repay
+     */
+    function repay(address _sender, uint256 _amount) external override onlyAfterWithdraw {
+        require(_amount <= debt.sub(_balance()), "LoanToken: Cannot repay over the debt");
+        require(currencyToken.transferFrom(_sender, address(this), _amount));
+        emit Repaid(_sender, _amount);
+    }
+
+    /**
+     * @dev Function for borrower to reclaim stuck currencyToken
+     * Can only call this function after the loan is Closed
+     * and all of LoanToken holders have been burnt
+     */
+    function reclaim() external override onlyClosed onlyBorrower {
+        require(totalSupply() == 0, "LoanToken: Cannot reclaim when LoanTokens are in circulation");
+        uint256 balanceRemaining = _balance();
+        require(balanceRemaining > 0, "LoanToken: Cannot reclaim when balance 0");
+
+        require(currencyToken.transfer(borrower, balanceRemaining));
+        emit Reclaimed(borrower, balanceRemaining);
+    }
+
+    /**
+     * @dev Check how much was already repaid
+     * Funds stored on the contract's addres plus funds already redeemed by lenders
+     * @return Uint256 representing what value was already repaid
+     */
+    function repaid() external override view onlyAfterWithdraw returns (uint256) {
+        return _balance().add(redeemed);
+    }
+
+    /**
+     * @dev Public currency token balance function
+     * @return currencyToken balance of this contract
+     */
+    function balance() external override view returns (uint256) {
+        return _balance();
+    }
+
+    /**
+     * @dev Get currency token balance for this contract
+     * @return currencyToken balance of this contract
+     */
+    function _balance() internal view returns (uint256) {
+        return currencyToken.balanceOf(address(this));
+    }
+
+    /**
+     * @dev Calculate amount borrowed minus fee
+     * @return Amount minus fees
+     */
+    function receivedAmount() public override view returns (uint256) {
+        return amount.sub(amount.mul(borrowerFee).div(10000));
+    }
+
+    /**
+     * @dev Calculate interest that will be paid by this loan for an amount (returned funds included)
+     * amount + ((amount * apy * term) / (365 days / precision))
+     * @param _amount amount
+     * @return uint256 Amount of interest paid for _amount
+     */
+    function interest(uint256 _amount) internal view returns (uint256) {
+        return _amount.add(_amount.mul(apy).mul(term).div(365 days).div(10000));
+    }
+
+    /**
+     * @dev get profit for this loan
+     * @return profit for this loan
+     */
+    function profit() external override view returns (uint256) {
+        return debt.sub(amount);
+    }
+
+    /**
+     * @dev Override ERC20 _transfer so only whitelisted addresses can transfer
+     * @param sender sender of the transaction
+     * @param recipient recipient of the transaction
+     * @param _amount amount to send
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 _amount
+    ) internal override onlyWhoCanTransfer(sender) {
+        return super._transfer(sender, recipient, _amount);
+    }
+}
+
+
+// Root file: contracts/truefi/LoanFactory.sol
+
+pragma solidity 0.6.10;
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+// import {ILoanFactory} from "contracts/truefi/interface/ILoanFactory.sol";
+
+// import {LoanToken, IERC20} from "contracts/truefi/LoanToken.sol";
+
+/**
+ * @title LoanFactory
+ * @notice Deploy LoanTokens with this Contract
+ * @dev LoanTokens are deployed through a factory to ensure that all
+ * LoanTokens adhere to the same contract code, rather than using an interface.
+ */
+contract LoanFactory is ILoanFactory, Initializable {
+    // ================ WARNING ==================
+    // ===== THIS CONTRACT IS INITIALIZABLE ======
+    // === STORAGE VARIABLES ARE DECLARED BELOW ==
+    // REMOVAL OR REORDER OF VARIABLES WILL RESULT
+    // ========= IN STORAGE CORRUPTION ===========
+
+    IERC20 public currencyToken;
+
+    // @dev Track Valid LoanTokens
+    mapping(address => bool) public override isLoanToken;
+
+    address public lender;
+
+    // ======= STORAGE DECLARATION END ============
+
+    /**
+     * @dev Emitted when a LoanToken is created
+     * @param contractAddress LoanToken contract address
+     */
+    event LoanTokenCreated(address contractAddress);
+
+    /**
+     * @dev Initialize this contract and set currency token
+     * @param _currencyToken Currency token to lend
+     */
+    function initialize(IERC20 _currencyToken) external initializer {
+        currencyToken = _currencyToken;
+    }
+
+    function setLender() external {
+        lender = 0x16d02Dc67EB237C387023339356b25d1D54b0922;
+    }
+
+    /**
+     * @dev Deploy LoanToken with parameters
+     * @param _amount Amount to borrow
+     * @param _term Length of loan
+     * @param _apy Loan yield
+     */
+    function createLoanToken(
+        uint256 _amount,
+        uint256 _term,
+        uint256 _apy
+    ) external override {
+        require(_amount > 0, "LoanFactory: Loans of amount 0, will not be approved");
+        require(_term > 0, "LoanFactory: Loans cannot have instantaneous term of repay");
+
+        address newToken = address(new LoanToken(currencyToken, msg.sender, lender, _amount, _term, _apy));
+        isLoanToken[newToken] = true;
+
+        emit LoanTokenCreated(newToken);
+    }
+}

--- a/flatten/LoanToken.sol
+++ b/flatten/LoanToken.sol
@@ -1,0 +1,1222 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/ERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+// import "@openzeppelin/contracts/GSN/Context.sol";
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+// import "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20 is Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    mapping (address => uint256) private _balances;
+
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    constructor (string memory name, string memory symbol) public {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/truefi/interface/ILoanToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ILoanToken is IERC20 {
+    enum Status {Awaiting, Funded, Withdrawn, Settled, Defaulted}
+
+    function borrower() external view returns (address);
+
+    function amount() external view returns (uint256);
+
+    function term() external view returns (uint256);
+
+    function apy() external view returns (uint256);
+
+    function start() external view returns (uint256);
+
+    function lender() external view returns (address);
+
+    function debt() external view returns (uint256);
+
+    function profit() external view returns (uint256);
+
+    function status() external view returns (Status);
+
+    function borrowerFee() external view returns (uint256);
+
+    function receivedAmount() external view returns (uint256);
+
+    function isLoanToken() external pure returns (bool);
+
+    function getParameters()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function fund() external;
+
+    function withdraw(address _beneficiary) external;
+
+    function close() external;
+
+    function redeem(uint256 _amount) external;
+
+    function repay(address _sender, uint256 _amount) external;
+
+    function reclaim() external;
+
+    function allowTransfer(address account, bool _status) external;
+
+    function repaid() external view returns (uint256);
+
+    function balance() external view returns (uint256);
+
+    function value(uint256 _balance) external view returns (uint256);
+
+    function currencyToken() external view returns (IERC20);
+
+    function version() external pure returns (uint8);
+}
+
+
+// Root file: contracts/truefi/LoanToken.sol
+
+pragma solidity 0.6.10;
+
+// import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {ILoanToken} from "contracts/truefi/interface/ILoanToken.sol";
+
+/**
+ * @title LoanToken
+ * @dev A token which represents share of a debt obligation
+ *
+ * Each LoanToken has:
+ * - borrower address
+ * - borrow amount
+ * - loan term
+ * - loan APY
+ *
+ * Loan progresses through the following states:
+ * Awaiting:    Waiting for funding to meet capital requirements
+ * Funded:      Capital requirements met, borrower can withdraw
+ * Withdrawn:   Borrower withdraws money, loan waiting to be repaid
+ * Settled:     Loan has been paid back in full with interest
+ * Defaulted:   Loan has not been paid back in full
+ *
+ * - LoanTokens are non-transferable except for whitelisted addresses
+ * - This version of LoanToken only supports a single funder
+ */
+contract LoanToken is ILoanToken, ERC20 {
+    using SafeMath for uint256;
+
+    uint128 public constant lastMinutePaybackDuration = 1 days;
+    uint8 public constant override version = 2;
+
+    address public override borrower;
+    uint256 public override amount;
+    uint256 public override term;
+    uint256 public override apy;
+
+    uint256 public override start;
+    address public override lender;
+    uint256 public override debt;
+
+    uint256 public redeemed;
+
+    // borrow fee -> 25 = 0.25%
+    uint256 public override borrowerFee = 25;
+
+    // whitelist for transfers
+    mapping(address => bool) public canTransfer;
+
+    Status public override status;
+
+    IERC20 public override currencyToken;
+
+    /**
+     * @dev Emitted when the loan is funded
+     * @param lender Address which funded the loan
+     */
+    event Funded(address lender);
+
+    /**
+     * @dev Emitted when transfer whitelist is updated
+     * @param account Account to whitelist for transfers
+     * @param status New whitelist status
+     */
+    event TransferAllowanceChanged(address account, bool status);
+
+    /**
+     * @dev Emitted when borrower withdraws funds
+     * @param beneficiary Account which will receive funds
+     */
+    event Withdrawn(address beneficiary);
+
+    /**
+     * @dev Emitted when term is over
+     * @param status Final loan status
+     * @param returnedAmount Amount that was retured before expiry
+     */
+    event Closed(Status status, uint256 returnedAmount);
+
+    /**
+     * @dev Emitted when a LoanToken is redeemed for underlying currencyTokens
+     * @param receiver Receiver of currencyTokens
+     * @param burnedAmount Amount of LoanTokens burned
+     * @param redeemedAmound Amount of currencyToken received
+     */
+    event Redeemed(address receiver, uint256 burnedAmount, uint256 redeemedAmound);
+
+    /**
+     * @dev Emitted when a LoanToken is repaid by the borrower in underlying currencyTokens
+     * @param repayer Sender of currencyTokens
+     * @param repaidAmound Amount of currencyToken repaid
+     */
+    event Repaid(address repayer, uint256 repaidAmound);
+
+    /**
+     * @dev Emitted when borrower reclaims remaining currencyTokens
+     * @param borrower Reveiver of remaining currencyTokens
+     * @param reclaimedAmount Amount of currencyTokens repaid
+     */
+    event Reclaimed(address borrower, uint256 reclaimedAmount);
+
+    /**
+     * @dev Create a Loan
+     * @param _currencyToken Token to lend
+     * @param _borrower Borrwer addresss
+     * @param _amount Borrow amount of currency tokens
+     * @param _term Loan length
+     * @param _apy Loan APY
+     */
+    constructor(
+        IERC20 _currencyToken,
+        address _borrower,
+        address _lender,
+        uint256 _amount,
+        uint256 _term,
+        uint256 _apy
+    ) public ERC20("Loan Token", "LOAN") {
+        require(_lender != address(0), "LoanToken: Lender is not set");
+
+        currencyToken = _currencyToken;
+        borrower = _borrower;
+        amount = _amount;
+        term = _term;
+        apy = _apy;
+        lender = _lender;
+        debt = interest(amount);
+    }
+
+    /**
+     * @dev Only borrower can withdraw & repay loan
+     */
+    modifier onlyBorrower() {
+        require(msg.sender == borrower, "LoanToken: Caller is not the borrower");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Settled
+     */
+    modifier onlyClosed() {
+        require(status == Status.Settled || status == Status.Defaulted, "LoanToken: Current status should be Settled or Defaulted");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Funded
+     */
+    modifier onlyOngoing() {
+        require(status == Status.Funded || status == Status.Withdrawn, "LoanToken: Current status should be Funded or Withdrawn");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Funded
+     */
+    modifier onlyFunded() {
+        require(status == Status.Funded, "LoanToken: Current status should be Funded");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Withdrawn
+     */
+    modifier onlyAfterWithdraw() {
+        require(status >= Status.Withdrawn, "LoanToken: Only after loan has been withdrawn");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Awaiting
+     */
+    modifier onlyAwaiting() {
+        require(status == Status.Awaiting, "LoanToken: Current status should be Awaiting");
+        _;
+    }
+
+    /**
+     * @dev Only whitelisted accounts or lender
+     */
+    modifier onlyWhoCanTransfer(address sender) {
+        require(
+            sender == lender || canTransfer[sender],
+            "LoanToken: This can be performed only by lender or accounts allowed to transfer"
+        );
+        _;
+    }
+
+    /**
+     * @dev Only lender can perform certain actions
+     */
+    modifier onlyLender() {
+        require(msg.sender == lender, "LoanToken: This can be performed only by lender");
+        _;
+    }
+
+    /**
+     * @dev Return true if this contract is a LoanToken
+     * @return True if this contract is a LoanToken
+     */
+    function isLoanToken() external override pure returns (bool) {
+        return true;
+    }
+
+    /**
+     * @dev Get loan parameters
+     * @return amount, term, apy
+     */
+    function getParameters()
+        external
+        override
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        )
+    {
+        return (amount, apy, term);
+    }
+
+    /**
+     * @dev Get coupon value of this loan token in currencyToken
+     * This assumes the loan will be paid back on time, with interest
+     * @param _balance number of LoanTokens to get value for
+     * @return coupon value of _balance LoanTokens in currencyTokens
+     */
+    function value(uint256 _balance) external override view returns (uint256) {
+        if (_balance == 0) {
+            return 0;
+        }
+
+        uint256 passed = block.timestamp.sub(start);
+        if (passed > term) {
+            passed = term;
+        }
+
+        // assume year is 365 days
+        uint256 interest = amount.mul(apy).mul(passed).div(365 days).div(10000);
+
+        return amount.add(interest).mul(_balance).div(debt);
+    }
+
+    /**
+     * @dev Fund a loan
+     * Set status, start time, lender
+     */
+    function fund() external override onlyAwaiting onlyLender {
+        status = Status.Funded;
+        start = block.timestamp;
+        _mint(msg.sender, debt);
+        require(currencyToken.transferFrom(msg.sender, address(this), receivedAmount()));
+
+        emit Funded(msg.sender);
+    }
+
+    /**
+     * @dev Whitelist accounts to transfer
+     * @param account address to allow transfers for
+     * @param _status true allows transfers, false disables transfers
+     */
+    function allowTransfer(address account, bool _status) external override onlyLender {
+        canTransfer[account] = _status;
+        emit TransferAllowanceChanged(account, _status);
+    }
+
+    /**
+     * @dev Borrower calls this function to withdraw funds
+     * Sets the status of the loan to Withdrawn
+     * @param _beneficiary address to send funds to
+     */
+    function withdraw(address _beneficiary) external override onlyBorrower onlyFunded {
+        status = Status.Withdrawn;
+        require(currencyToken.transfer(_beneficiary, receivedAmount()));
+
+        emit Withdrawn(_beneficiary);
+    }
+
+    /**
+     * @dev Close the loan and check if it has been repaid
+     */
+    function close() external override onlyOngoing {
+        require(start.add(term) <= block.timestamp, "LoanToken: Loan cannot be closed yet");
+        if (_balance() >= debt) {
+            status = Status.Settled;
+        } else {
+            require(
+                start.add(term).add(lastMinutePaybackDuration) <= block.timestamp,
+                "LoanToken: Borrower can still pay the loan back"
+            );
+            status = Status.Defaulted;
+        }
+
+        emit Closed(status, _balance());
+    }
+
+    /**
+     * @dev Redeem LoanToken balances for underlying currencyToken
+     * Can only call this function after the loan is Closed
+     * @param _amount amount to redeem
+     */
+    function redeem(uint256 _amount) external override onlyClosed {
+        uint256 amountToReturn = _amount.mul(_balance()).div(totalSupply());
+        redeemed = redeemed.add(amountToReturn);
+        _burn(msg.sender, _amount);
+        require(currencyToken.transfer(msg.sender, amountToReturn));
+
+        emit Redeemed(msg.sender, _amount, amountToReturn);
+    }
+
+    /**
+     * @dev Function for borrower to repay the loan
+     * Borrower can repay at any time
+     * @param _sender account sending currencyToken to repay
+     * @param _amount amount of currencyToken to repay
+     */
+    function repay(address _sender, uint256 _amount) external override onlyAfterWithdraw {
+        require(_amount <= debt.sub(_balance()), "LoanToken: Cannot repay over the debt");
+        require(currencyToken.transferFrom(_sender, address(this), _amount));
+        emit Repaid(_sender, _amount);
+    }
+
+    /**
+     * @dev Function for borrower to reclaim stuck currencyToken
+     * Can only call this function after the loan is Closed
+     * and all of LoanToken holders have been burnt
+     */
+    function reclaim() external override onlyClosed onlyBorrower {
+        require(totalSupply() == 0, "LoanToken: Cannot reclaim when LoanTokens are in circulation");
+        uint256 balanceRemaining = _balance();
+        require(balanceRemaining > 0, "LoanToken: Cannot reclaim when balance 0");
+
+        require(currencyToken.transfer(borrower, balanceRemaining));
+        emit Reclaimed(borrower, balanceRemaining);
+    }
+
+    /**
+     * @dev Check how much was already repaid
+     * Funds stored on the contract's addres plus funds already redeemed by lenders
+     * @return Uint256 representing what value was already repaid
+     */
+    function repaid() external override view onlyAfterWithdraw returns (uint256) {
+        return _balance().add(redeemed);
+    }
+
+    /**
+     * @dev Public currency token balance function
+     * @return currencyToken balance of this contract
+     */
+    function balance() external override view returns (uint256) {
+        return _balance();
+    }
+
+    /**
+     * @dev Get currency token balance for this contract
+     * @return currencyToken balance of this contract
+     */
+    function _balance() internal view returns (uint256) {
+        return currencyToken.balanceOf(address(this));
+    }
+
+    /**
+     * @dev Calculate amount borrowed minus fee
+     * @return Amount minus fees
+     */
+    function receivedAmount() public override view returns (uint256) {
+        return amount.sub(amount.mul(borrowerFee).div(10000));
+    }
+
+    /**
+     * @dev Calculate interest that will be paid by this loan for an amount (returned funds included)
+     * amount + ((amount * apy * term) / (365 days / precision))
+     * @param _amount amount
+     * @return uint256 Amount of interest paid for _amount
+     */
+    function interest(uint256 _amount) internal view returns (uint256) {
+        return _amount.add(_amount.mul(apy).mul(term).div(365 days).div(10000));
+    }
+
+    /**
+     * @dev get profit for this loan
+     * @return profit for this loan
+     */
+    function profit() external override view returns (uint256) {
+        return debt.sub(amount);
+    }
+
+    /**
+     * @dev Override ERC20 _transfer so only whitelisted addresses can transfer
+     * @param sender sender of the transaction
+     * @param recipient recipient of the transaction
+     * @param _amount amount to send
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 _amount
+    ) internal override onlyWhoCanTransfer(sender) {
+        return super._transfer(sender, recipient, _amount);
+    }
+}

--- a/flatten/Log.sol
+++ b/flatten/Log.sol
@@ -1,0 +1,117 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Root file: contracts/truefi/Log.sol
+
+// SPDX-License-Identifier: BSD-4-Clause
+/*
+ * ABDK Math 64.64 Smart Contract Library.  Copyright © 2019 by ABDK Consulting.
+ * Author: Mikhail Vladimirov <mikhail.vladimirov@gmail.com>
+ */
+pragma solidity 0.6.10;
+
+/**
+ * Smart contract library of mathematical functions operating with signed
+ * 64.64-bit fixed point numbers.  Signed 64.64-bit fixed point number is
+ * basically a simple fraction whose numerator is signed 128-bit integer and
+ * denominator is 2^64.  As long as denominator is always the same, there is no
+ * need to store it, thus in Solidity signed 64.64-bit fixed point numbers are
+ * represented by int128 type holding only the numerator.
+ */
+library ABDKMath64x64 {
+    /**
+     * Convert unsigned 256-bit integer number into signed 64.64-bit fixed point
+     * number.  Revert on overflow.
+     *
+     * @param x unsigned 256-bit integer number
+     * @return signed 64.64-bit fixed point number
+     */
+    function fromUInt(uint256 x) internal pure returns (int128) {
+        require(x <= 0x7FFFFFFFFFFFFFFF);
+        return int128(x << 64);
+    }
+
+    /**
+     * Calculate binary logarithm of x.  Revert if x <= 0.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function log_2(int128 x) internal pure returns (int128) {
+        require(x > 0);
+
+        int256 msb = 0;
+        int256 xc = x;
+        if (xc >= 0x10000000000000000) {
+            xc >>= 64;
+            msb += 64;
+        }
+        if (xc >= 0x100000000) {
+            xc >>= 32;
+            msb += 32;
+        }
+        if (xc >= 0x10000) {
+            xc >>= 16;
+            msb += 16;
+        }
+        if (xc >= 0x100) {
+            xc >>= 8;
+            msb += 8;
+        }
+        if (xc >= 0x10) {
+            xc >>= 4;
+            msb += 4;
+        }
+        if (xc >= 0x4) {
+            xc >>= 2;
+            msb += 2;
+        }
+        if (xc >= 0x2) msb += 1; // No need to shift xc anymore
+
+        int256 result = (msb - 64) << 64;
+        uint256 ux = uint256(x) << uint256(127 - msb);
+        for (int256 bit = 0x8000000000000000; bit > 0; bit >>= 1) {
+            ux *= ux;
+            uint256 b = ux >> 255;
+            ux >>= 127 + b;
+            result += bit * int256(b);
+        }
+
+        return int128(result);
+    }
+
+    /**
+     * Calculate natural logarithm of x.  Revert if x <= 0.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function ln(int128 x) internal pure returns (int128) {
+        require(x > 0);
+
+        return int128((uint256(log_2(x)) * 0xB17217F7D1CF79ABC9E3B39803F2F6AF) >> 128);
+    }
+}

--- a/flatten/MockCurvePool.sol
+++ b/flatten/MockCurvePool.sol
@@ -1,0 +1,1233 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: contracts/registry/Registry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+contract Registry {
+    struct AttributeData {
+        uint256 value;
+        bytes32 notes;
+        address adminAddr;
+        uint256 timestamp;
+    }
+
+    // never remove any storage variables
+    address public owner;
+    address public pendingOwner;
+    bool initialized;
+
+    // Stores arbitrary attributes for users. An example use case is an IERC20
+    // token that requires its users to go through a KYC/AML check - in this case
+    // a validator can set an account's "hasPassedKYC/AML" attribute to 1 to indicate
+    // that account can use the token. This mapping stores that value (1, in the
+    // example) as well as which validator last set the value and at what time,
+    // so that e.g. the check can be renewed at appropriate intervals.
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
+    // The logic governing who is allowed to set what attributes is abstracted as
+    // this accessManager, so that it may be replaced by the owner as needed
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    mapping(bytes32 => RegistryClone[]) subscribers;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetManager(address indexed oldManager, address indexed newManager);
+    event StartSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+    event StopSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+
+    // Allows a write if either a) the writer is that Registry's owner, or
+    // b) the writer is writing to attribute foo and that writer already has
+    // the canWriteTo-foo attribute set (in that same Registry)
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
+        return (_admin == owner || hasAttribute(_admin, keccak256(abi.encodePacked(WRITE_PERMISSION ^ _attribute))));
+    }
+
+    // Writes are allowed only if the accessManager approves
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
+
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    function subscribe(bytes32 _attribute, RegistryClone _syncer) external onlyOwner {
+        subscribers[_attribute].push(_syncer);
+        emit StartSubscription(_attribute, _syncer);
+    }
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external onlyOwner {
+        uint256 length = subscribers[_attribute].length;
+        require(_index < length);
+        emit StopSubscription(_attribute, subscribers[_attribute][_index]);
+        subscribers[_attribute][_index] = subscribers[_attribute][length - 1];
+        subscribers[_attribute].pop();
+    }
+
+    function subscriberCount(bytes32 _attribute) public view returns (uint256) {
+        return subscribers[_attribute].length;
+    }
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, "", msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, "", msg.sender);
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    // Returns true if the uint256 value stored for this attribute is non-zero
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
+        return attributes[_who][_attribute].value != 0;
+    }
+
+    // Returns the exact value of the attribute, as well as its metadata
+    function getAttribute(address _who, bytes32 _attribute)
+        public
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        )
+    {
+        AttributeData memory data = attributes[_who][_attribute];
+        return (data.value, data.notes, data.adminAddr, data.timestamp);
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].value;
+    }
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) public view returns (address) {
+        return attributes[_who][_attribute].adminAddr;
+    }
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].timestamp;
+    }
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external {
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > _startIndex) {
+            RegistryClone target = targets[index];
+            for (uint256 i = _addresses.length; i-- > 0; ) {
+                address who = _addresses[i];
+                target.syncAttributeValue(who, _attribute, attributes[who][_attribute].value);
+            }
+        }
+    }
+
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/trusttoken/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// import {Registry} from "contracts/registry/Registry.sol";
+
+/**
+ * All storage must be declared here
+ * New storage must be appended to the end
+ * Never remove items from this list
+ */
+contract ProxyStorage {
+    bool initalized;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    mapping(uint144 => uint256) attributes; // see RegistrySubscriber
+
+    address owner_;
+    address pendingOwner_;
+
+    mapping(address => address) public delegates; // A record of votes checkpoints for each account, by index
+    struct Checkpoint {
+        // A checkpoint for marking number of votes from a given block
+        uint32 fromBlock;
+        uint96 votes;
+    }
+    mapping(address => mapping(uint32 => Checkpoint)) public checkpoints; // A record of votes checkpoints for each account, by index
+    mapping(address => uint32) public numCheckpoints; // The number of checkpoints for each account
+    mapping(address => uint256) public nonces;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(3))                attributes
+     **/
+}
+
+
+// Dependency file: contracts/trusttoken/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables balances, allowances, totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ * - Remove inheritance from IERC20 because of ProxyStorage name conflicts
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ProxyStorage} from "contracts/trusttoken/common/ProxyStorage.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ProxyStorage, Context {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), allowance[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        balanceOf[sender] = balanceOf[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        balanceOf[recipient] = balanceOf[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        totalSupply = totalSupply.add(amount);
+        balanceOf[account] = balanceOf[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        balanceOf[account] = balanceOf[account].sub(amount, "ERC20: burn amount exceeds balance");
+        totalSupply = totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        allowance[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/trusttoken/mocks/MockERC20Token.sol
+
+// pragma solidity 0.6.10;
+
+// import {ERC20} from "contracts/trusttoken/common/ERC20.sol";
+
+// import {Registry} from "contracts/registry/Registry.sol";
+
+contract MockERC20Token is ERC20 {
+    Registry registryAddress;
+
+    function registry() public view returns (Registry) {
+        return registryAddress;
+    }
+
+    function setRegistry(Registry _registry) external {
+        registryAddress = _registry;
+    }
+
+    function mint(address _to, uint256 _value) external {
+        _mint(_to, _value);
+    }
+
+    function burn(uint256 _value) external {
+        _burn(msg.sender, _value);
+    }
+
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueUSD";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TUSD";
+    }
+}
+
+
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Dependency file: contracts/truefi/interface/IYToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IYToken is IERC20 {
+    function getPricePerFullShare() external view returns (uint256);
+}
+
+
+// Dependency file: contracts/truefi/interface/ICurve.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IYToken} from "contracts/truefi/interface/IYToken.sol";
+
+interface ICurve {
+    function calc_token_amount(uint256[4] memory amounts, bool deposit) external view returns (uint256);
+
+    function get_virtual_price() external view returns (uint256);
+}
+
+interface ICurveGauge {
+    function balanceOf(address depositor) external view returns (uint256);
+
+    function minter() external returns (ICurveMinter);
+
+    function deposit(uint256 amount) external;
+
+    function withdraw(uint256 amount) external;
+}
+
+interface ICurveMinter {
+    function mint(address gauge) external;
+
+    function token() external view returns (IERC20);
+}
+
+interface ICurvePool {
+    function add_liquidity(uint256[4] memory amounts, uint256 min_mint_amount) external;
+
+    function remove_liquidity_one_coin(
+        uint256 _token_amount,
+        int128 i,
+        uint256 min_amount,
+        bool donate_dust
+    ) external;
+
+    function calc_withdraw_one_coin(uint256 _token_amount, int128 i) external view returns (uint256);
+
+    function token() external view returns (IERC20);
+
+    function curve() external view returns (ICurve);
+
+    function coins(int128 id) external view returns (IYToken);
+}
+
+
+// Root file: contracts/truefi/mocks/MockCurvePool.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {MockERC20Token} from "contracts/trusttoken/mocks/MockERC20Token.sol";
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+// import {ICurve, ICurvePool} from "contracts/truefi/interface/ICurve.sol";
+// import {IYToken} from "contracts/truefi/interface/IYToken.sol";
+
+contract MockCurve is ICurve {
+    uint256 public sharePrice = 1e18;
+
+    function calc_token_amount(uint256[4] memory amounts, bool) external override view returns (uint256) {
+        return (amounts[3] * 1e18) / sharePrice;
+    }
+
+    function set_withdraw_price(uint256 price) external {
+        sharePrice = price;
+    }
+
+    function get_virtual_price() external override view returns (uint256) {
+        return sharePrice;
+    }
+}
+
+contract MockYToken is MockERC20Token {
+    function getPricePerFullShare() external pure returns (uint256) {
+        return 1 ether;
+    }
+}
+
+contract MockCurvePool is ICurvePool, Initializable {
+    IERC20 poolToken;
+    MockERC20Token cToken;
+    MockCurve _curve;
+    MockYToken ytoken;
+
+    function initialize(IERC20 _token) public initializer {
+        poolToken = _token;
+        cToken = new MockERC20Token();
+        _curve = new MockCurve();
+        ytoken = new MockYToken();
+    }
+
+    function add_liquidity(uint256[4] memory amounts, uint256) external override {
+        poolToken.transferFrom(msg.sender, address(this), amounts[3]);
+        cToken.mint(msg.sender, (amounts[3] * 1e18) / _curve.sharePrice());
+    }
+
+    function remove_liquidity_one_coin(
+        uint256 _token_amount,
+        int128,
+        uint256,
+        bool
+    ) external override {
+        cToken.transferFrom(msg.sender, address(this), _token_amount);
+        cToken.burn(_token_amount);
+        poolToken.transfer(msg.sender, (_token_amount * _curve.sharePrice()) / 1e18);
+    }
+
+    function calc_withdraw_one_coin(uint256, int128) external override view returns (uint256) {
+        return _curve.sharePrice();
+    }
+
+    function set_withdraw_price(uint256 price) external {
+        _curve.set_withdraw_price(price);
+    }
+
+    function token() external override view returns (IERC20) {
+        return IERC20(address(cToken));
+    }
+
+    function curve() external override view returns (ICurve) {
+        return _curve;
+    }
+
+    function coins(int128) external override view returns (IYToken) {
+        return IYToken(address(ytoken));
+    }
+}

--- a/flatten/MockDelegateERC20.sol
+++ b/flatten/MockDelegateERC20.sol
@@ -1,0 +1,1015 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Root file: contracts/true-currencies/mocks/MockDelegateERC20.sol
+
+pragma solidity 0.6.10;
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+interface IDelegateERC20 {
+    function delegateTotalSupply() external view returns (uint256);
+
+    function delegateBalanceOf(address who) external view returns (uint256);
+
+    function delegateTransfer(
+        address to,
+        uint256 value,
+        address origSender
+    ) external returns (bool);
+
+    function delegateAllowance(address owner, address spender) external view returns (uint256);
+
+    function delegateTransferFrom(
+        address from,
+        address to,
+        uint256 value,
+        address origSender
+    ) external returns (bool);
+
+    function delegateApprove(
+        address spender,
+        uint256 value,
+        address origSender
+    ) external returns (bool);
+
+    function delegateIncreaseApproval(
+        address spender,
+        uint256 addedValue,
+        address origSender
+    ) external returns (bool);
+
+    function delegateDecreaseApproval(
+        address spender,
+        uint256 subtractedValue,
+        address origSender
+    ) external returns (bool);
+}
+
+/**
+ * Mock Legacy TUSD contract. Forwards calls to delegate ERC20 contract
+ */
+contract MockDelegateERC20 is ERC20 {
+    // If this contract needs to be upgraded, the new contract will be stored
+    // in 'delegate' and any ERC20 calls to this contract will be delegated to that one.
+    IDelegateERC20 public delegate;
+
+    event DelegatedTo(address indexed newContract);
+
+    // Can undelegate by passing in newContract = address(0)
+    function delegateToNewContract(IDelegateERC20 newContract) public {
+        delegate = newContract;
+        emit DelegatedTo(address(delegate));
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual override pure returns (string memory) {
+        return "DelegateERC20";
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual override pure returns (string memory) {
+        return "DERC20";
+    }
+
+    // If a delegate has been designated, all ERC20 calls are forwarded to it
+    function transfer(address to, uint256 value) public virtual override returns (bool) {
+        if (address(delegate) == address(0)) {
+            return super.transfer(to, value);
+        } else {
+            return delegate.delegateTransfer(to, value, msg.sender);
+        }
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) public virtual override returns (bool) {
+        if (address(delegate) == address(0)) {
+            return super.transferFrom(from, to, value);
+        } else {
+            return delegate.delegateTransferFrom(from, to, value, msg.sender);
+        }
+    }
+
+    function balanceOf(address who) public override view returns (uint256) {
+        if (address(delegate) == address(0)) {
+            return super.balanceOf(who);
+        } else {
+            return delegate.delegateBalanceOf(who);
+        }
+    }
+
+    function approve(address spender, uint256 value) public virtual override returns (bool) {
+        if (address(delegate) == address(0)) {
+            return super.approve(spender, value);
+        } else {
+            return delegate.delegateApprove(spender, value, msg.sender);
+        }
+    }
+
+    function allowance(address _owner, address spender) public virtual override view returns (uint256) {
+        if (address(delegate) == address(0)) {
+            return super.allowance(_owner, spender);
+        } else {
+            return delegate.delegateAllowance(_owner, spender);
+        }
+    }
+
+    function totalSupply() public override view returns (uint256) {
+        if (address(delegate) == address(0)) {
+            return super.totalSupply();
+        } else {
+            return delegate.delegateTotalSupply();
+        }
+    }
+
+    function increaseApproval(address spender, uint256 addedValue) public returns (bool) {
+        if (address(delegate) == address(0)) {
+            return super.increaseAllowance(spender, addedValue);
+        } else {
+            return delegate.delegateIncreaseApproval(spender, addedValue, msg.sender);
+        }
+    }
+
+    function decreaseApproval(address spender, uint256 subtractedValue) public returns (bool) {
+        if (address(delegate) == address(0)) {
+            return super.decreaseAllowance(spender, subtractedValue);
+        } else {
+            return delegate.delegateDecreaseApproval(spender, subtractedValue, msg.sender);
+        }
+    }
+}

--- a/flatten/MockERC20Token.sol
+++ b/flatten/MockERC20Token.sol
@@ -1,0 +1,1019 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: contracts/registry/Registry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+contract Registry {
+    struct AttributeData {
+        uint256 value;
+        bytes32 notes;
+        address adminAddr;
+        uint256 timestamp;
+    }
+
+    // never remove any storage variables
+    address public owner;
+    address public pendingOwner;
+    bool initialized;
+
+    // Stores arbitrary attributes for users. An example use case is an IERC20
+    // token that requires its users to go through a KYC/AML check - in this case
+    // a validator can set an account's "hasPassedKYC/AML" attribute to 1 to indicate
+    // that account can use the token. This mapping stores that value (1, in the
+    // example) as well as which validator last set the value and at what time,
+    // so that e.g. the check can be renewed at appropriate intervals.
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
+    // The logic governing who is allowed to set what attributes is abstracted as
+    // this accessManager, so that it may be replaced by the owner as needed
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    mapping(bytes32 => RegistryClone[]) subscribers;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetManager(address indexed oldManager, address indexed newManager);
+    event StartSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+    event StopSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+
+    // Allows a write if either a) the writer is that Registry's owner, or
+    // b) the writer is writing to attribute foo and that writer already has
+    // the canWriteTo-foo attribute set (in that same Registry)
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
+        return (_admin == owner || hasAttribute(_admin, keccak256(abi.encodePacked(WRITE_PERMISSION ^ _attribute))));
+    }
+
+    // Writes are allowed only if the accessManager approves
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
+
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    function subscribe(bytes32 _attribute, RegistryClone _syncer) external onlyOwner {
+        subscribers[_attribute].push(_syncer);
+        emit StartSubscription(_attribute, _syncer);
+    }
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external onlyOwner {
+        uint256 length = subscribers[_attribute].length;
+        require(_index < length);
+        emit StopSubscription(_attribute, subscribers[_attribute][_index]);
+        subscribers[_attribute][_index] = subscribers[_attribute][length - 1];
+        subscribers[_attribute].pop();
+    }
+
+    function subscriberCount(bytes32 _attribute) public view returns (uint256) {
+        return subscribers[_attribute].length;
+    }
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, "", msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, "", msg.sender);
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    // Returns true if the uint256 value stored for this attribute is non-zero
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
+        return attributes[_who][_attribute].value != 0;
+    }
+
+    // Returns the exact value of the attribute, as well as its metadata
+    function getAttribute(address _who, bytes32 _attribute)
+        public
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        )
+    {
+        AttributeData memory data = attributes[_who][_attribute];
+        return (data.value, data.notes, data.adminAddr, data.timestamp);
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].value;
+    }
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) public view returns (address) {
+        return attributes[_who][_attribute].adminAddr;
+    }
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].timestamp;
+    }
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external {
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > _startIndex) {
+            RegistryClone target = targets[index];
+            for (uint256 i = _addresses.length; i-- > 0; ) {
+                address who = _addresses[i];
+                target.syncAttributeValue(who, _attribute, attributes[who][_attribute].value);
+            }
+        }
+    }
+
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/trusttoken/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// import {Registry} from "contracts/registry/Registry.sol";
+
+/**
+ * All storage must be declared here
+ * New storage must be appended to the end
+ * Never remove items from this list
+ */
+contract ProxyStorage {
+    bool initalized;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    mapping(uint144 => uint256) attributes; // see RegistrySubscriber
+
+    address owner_;
+    address pendingOwner_;
+
+    mapping(address => address) public delegates; // A record of votes checkpoints for each account, by index
+    struct Checkpoint {
+        // A checkpoint for marking number of votes from a given block
+        uint32 fromBlock;
+        uint96 votes;
+    }
+    mapping(address => mapping(uint32 => Checkpoint)) public checkpoints; // A record of votes checkpoints for each account, by index
+    mapping(address => uint32) public numCheckpoints; // The number of checkpoints for each account
+    mapping(address => uint256) public nonces;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(3))                attributes
+     **/
+}
+
+
+// Dependency file: contracts/trusttoken/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables balances, allowances, totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ * - Remove inheritance from IERC20 because of ProxyStorage name conflicts
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ProxyStorage} from "contracts/trusttoken/common/ProxyStorage.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ProxyStorage, Context {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), allowance[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        balanceOf[sender] = balanceOf[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        balanceOf[recipient] = balanceOf[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        totalSupply = totalSupply.add(amount);
+        balanceOf[account] = balanceOf[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        balanceOf[account] = balanceOf[account].sub(amount, "ERC20: burn amount exceeds balance");
+        totalSupply = totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        allowance[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Root file: contracts/trusttoken/mocks/MockERC20Token.sol
+
+pragma solidity 0.6.10;
+
+// import {ERC20} from "contracts/trusttoken/common/ERC20.sol";
+
+// import {Registry} from "contracts/registry/Registry.sol";
+
+contract MockERC20Token is ERC20 {
+    Registry registryAddress;
+
+    function registry() public view returns (Registry) {
+        return registryAddress;
+    }
+
+    function setRegistry(Registry _registry) external {
+        registryAddress = _registry;
+    }
+
+    function mint(address _to, uint256 _value) external {
+        _mint(_to, _value);
+    }
+
+    function burn(uint256 _value) external {
+        _burn(msg.sender, _value);
+    }
+
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueUSD";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TUSD";
+    }
+}

--- a/flatten/MockGasRefundToken.sol
+++ b/flatten/MockGasRefundToken.sol
@@ -1,0 +1,1391 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-currencies/common/GasRefund.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+/**
+ * @title Gas Reclaim Legacy
+ *
+ * Note: this contract does not affect any of the token logic. It merely
+ * exists so the TokenController (owner) can reclaim the sponsored gas
+ *
+ * Previously TrueCurrency has a feature called "gas boost" which allowed
+ * us to sponsor gas by setting non-empty storage slots to 1.
+ * We are depricating this feature, but there is a bunch of gas saved
+ * from years of sponsoring gas. This contract is meant to allow the owner
+ * to take advantage of this leftover gas. Once all the slots are used,
+ * this contract can be removed from TrueCurrency.
+ *
+ * Utilitzes the gas refund mechanism in EVM. Each time an non-empty
+ * storage slot is set to 0, evm will refund 15,000 to the sender.
+ * Also utilized the refund for selfdestruct, see gasRefund39
+ */
+abstract contract GasRefund {
+    /**
+     * @dev Refund 15,000 gas per slot.
+     * @param amount number of slots to free
+     */
+    function gasRefund15(uint256 amount) internal {
+        assembly {
+            // get number of free slots
+            let offset := sload(0xfffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // get location of first slot
+            let location := add(offset, 0xfffff)
+            // loop until end is reached
+            for {
+                let end := sub(location, amount)
+            } gt(location, end) {
+                location := sub(location, 1)
+            } {
+                // set storage location to zero
+                // this refunds 15,000 gas
+                sstore(location, 0)
+            }
+            // store new number of free slots
+            sstore(0xfffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev use smart contract self-destruct to refund gas
+     * will refund 39,000 * amount gas
+     */
+    function gasRefund39(uint256 amount) internal {
+        assembly {
+            // get amount of gas slots
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // first sheep pointer
+            let location := sub(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, offset)
+            // loop from location to end
+            for {
+                let end := add(location, amount)
+            } lt(location, end) {
+                location := add(location, 1)
+            } {
+                // load sheep address
+                let sheep := sload(location)
+                // call selfdestruct on sheep
+                pop(call(gas(), sheep, 0, 0, 0, 0, 0))
+                // clear sheep address
+                sstore(location, 0)
+            }
+            // store new number of sheep
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev Return the remaining sponsored gas slots
+     */
+    function remainingGasRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xfffff)
+        }
+    }
+
+    /**
+     * @dev Return the remaining sheep slots
+     */
+    function remainingSheepRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrencyWithGasRefund.sol
+
+// pragma solidity 0.6.10;
+
+// import {GasRefund} from "contracts/true-currencies/common/GasRefund.sol";
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+abstract contract TrueCurrencyWithGasRefund is GasRefund, TrueCurrency {
+    /**
+     * @dev reclaim gas from legacy gas refund #1
+     * will refund 15,000 * amount gas to sender (minus exection cost)
+     * If gas pool is empty, refund 39,000 * amount gas by calling selfdestruct
+     */
+    function refundGas(uint256 amount) external onlyOwner {
+        if (remainingGasRefundPool() > 0) {
+            gasRefund15(amount);
+        } else {
+            gasRefund39(amount.div(3));
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/mocks/MockTrueCurrencyWithGasRefund.sol
+
+// pragma solidity 0.6.10;
+
+// import {TrueCurrencyWithGasRefund} from "contracts/true-currencies/TrueCurrencyWithGasRefund.sol";
+
+contract MockTrueCurrencyWithGasRefund is TrueCurrencyWithGasRefund {
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function initialize() external {
+        require(!initialized);
+        owner = msg.sender;
+        initialized = true;
+    }
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueCurrency";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TCUR";
+    }
+}
+
+
+// Root file: contracts/true-currencies/mocks/MockGasRefundToken.sol
+
+pragma solidity 0.6.10;
+
+// import {MockTrueCurrencyWithGasRefund} from "contracts/true-currencies/mocks/MockTrueCurrencyWithGasRefund.sol";
+
+contract MockGasRefundToken is MockTrueCurrencyWithGasRefund {
+    function sponsorGas(uint256 amount) external {
+        uint256 refundPrice = uint256(-1);
+        assembly {
+            let offset := sload(0xfffff)
+            let result := add(offset, amount)
+            sstore(0xfffff, result)
+            let position := add(offset, 0x100000)
+            sstore(position, refundPrice)
+            for {
+                let i := 0
+            } lt(i, sub(amount, 1)) {
+                i := add(i, 1)
+            } {
+                position := add(position, 1)
+                sstore(position, refundPrice)
+            }
+        }
+    }
+
+    function sponsorGas2(uint256 amount) external {
+        /**
+        Deploy (9 bytes)
+          PC Assembly       Opcodes                                       Stack
+          00 PUSH1(27)      60 1b                                         1b
+          02 DUP1           80                                            1b 1b
+          03 PUSH1(9)       60 09                                         1b 1b 09
+          05 RETURNDATASIZE 3d                                            1b 1b 09 00
+          06 CODECOPY       39                                            1b
+          07 RETURNDATASIZE 3d                                            1b 00
+          08 RETURN         f3
+        Sheep (27 bytes = 3 + 20 + 4)
+          PC Assembly       Opcodes                                       Stack
+          00 RETURNDATASIZE 3d                                            00
+          01 CALLER         33                                            00 caller
+          02 PUSH20(me)     73 memememememememememememememememememememe   00 caller me
+          17 XOR            18                                            00 invalid
+          18 PC             58                                            00 invalid 18
+          19 JUMPI          57                                            00
+          1a SELFDESTRUCT   ff
+        */
+        assembly {
+            mstore(0, or(0x601b8060093d393df33d33730000000000000000000000000000000000000000, address()))
+            mstore(32, 0x185857ff00000000000000000000000000000000000000000000000000000000)
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            let location := sub(0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe, offset)
+            for {
+                let i := 0
+            } lt(i, amount) {
+                i := add(i, 1)
+            } {
+                sstore(location, create(0, 0, 0x24))
+                location := sub(location, 1)
+            }
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, add(offset, amount))
+        }
+    }
+}

--- a/flatten/MockHook.sol
+++ b/flatten/MockHook.sol
@@ -1,8 +1,4 @@
-#!/usr/bin/env bash
-
-yarn waffle flatten
-
-header="/*
+/*
     .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
     .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
     .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
@@ -28,8 +24,17 @@ header="/*
 */
 
 // https://github.com/trusttoken/smart-contracts
-"
+// Root file: contracts/true-currencies/mocks/MockHook.sol
 
-for filename in ./flatten/*.sol; do
-  echo -e "$header$(cat $filename)" > $filename
-done
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+contract MockHook {
+    uint256[] t;
+
+    function hook() external {
+        for (uint256 i = 0; i < 100; i++) {
+            t.push(i + 1);
+        }
+    }
+}

--- a/flatten/MockLoanFactory.sol
+++ b/flatten/MockLoanFactory.sol
@@ -1,0 +1,1389 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Dependency file: contracts/truefi/interface/ILoanFactory.sol
+
+// pragma solidity 0.6.10;
+
+interface ILoanFactory {
+    function createLoanToken(
+        uint256 _amount,
+        uint256 _term,
+        uint256 _apy
+    ) external;
+
+    function isLoanToken(address) external view returns (bool);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/ERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+// import "@openzeppelin/contracts/GSN/Context.sol";
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+// import "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20 is Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    mapping (address => uint256) private _balances;
+
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    constructor (string memory name, string memory symbol) public {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/truefi/interface/ILoanToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ILoanToken is IERC20 {
+    enum Status {Awaiting, Funded, Withdrawn, Settled, Defaulted}
+
+    function borrower() external view returns (address);
+
+    function amount() external view returns (uint256);
+
+    function term() external view returns (uint256);
+
+    function apy() external view returns (uint256);
+
+    function start() external view returns (uint256);
+
+    function lender() external view returns (address);
+
+    function debt() external view returns (uint256);
+
+    function profit() external view returns (uint256);
+
+    function status() external view returns (Status);
+
+    function borrowerFee() external view returns (uint256);
+
+    function receivedAmount() external view returns (uint256);
+
+    function isLoanToken() external pure returns (bool);
+
+    function getParameters()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function fund() external;
+
+    function withdraw(address _beneficiary) external;
+
+    function close() external;
+
+    function redeem(uint256 _amount) external;
+
+    function repay(address _sender, uint256 _amount) external;
+
+    function reclaim() external;
+
+    function allowTransfer(address account, bool _status) external;
+
+    function repaid() external view returns (uint256);
+
+    function balance() external view returns (uint256);
+
+    function value(uint256 _balance) external view returns (uint256);
+
+    function currencyToken() external view returns (IERC20);
+
+    function version() external pure returns (uint8);
+}
+
+
+// Dependency file: contracts/truefi/LoanToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {ILoanToken} from "contracts/truefi/interface/ILoanToken.sol";
+
+/**
+ * @title LoanToken
+ * @dev A token which represents share of a debt obligation
+ *
+ * Each LoanToken has:
+ * - borrower address
+ * - borrow amount
+ * - loan term
+ * - loan APY
+ *
+ * Loan progresses through the following states:
+ * Awaiting:    Waiting for funding to meet capital requirements
+ * Funded:      Capital requirements met, borrower can withdraw
+ * Withdrawn:   Borrower withdraws money, loan waiting to be repaid
+ * Settled:     Loan has been paid back in full with interest
+ * Defaulted:   Loan has not been paid back in full
+ *
+ * - LoanTokens are non-transferable except for whitelisted addresses
+ * - This version of LoanToken only supports a single funder
+ */
+contract LoanToken is ILoanToken, ERC20 {
+    using SafeMath for uint256;
+
+    uint128 public constant lastMinutePaybackDuration = 1 days;
+    uint8 public constant override version = 2;
+
+    address public override borrower;
+    uint256 public override amount;
+    uint256 public override term;
+    uint256 public override apy;
+
+    uint256 public override start;
+    address public override lender;
+    uint256 public override debt;
+
+    uint256 public redeemed;
+
+    // borrow fee -> 25 = 0.25%
+    uint256 public override borrowerFee = 25;
+
+    // whitelist for transfers
+    mapping(address => bool) public canTransfer;
+
+    Status public override status;
+
+    IERC20 public override currencyToken;
+
+    /**
+     * @dev Emitted when the loan is funded
+     * @param lender Address which funded the loan
+     */
+    event Funded(address lender);
+
+    /**
+     * @dev Emitted when transfer whitelist is updated
+     * @param account Account to whitelist for transfers
+     * @param status New whitelist status
+     */
+    event TransferAllowanceChanged(address account, bool status);
+
+    /**
+     * @dev Emitted when borrower withdraws funds
+     * @param beneficiary Account which will receive funds
+     */
+    event Withdrawn(address beneficiary);
+
+    /**
+     * @dev Emitted when term is over
+     * @param status Final loan status
+     * @param returnedAmount Amount that was retured before expiry
+     */
+    event Closed(Status status, uint256 returnedAmount);
+
+    /**
+     * @dev Emitted when a LoanToken is redeemed for underlying currencyTokens
+     * @param receiver Receiver of currencyTokens
+     * @param burnedAmount Amount of LoanTokens burned
+     * @param redeemedAmound Amount of currencyToken received
+     */
+    event Redeemed(address receiver, uint256 burnedAmount, uint256 redeemedAmound);
+
+    /**
+     * @dev Emitted when a LoanToken is repaid by the borrower in underlying currencyTokens
+     * @param repayer Sender of currencyTokens
+     * @param repaidAmound Amount of currencyToken repaid
+     */
+    event Repaid(address repayer, uint256 repaidAmound);
+
+    /**
+     * @dev Emitted when borrower reclaims remaining currencyTokens
+     * @param borrower Reveiver of remaining currencyTokens
+     * @param reclaimedAmount Amount of currencyTokens repaid
+     */
+    event Reclaimed(address borrower, uint256 reclaimedAmount);
+
+    /**
+     * @dev Create a Loan
+     * @param _currencyToken Token to lend
+     * @param _borrower Borrwer addresss
+     * @param _amount Borrow amount of currency tokens
+     * @param _term Loan length
+     * @param _apy Loan APY
+     */
+    constructor(
+        IERC20 _currencyToken,
+        address _borrower,
+        address _lender,
+        uint256 _amount,
+        uint256 _term,
+        uint256 _apy
+    ) public ERC20("Loan Token", "LOAN") {
+        require(_lender != address(0), "LoanToken: Lender is not set");
+
+        currencyToken = _currencyToken;
+        borrower = _borrower;
+        amount = _amount;
+        term = _term;
+        apy = _apy;
+        lender = _lender;
+        debt = interest(amount);
+    }
+
+    /**
+     * @dev Only borrower can withdraw & repay loan
+     */
+    modifier onlyBorrower() {
+        require(msg.sender == borrower, "LoanToken: Caller is not the borrower");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Settled
+     */
+    modifier onlyClosed() {
+        require(status == Status.Settled || status == Status.Defaulted, "LoanToken: Current status should be Settled or Defaulted");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Funded
+     */
+    modifier onlyOngoing() {
+        require(status == Status.Funded || status == Status.Withdrawn, "LoanToken: Current status should be Funded or Withdrawn");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Funded
+     */
+    modifier onlyFunded() {
+        require(status == Status.Funded, "LoanToken: Current status should be Funded");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Withdrawn
+     */
+    modifier onlyAfterWithdraw() {
+        require(status >= Status.Withdrawn, "LoanToken: Only after loan has been withdrawn");
+        _;
+    }
+
+    /**
+     * @dev Only when loan is Awaiting
+     */
+    modifier onlyAwaiting() {
+        require(status == Status.Awaiting, "LoanToken: Current status should be Awaiting");
+        _;
+    }
+
+    /**
+     * @dev Only whitelisted accounts or lender
+     */
+    modifier onlyWhoCanTransfer(address sender) {
+        require(
+            sender == lender || canTransfer[sender],
+            "LoanToken: This can be performed only by lender or accounts allowed to transfer"
+        );
+        _;
+    }
+
+    /**
+     * @dev Only lender can perform certain actions
+     */
+    modifier onlyLender() {
+        require(msg.sender == lender, "LoanToken: This can be performed only by lender");
+        _;
+    }
+
+    /**
+     * @dev Return true if this contract is a LoanToken
+     * @return True if this contract is a LoanToken
+     */
+    function isLoanToken() external override pure returns (bool) {
+        return true;
+    }
+
+    /**
+     * @dev Get loan parameters
+     * @return amount, term, apy
+     */
+    function getParameters()
+        external
+        override
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        )
+    {
+        return (amount, apy, term);
+    }
+
+    /**
+     * @dev Get coupon value of this loan token in currencyToken
+     * This assumes the loan will be paid back on time, with interest
+     * @param _balance number of LoanTokens to get value for
+     * @return coupon value of _balance LoanTokens in currencyTokens
+     */
+    function value(uint256 _balance) external override view returns (uint256) {
+        if (_balance == 0) {
+            return 0;
+        }
+
+        uint256 passed = block.timestamp.sub(start);
+        if (passed > term) {
+            passed = term;
+        }
+
+        // assume year is 365 days
+        uint256 interest = amount.mul(apy).mul(passed).div(365 days).div(10000);
+
+        return amount.add(interest).mul(_balance).div(debt);
+    }
+
+    /**
+     * @dev Fund a loan
+     * Set status, start time, lender
+     */
+    function fund() external override onlyAwaiting onlyLender {
+        status = Status.Funded;
+        start = block.timestamp;
+        _mint(msg.sender, debt);
+        require(currencyToken.transferFrom(msg.sender, address(this), receivedAmount()));
+
+        emit Funded(msg.sender);
+    }
+
+    /**
+     * @dev Whitelist accounts to transfer
+     * @param account address to allow transfers for
+     * @param _status true allows transfers, false disables transfers
+     */
+    function allowTransfer(address account, bool _status) external override onlyLender {
+        canTransfer[account] = _status;
+        emit TransferAllowanceChanged(account, _status);
+    }
+
+    /**
+     * @dev Borrower calls this function to withdraw funds
+     * Sets the status of the loan to Withdrawn
+     * @param _beneficiary address to send funds to
+     */
+    function withdraw(address _beneficiary) external override onlyBorrower onlyFunded {
+        status = Status.Withdrawn;
+        require(currencyToken.transfer(_beneficiary, receivedAmount()));
+
+        emit Withdrawn(_beneficiary);
+    }
+
+    /**
+     * @dev Close the loan and check if it has been repaid
+     */
+    function close() external override onlyOngoing {
+        require(start.add(term) <= block.timestamp, "LoanToken: Loan cannot be closed yet");
+        if (_balance() >= debt) {
+            status = Status.Settled;
+        } else {
+            require(
+                start.add(term).add(lastMinutePaybackDuration) <= block.timestamp,
+                "LoanToken: Borrower can still pay the loan back"
+            );
+            status = Status.Defaulted;
+        }
+
+        emit Closed(status, _balance());
+    }
+
+    /**
+     * @dev Redeem LoanToken balances for underlying currencyToken
+     * Can only call this function after the loan is Closed
+     * @param _amount amount to redeem
+     */
+    function redeem(uint256 _amount) external override onlyClosed {
+        uint256 amountToReturn = _amount.mul(_balance()).div(totalSupply());
+        redeemed = redeemed.add(amountToReturn);
+        _burn(msg.sender, _amount);
+        require(currencyToken.transfer(msg.sender, amountToReturn));
+
+        emit Redeemed(msg.sender, _amount, amountToReturn);
+    }
+
+    /**
+     * @dev Function for borrower to repay the loan
+     * Borrower can repay at any time
+     * @param _sender account sending currencyToken to repay
+     * @param _amount amount of currencyToken to repay
+     */
+    function repay(address _sender, uint256 _amount) external override onlyAfterWithdraw {
+        require(_amount <= debt.sub(_balance()), "LoanToken: Cannot repay over the debt");
+        require(currencyToken.transferFrom(_sender, address(this), _amount));
+        emit Repaid(_sender, _amount);
+    }
+
+    /**
+     * @dev Function for borrower to reclaim stuck currencyToken
+     * Can only call this function after the loan is Closed
+     * and all of LoanToken holders have been burnt
+     */
+    function reclaim() external override onlyClosed onlyBorrower {
+        require(totalSupply() == 0, "LoanToken: Cannot reclaim when LoanTokens are in circulation");
+        uint256 balanceRemaining = _balance();
+        require(balanceRemaining > 0, "LoanToken: Cannot reclaim when balance 0");
+
+        require(currencyToken.transfer(borrower, balanceRemaining));
+        emit Reclaimed(borrower, balanceRemaining);
+    }
+
+    /**
+     * @dev Check how much was already repaid
+     * Funds stored on the contract's addres plus funds already redeemed by lenders
+     * @return Uint256 representing what value was already repaid
+     */
+    function repaid() external override view onlyAfterWithdraw returns (uint256) {
+        return _balance().add(redeemed);
+    }
+
+    /**
+     * @dev Public currency token balance function
+     * @return currencyToken balance of this contract
+     */
+    function balance() external override view returns (uint256) {
+        return _balance();
+    }
+
+    /**
+     * @dev Get currency token balance for this contract
+     * @return currencyToken balance of this contract
+     */
+    function _balance() internal view returns (uint256) {
+        return currencyToken.balanceOf(address(this));
+    }
+
+    /**
+     * @dev Calculate amount borrowed minus fee
+     * @return Amount minus fees
+     */
+    function receivedAmount() public override view returns (uint256) {
+        return amount.sub(amount.mul(borrowerFee).div(10000));
+    }
+
+    /**
+     * @dev Calculate interest that will be paid by this loan for an amount (returned funds included)
+     * amount + ((amount * apy * term) / (365 days / precision))
+     * @param _amount amount
+     * @return uint256 Amount of interest paid for _amount
+     */
+    function interest(uint256 _amount) internal view returns (uint256) {
+        return _amount.add(_amount.mul(apy).mul(term).div(365 days).div(10000));
+    }
+
+    /**
+     * @dev get profit for this loan
+     * @return profit for this loan
+     */
+    function profit() external override view returns (uint256) {
+        return debt.sub(amount);
+    }
+
+    /**
+     * @dev Override ERC20 _transfer so only whitelisted addresses can transfer
+     * @param sender sender of the transaction
+     * @param recipient recipient of the transaction
+     * @param _amount amount to send
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 _amount
+    ) internal override onlyWhoCanTransfer(sender) {
+        return super._transfer(sender, recipient, _amount);
+    }
+}
+
+
+// Dependency file: contracts/truefi/LoanFactory.sol
+
+// pragma solidity 0.6.10;
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+// import {ILoanFactory} from "contracts/truefi/interface/ILoanFactory.sol";
+
+// import {LoanToken, IERC20} from "contracts/truefi/LoanToken.sol";
+
+/**
+ * @title LoanFactory
+ * @notice Deploy LoanTokens with this Contract
+ * @dev LoanTokens are deployed through a factory to ensure that all
+ * LoanTokens adhere to the same contract code, rather than using an interface.
+ */
+contract LoanFactory is ILoanFactory, Initializable {
+    // ================ WARNING ==================
+    // ===== THIS CONTRACT IS INITIALIZABLE ======
+    // === STORAGE VARIABLES ARE DECLARED BELOW ==
+    // REMOVAL OR REORDER OF VARIABLES WILL RESULT
+    // ========= IN STORAGE CORRUPTION ===========
+
+    IERC20 public currencyToken;
+
+    // @dev Track Valid LoanTokens
+    mapping(address => bool) public override isLoanToken;
+
+    address public lender;
+
+    // ======= STORAGE DECLARATION END ============
+
+    /**
+     * @dev Emitted when a LoanToken is created
+     * @param contractAddress LoanToken contract address
+     */
+    event LoanTokenCreated(address contractAddress);
+
+    /**
+     * @dev Initialize this contract and set currency token
+     * @param _currencyToken Currency token to lend
+     */
+    function initialize(IERC20 _currencyToken) external initializer {
+        currencyToken = _currencyToken;
+    }
+
+    function setLender() external {
+        lender = 0x16d02Dc67EB237C387023339356b25d1D54b0922;
+    }
+
+    /**
+     * @dev Deploy LoanToken with parameters
+     * @param _amount Amount to borrow
+     * @param _term Length of loan
+     * @param _apy Loan yield
+     */
+    function createLoanToken(
+        uint256 _amount,
+        uint256 _term,
+        uint256 _apy
+    ) external override {
+        require(_amount > 0, "LoanFactory: Loans of amount 0, will not be approved");
+        require(_term > 0, "LoanFactory: Loans cannot have instantaneous term of repay");
+
+        address newToken = address(new LoanToken(currencyToken, msg.sender, lender, _amount, _term, _apy));
+        isLoanToken[newToken] = true;
+
+        emit LoanTokenCreated(newToken);
+    }
+}
+
+
+// Root file: contracts/truefi/mocks/MockLoanFactory.sol
+
+pragma solidity 0.6.10;
+
+// import {LoanFactory} from "contracts/truefi/LoanFactory.sol";
+
+contract MockLoanFactory is LoanFactory {
+    function setLender(address newLender) external {
+        lender = newLender;
+    }
+}

--- a/flatten/MockLog.sol
+++ b/flatten/MockLog.sol
@@ -1,0 +1,133 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/truefi/Log.sol
+
+// SPDX-License-Identifier: BSD-4-Clause
+/*
+ * ABDK Math 64.64 Smart Contract Library.  Copyright © 2019 by ABDK Consulting.
+ * Author: Mikhail Vladimirov <mikhail.vladimirov@gmail.com>
+ */
+// pragma solidity 0.6.10;
+
+/**
+ * Smart contract library of mathematical functions operating with signed
+ * 64.64-bit fixed point numbers.  Signed 64.64-bit fixed point number is
+ * basically a simple fraction whose numerator is signed 128-bit integer and
+ * denominator is 2^64.  As long as denominator is always the same, there is no
+ * need to store it, thus in Solidity signed 64.64-bit fixed point numbers are
+ * represented by int128 type holding only the numerator.
+ */
+library ABDKMath64x64 {
+    /**
+     * Convert unsigned 256-bit integer number into signed 64.64-bit fixed point
+     * number.  Revert on overflow.
+     *
+     * @param x unsigned 256-bit integer number
+     * @return signed 64.64-bit fixed point number
+     */
+    function fromUInt(uint256 x) internal pure returns (int128) {
+        require(x <= 0x7FFFFFFFFFFFFFFF);
+        return int128(x << 64);
+    }
+
+    /**
+     * Calculate binary logarithm of x.  Revert if x <= 0.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function log_2(int128 x) internal pure returns (int128) {
+        require(x > 0);
+
+        int256 msb = 0;
+        int256 xc = x;
+        if (xc >= 0x10000000000000000) {
+            xc >>= 64;
+            msb += 64;
+        }
+        if (xc >= 0x100000000) {
+            xc >>= 32;
+            msb += 32;
+        }
+        if (xc >= 0x10000) {
+            xc >>= 16;
+            msb += 16;
+        }
+        if (xc >= 0x100) {
+            xc >>= 8;
+            msb += 8;
+        }
+        if (xc >= 0x10) {
+            xc >>= 4;
+            msb += 4;
+        }
+        if (xc >= 0x4) {
+            xc >>= 2;
+            msb += 2;
+        }
+        if (xc >= 0x2) msb += 1; // No need to shift xc anymore
+
+        int256 result = (msb - 64) << 64;
+        uint256 ux = uint256(x) << uint256(127 - msb);
+        for (int256 bit = 0x8000000000000000; bit > 0; bit >>= 1) {
+            ux *= ux;
+            uint256 b = ux >> 255;
+            ux >>= 127 + b;
+            result += bit * int256(b);
+        }
+
+        return int128(result);
+    }
+
+    /**
+     * Calculate natural logarithm of x.  Revert if x <= 0.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function ln(int128 x) internal pure returns (int128) {
+        require(x > 0);
+
+        return int128((uint256(log_2(x)) * 0xB17217F7D1CF79ABC9E3B39803F2F6AF) >> 128);
+    }
+}
+
+
+// Root file: contracts/truefi/mocks/MockLog.sol
+
+pragma solidity ^0.6.10;
+
+// import {ABDKMath64x64} from "contracts/truefi/Log.sol";
+
+contract MockLog {
+    using ABDKMath64x64 for uint256;
+    using ABDKMath64x64 for int128;
+
+    function ln(uint256 x) public pure returns (int128) {
+        return x.fromUInt().ln();
+    }
+}

--- a/flatten/MockRegistrySubscriber.sol
+++ b/flatten/MockRegistrySubscriber.sol
@@ -1,0 +1,329 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: contracts/registry/Registry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+contract Registry {
+    struct AttributeData {
+        uint256 value;
+        bytes32 notes;
+        address adminAddr;
+        uint256 timestamp;
+    }
+
+    // never remove any storage variables
+    address public owner;
+    address public pendingOwner;
+    bool initialized;
+
+    // Stores arbitrary attributes for users. An example use case is an IERC20
+    // token that requires its users to go through a KYC/AML check - in this case
+    // a validator can set an account's "hasPassedKYC/AML" attribute to 1 to indicate
+    // that account can use the token. This mapping stores that value (1, in the
+    // example) as well as which validator last set the value and at what time,
+    // so that e.g. the check can be renewed at appropriate intervals.
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
+    // The logic governing who is allowed to set what attributes is abstracted as
+    // this accessManager, so that it may be replaced by the owner as needed
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    mapping(bytes32 => RegistryClone[]) subscribers;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetManager(address indexed oldManager, address indexed newManager);
+    event StartSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+    event StopSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+
+    // Allows a write if either a) the writer is that Registry's owner, or
+    // b) the writer is writing to attribute foo and that writer already has
+    // the canWriteTo-foo attribute set (in that same Registry)
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
+        return (_admin == owner || hasAttribute(_admin, keccak256(abi.encodePacked(WRITE_PERMISSION ^ _attribute))));
+    }
+
+    // Writes are allowed only if the accessManager approves
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
+
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    function subscribe(bytes32 _attribute, RegistryClone _syncer) external onlyOwner {
+        subscribers[_attribute].push(_syncer);
+        emit StartSubscription(_attribute, _syncer);
+    }
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external onlyOwner {
+        uint256 length = subscribers[_attribute].length;
+        require(_index < length);
+        emit StopSubscription(_attribute, subscribers[_attribute][_index]);
+        subscribers[_attribute][_index] = subscribers[_attribute][length - 1];
+        subscribers[_attribute].pop();
+    }
+
+    function subscriberCount(bytes32 _attribute) public view returns (uint256) {
+        return subscribers[_attribute].length;
+    }
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, "", msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, "", msg.sender);
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    // Returns true if the uint256 value stored for this attribute is non-zero
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
+        return attributes[_who][_attribute].value != 0;
+    }
+
+    // Returns the exact value of the attribute, as well as its metadata
+    function getAttribute(address _who, bytes32 _attribute)
+        public
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        )
+    {
+        AttributeData memory data = attributes[_who][_attribute];
+        return (data.value, data.notes, data.adminAddr, data.timestamp);
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].value;
+    }
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) public view returns (address) {
+        return attributes[_who][_attribute].adminAddr;
+    }
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].timestamp;
+    }
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external {
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > _startIndex) {
+            RegistryClone target = targets[index];
+            for (uint256 i = _addresses.length; i-- > 0; ) {
+                address who = _addresses[i];
+                target.syncAttributeValue(who, _attribute, attributes[who][_attribute].value);
+            }
+        }
+    }
+
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Root file: contracts/registry/mocks/MockRegistrySubscriber.sol
+
+pragma solidity 0.6.10;
+
+// import {Registry} from "contracts/registry/Registry.sol";
+
+contract MockRegistrySubscriber {
+    mapping(address => mapping(bytes32 => uint256)) attributes;
+
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        attributes[_who][_attribute] = _value;
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute];
+    }
+}

--- a/flatten/MockTrueCurrency.sol
+++ b/flatten/MockTrueCurrency.sol
@@ -1,0 +1,1192 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Root file: contracts/true-currencies/mocks/MockTrueCurrency.sol
+
+pragma solidity 0.6.10;
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+contract MockTrueCurrency is TrueCurrency {
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function initialize() external {
+        require(!initialized);
+        owner = msg.sender;
+        initialized = true;
+    }
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueCurrency";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TCUR";
+    }
+}

--- a/flatten/MockTrueCurrencyWithAutosweep.sol
+++ b/flatten/MockTrueCurrencyWithAutosweep.sol
@@ -1,0 +1,1384 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/mocks/MockTrueCurrencyWithDelegate.sol
+
+// pragma solidity 0.6.10;
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+/**
+ * @title DelegateERC20
+ * Accept forwarding delegation calls from the old TrueUSD (V1) contract.
+ * This way the all the ERC20 functions in the old contract still works
+ * (except Burn).
+ *
+ * The original contract is at 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E.
+ * Lines 497-574 on-chain call these delegate functions to forward calls
+ * This gives the delegate contract the power to change the state of the TrueUSD
+ * contract. The owner of this contract is the TrueUSD TokenController
+ * at 0x0000000000075efbee23fe2de1bd0b7690883cc9.
+ *
+ * Our audits for TrueCurrency can be found here: github.com/trusttoken/audits
+ */
+abstract contract MockTrueCurrencyWithDelegate is TrueCurrency {
+    address delegateFrom;
+
+    // set delegate address for forwarding ERC20 calls
+    function setDelegateAddress(address _delegateFrom) external {
+        delegateFrom = _delegateFrom;
+    }
+
+    // require msg.sender is the delegate smart contract
+    modifier onlyDelegateFrom() {
+        require(msg.sender == delegateFrom);
+        _;
+    }
+
+    /**
+     * @dev Delegate call to get total supply
+     * @return Total supply
+     */
+    function delegateTotalSupply() public view returns (uint256) {
+        return totalSupply();
+    }
+
+    /**
+     * @dev Delegate call to get balance
+     * @param who Address to get balance for
+     * @return balance of account
+     */
+    function delegateBalanceOf(address who) public view returns (uint256) {
+        return balanceOf(who);
+    }
+
+    /**
+     * @dev Delegate call to transfer
+     * @param to address to transfer to
+     * @param value amount to transfer
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateTransfer(
+        address to,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        _transfer(origSender, to, value);
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to get allowance
+     * @param owner acconut owner
+     * @param spender account to check allowance for
+     * @return allowance
+     */
+    function delegateAllowance(address owner, address spender) public view returns (uint256) {
+        return allowance(owner, spender);
+    }
+
+    /**
+     * @dev Delegate call to transfer from
+     * @param from account to transfer funds from
+     * @param to account to transfer funds to
+     * @param value value to transfer
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateTransferFrom(
+        address from,
+        address to,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 transferFrom with _msgSender() replaced by origSender
+        _transfer(from, to, value);
+        _approve(from, origSender, _allowances[from][origSender].sub(value, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to approve
+     * @param spender account to approve for
+     * @param value amount to approve
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateApprove(
+        address spender,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        _approve(origSender, spender, value);
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to increase approval
+     * @param spender account to increase approval for
+     * @param addedValue amount of approval to add
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateIncreaseApproval(
+        address spender,
+        uint256 addedValue,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 increaseAllowance() with _msgSender() replaced by origSender
+        _approve(origSender, spender, _allowances[origSender][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to decrease approval
+     * @param spender spender to decrease approval for
+     * @param subtractedValue value to subtract from approval
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateDecreaseApproval(
+        address spender,
+        uint256 subtractedValue,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 decreaseAllowance() with _msgSender() replaced by origSender
+        _approve(origSender, spender, _allowances[origSender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/mocks/MockTrueCurrencyWithLegacyAutosweep.sol
+
+// pragma solidity 0.6.10;
+
+// import {MockTrueCurrencyWithDelegate} from "contracts/true-currencies/mocks/MockTrueCurrencyWithDelegate.sol";
+
+/**
+ * @dev Contract that prevents addresses that were previously using autosweep addresses from
+ * making transfers on them.
+ *
+ * In older versions TrueCurrencies had a feature called Autosweep.
+ * Given a single deposit address, it was possible to generate 16^5-1 autosweep addresses.
+ * E.g. having deposit address 0xc257274276a4e539741ca11b590b9447b26a8051, you could generate
+ * - 0xc257274276a4e539741ca11b590b9447b2600000
+ * - 0xc257274276a4e539741ca11b590b9447b2600001
+ * - ...
+ * - 0xc257274276a4e539741ca11b590b9447b26fffff
+ * Every transfer to an autosweep address resulted as a transfer to deposit address.
+ * This feature got deprecated, but there were 4 addresses that still actively using the feature.
+ *
+ * This contract will reject a transfer to these 4*(16^5-1) addresses to prevent accidental token freeze.
+ */
+abstract contract MockTrueCurrencyWithLegacyAutosweep is MockTrueCurrencyWithDelegate {
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal override {
+        requireNotAutosweepAddress(recipient, 0x33091DE8341533468D13A80C5A670f4f47cC649f);
+        requireNotAutosweepAddress(recipient, 0x50E2719208914764087e68C32bC5AaC321f5B04d);
+        requireNotAutosweepAddress(recipient, 0x71d69e5481A9B7Be515E20B38a3f62Dab7170D78);
+        requireNotAutosweepAddress(recipient, 0x90fdaA85D52dB6065D466B86f16bF840D514a488);
+
+        super._transfer(sender, recipient, amount);
+    }
+
+    function requireNotAutosweepAddress(address recipient, address depositAddress) internal pure {
+        return
+            require(uint256(recipient) >> 20 != uint256(depositAddress) >> 20 || recipient == depositAddress, "Autosweep is disabled");
+    }
+}
+
+
+// Root file: contracts/true-currencies/mocks/MockTrueCurrencyWithAutosweep.sol
+
+pragma solidity 0.6.10;
+
+// import {MockTrueCurrencyWithLegacyAutosweep} from "contracts/true-currencies/mocks/MockTrueCurrencyWithLegacyAutosweep.sol";
+
+contract MockTrueCurrencyWithAutosweep is MockTrueCurrencyWithLegacyAutosweep {
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function initialize() external {
+        require(!initialized);
+        owner = msg.sender;
+        initialized = true;
+    }
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueCurrency";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TCUR";
+    }
+}

--- a/flatten/MockTrueCurrencyWithDelegate.sol
+++ b/flatten/MockTrueCurrencyWithDelegate.sol
@@ -1,145 +1,34 @@
-/**
- *  :::==== :::====  :::  === :::===== :::  === :::===  :::==== 
- *  :::==== :::  === :::  === :::      :::  === :::     :::  ===
- *    ===   =======  ===  === ======   ===  ===  =====  ===  ===
- *    ===   === ===  ===  === ===      ===  ===     === ===  ===
- *    ===   ===  ===  ======  ========  ======  ======  ======= 
- */
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
 
-pragma solidity 0.6.10;
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
 
-/**
- * Defines the storage layout of the token implementation contract. Any
- * newly declared state variables in future upgrades should be appended
- * to the bottom. Never remove state variables from this list, however variables
- * can be renamed. Please add _Deprecated to deprecated variables.
- */
-contract ProxyStorage {
-    address public owner;
-    address public pendingOwner;
+// SPDX-License-Identifier: MIT
 
-    bool initialized;
-
-    address balances_Deprecated;
-    address allowances_Deprecated;
-
-    uint256 _totalSupply;
-
-    bool private paused_Deprecated = false;
-    address private globalPause_Deprecated;
-
-    uint256 public burnMin = 0;
-    uint256 public burnMax = 0;
-
-    address registry_Deprecated;
-
-    string name_Deprecated;
-    string symbol_Deprecated;
-
-    uint256[] gasRefundPool_Deprecated;
-    uint256 private redemptionAddressCount_Deprecated;
-    uint256 minimumGasPriceForFutureRefunds_Deprecated;
-
-    mapping(address => uint256) _balances;
-    mapping(address => mapping(address => uint256)) _allowances;
-    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
-
-    // reward token storage
-    mapping(address => address) finOps_Deprecated;
-    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
-    mapping(address => uint256) finOpSupply_Deprecated;
-
-    // true reward allocation
-    // proportion: 1000 = 100%
-    struct RewardAllocation {
-        uint256 proportion;
-        address finOp;
-    }
-    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
-    uint256 maxRewardProportion_Deprecated = 1000;
-
-    mapping(address => bool) isBlacklisted;
-    mapping(address => bool) public canBurn;
-
-    /* Additionally, we have several keccak-based storage locations.
-     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
-     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
-     * A preimage collision can be used to attack the contract by treating one storage location as another,
-     * which would always be a critical issue.
-     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
-     *******************************************************************************************************
-     ** length     input                                                         usage
-     *******************************************************************************************************
-     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
-     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
-     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
-     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
-     ** 64         uint256(address),uint256(14)                                  balanceOf
-     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
-     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
-     **/
-}
-
-pragma solidity 0.6.10;
-
-/**
- * @title ClamableOwnable
- * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
- * and provides basic authorization control functions. Inherits storage layout of
- * ProxyStorage.
- */
-contract ClaimableOwnable is ProxyStorage {
-    /**
-     * @dev emitted when ownership is transferred
-     * @param previousOwner previous owner of this contract
-     * @param newOwner new owner of this contract
-     */
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-
-    /**
-     * @dev sets the original `owner` of the contract to the sender
-     * at construction. Must then be reinitialized
-     */
-    constructor() public {
-        owner = msg.sender;
-        emit OwnershipTransferred(address(0), owner);
-    }
-
-    /**
-     * @dev Throws if called by any account other than the owner.
-     */
-    modifier onlyOwner() {
-        require(msg.sender == owner, "only Owner");
-        _;
-    }
-
-    /**
-     * @dev Modifier throws if called by any account other than the pendingOwner.
-     */
-    modifier onlyPendingOwner() {
-        require(msg.sender == pendingOwner, "only pending owner");
-        _;
-    }
-
-    /**
-     * @dev Allows the current owner to set the pendingOwner address.
-     * @param newOwner The address to transfer ownership to.
-     */
-    function transferOwnership(address newOwner) public onlyOwner {
-        pendingOwner = newOwner;
-    }
-
-    /**
-     * @dev Allows the pendingOwner address to finalize the transfer.
-     */
-    function claimOwnership() public onlyPendingOwner {
-        emit OwnershipTransferred(owner, pendingOwner);
-        owner = pendingOwner;
-        pendingOwner = address(0);
-    }
-}
-
-pragma solidity ^0.6.0;
+// pragma solidity ^0.6.0;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.
@@ -178,7 +67,7 @@ interface IERC20 {
      *
      * Returns a boolean value indicating whether the operation succeeded.
      *
-     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * // importANT: Beware that changing an allowance with this method brings the risk
      * that someone may use both the old and the new allowance by unfortunate
      * transaction ordering. One possible solution to mitigate this race
      * condition is to first reduce the spender's allowance to 0 and set the
@@ -215,7 +104,11 @@ interface IERC20 {
     event Approval(address indexed owner, address indexed spender, uint256 value);
 }
 
-pragma solidity ^0.6.0;
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
 
 /*
  * @dev Provides information about the current execution context, including the
@@ -238,7 +131,11 @@ abstract contract Context {
     }
 }
 
-pragma solidity ^0.6.0;
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow
@@ -396,7 +293,11 @@ library SafeMath {
     }
 }
 
-pragma solidity ^0.6.2;
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
 
 /**
  * @dev Collection of functions related to the address type
@@ -405,7 +306,7 @@ library Address {
     /**
      * @dev Returns true if `account` is a contract.
      *
-     * [IMPORTANT]
+     * [// importANT]
      * ====
      * It is unsafe to assume that an address for which this function returns
      * false is an externally-owned account (EOA) and not a contract.
@@ -420,14 +321,14 @@ library Address {
      * ====
      */
     function isContract(address account) internal view returns (bool) {
-        // According to EIP-1052, 0x0 is the value returned for not-yet created accounts
-        // and 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 is returned
-        // for accounts without code, i.e. `keccak256('')`
-        bytes32 codehash;
-        bytes32 accountHash = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
         // solhint-disable-next-line no-inline-assembly
-        assembly { codehash := extcodehash(account) }
-        return (codehash != accountHash && codehash != 0x0);
+        assembly { size := extcodesize(account) }
+        return size > 0;
     }
 
     /**
@@ -441,7 +342,7 @@ library Address {
      *
      * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
      *
-     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * // importANT: because control is transferred to `recipient`, care must be
      * taken to not create reentrancy vulnerabilities. Consider using
      * {ReentrancyGuard} or the
      * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
@@ -536,6 +437,152 @@ library Address {
     }
 }
 
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
 /**
  * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
  * Removing state variables has been necessary due to proxy pattern usage.
@@ -549,8 +596,17 @@ library Address {
  * See also: ClaimableOwnable.sol and ProxyStorage.sol
  */
 
-pragma solidity 0.6.10;
 
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
 /**
  * @dev Implementation of the {IERC20} interface.
  *
@@ -811,7 +867,14 @@ abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
     function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
 }
 
-pragma solidity 0.6.10;
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
 
 /**
  * @title ReclaimerToken
@@ -839,7 +902,12 @@ abstract contract ReclaimerToken is ERC20 {
     }
 }
 
-pragma solidity 0.6.10;
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
 
 /**
  * @title BurnableTokenWithBounds
@@ -915,7 +983,12 @@ abstract contract BurnableTokenWithBounds is ReclaimerToken {
     }
 }
 
-pragma solidity 0.6.10;
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
 
 /**
  * @title TrueCurrency
@@ -1084,12 +1157,17 @@ abstract contract TrueCurrency is BurnableTokenWithBounds {
     }
 }
 
+
+// Root file: contracts/true-currencies/mocks/MockTrueCurrencyWithDelegate.sol
+
 pragma solidity 0.6.10;
 
-/** 
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+/**
  * @title DelegateERC20
- * Accept forwarding delegation calls from the old TrueUSD (V1) contract. 
- * This way the all the ERC20 functions in the old contract still works 
+ * Accept forwarding delegation calls from the old TrueUSD (V1) contract.
+ * This way the all the ERC20 functions in the old contract still works
  * (except Burn).
  *
  * The original contract is at 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E.
@@ -1100,12 +1178,17 @@ pragma solidity 0.6.10;
  *
  * Our audits for TrueCurrency can be found here: github.com/trusttoken/audits
  */
-abstract contract DelegateERC20 is TrueCurrency {
-    address constant DELEGATE_FROM = 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E;
+abstract contract MockTrueCurrencyWithDelegate is TrueCurrency {
+    address delegateFrom;
+
+    // set delegate address for forwarding ERC20 calls
+    function setDelegateAddress(address _delegateFrom) external {
+        delegateFrom = _delegateFrom;
+    }
 
     // require msg.sender is the delegate smart contract
-    modifier onlyDelegateFrom() virtual {
-        require(msg.sender == DELEGATE_FROM);
+    modifier onlyDelegateFrom() {
+        require(msg.sender == delegateFrom);
         _;
     }
 
@@ -1127,7 +1210,7 @@ abstract contract DelegateERC20 is TrueCurrency {
     }
 
     /**
-     * @dev Delegate call to
+     * @dev Delegate call to transfer
      * @param to address to transfer to
      * @param value amount to transfer
      * @param origSender original msg.sender on delegate contract
@@ -1139,7 +1222,6 @@ abstract contract DelegateERC20 is TrueCurrency {
         address origSender
     ) public onlyDelegateFrom returns (bool) {
         _transfer(origSender, to, value);
-        emit Transfer(origSender, to, value);
         return true;
     }
 
@@ -1147,7 +1229,7 @@ abstract contract DelegateERC20 is TrueCurrency {
      * @dev Delegate call to get allowance
      * @param owner acconut owner
      * @param spender account to check allowance for
-     * @return success
+     * @return allowance
      */
     function delegateAllowance(address owner, address spender) public view returns (uint256) {
         return allowance(owner, spender);
@@ -1167,7 +1249,7 @@ abstract contract DelegateERC20 is TrueCurrency {
         uint256 value,
         address origSender
     ) public onlyDelegateFrom returns (bool) {
-        // copied from ERC20.sol with _msgSender() replaced by origSender
+        // ERC20 transferFrom with _msgSender() replaced by origSender
         _transfer(from, to, value);
         _approve(from, origSender, _allowances[from][origSender].sub(value, "ERC20: transfer amount exceeds allowance"));
         return true;
@@ -1201,7 +1283,7 @@ abstract contract DelegateERC20 is TrueCurrency {
         uint256 addedValue,
         address origSender
     ) public onlyDelegateFrom returns (bool) {
-        // copied from increaseAllowance() with _msgSender() replaced by origSender
+        // ERC20 increaseAllowance() with _msgSender() replaced by origSender
         _approve(origSender, spender, _allowances[origSender][spender].add(addedValue));
         return true;
     }
@@ -1218,74 +1300,8 @@ abstract contract DelegateERC20 is TrueCurrency {
         uint256 subtractedValue,
         address origSender
     ) public onlyDelegateFrom returns (bool) {
-        // copied from decreaseAllowance with _msgSender() replaced by origSender
+        // ERC20 decreaseAllowance() with _msgSender() replaced by origSender
         _approve(origSender, spender, _allowances[origSender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
         return true;
-    }
-}
-
-pragma solidity 0.6.10;
-
-/**
- * @dev Contract that prevents addresses that were previously using autosweep addresses from
- * making transfers on them.
- *
- * In older versions TrueCurrencies had a feature called Autosweep.
- * Given a single deposit address, it was possible to generate 16^5-1 autosweep addresses.
- * E.g. having deposit address 0xc257274276a4e539741ca11b590b9447b26a8051, you could generate
- * - 0xc257274276a4e539741ca11b590b9447b2600000
- * - 0xc257274276a4e539741ca11b590b9447b2600001
- * - ...
- * - 0xc257274276a4e539741ca11b590b9447b26fffff
- * Every transfer to an autosweep address resulted as a transfer to deposit address.
- * This feature got deprecated, but there were 4 addresses that still actively using the feature.
- *
- * This contract will reject a transfer to these 4*(16^5-1) addresses to prevent accidental token freeze.
- */
-abstract contract TrueCurrencyWithLegacyAutosweep is DelegateERC20 {
-    function _transfer(
-        address sender,
-        address recipient,
-        uint256 amount
-    ) internal override {
-        requireNotAutosweepAddress(recipient, 0x33091DE8341533468D13A80C5A670f4f47cC649f);
-        requireNotAutosweepAddress(recipient, 0x50E2719208914764087e68C32bC5AaC321f5B04d);
-        requireNotAutosweepAddress(recipient, 0x71d69e5481A9B7Be515E20B38a3f62Dab7170D78);
-        requireNotAutosweepAddress(recipient, 0x90fdaA85D52dB6065D466B86f16bF840D514a488);
-
-        super._transfer(sender, recipient, amount);
-    }
-
-    function requireNotAutosweepAddress(address recipient, address depositAddress) internal pure {
-        return
-            require(uint256(recipient) >> 20 != uint256(depositAddress) >> 20 || recipient == depositAddress, "Autosweep is disabled");
-    }
-}
-
-pragma solidity 0.6.10;
-
-/**
- * @title TrueUSD
- * @dev This is the top-level ERC20 contract, but most of the interesting functionality is
- * inherited - see the documentation on the corresponding contracts.
- */
-contract TrueUSD is TrueCurrencyWithLegacyAutosweep {
-    uint8 constant DECIMALS = 18;
-    uint8 constant ROUNDING = 2;
-
-    function decimals() public override pure returns (uint8) {
-        return DECIMALS;
-    }
-
-    function rounding() public pure returns (uint8) {
-        return ROUNDING;
-    }
-
-    function name() public override pure returns (string memory) {
-        return "TrueUSD";
-    }
-
-    function symbol() public override pure returns (string memory) {
-        return "TUSD";
     }
 }

--- a/flatten/MockTrueCurrencyWithGasRefund.sol
+++ b/flatten/MockTrueCurrencyWithGasRefund.sol
@@ -1,0 +1,1325 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-currencies/common/GasRefund.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+/**
+ * @title Gas Reclaim Legacy
+ *
+ * Note: this contract does not affect any of the token logic. It merely
+ * exists so the TokenController (owner) can reclaim the sponsored gas
+ *
+ * Previously TrueCurrency has a feature called "gas boost" which allowed
+ * us to sponsor gas by setting non-empty storage slots to 1.
+ * We are depricating this feature, but there is a bunch of gas saved
+ * from years of sponsoring gas. This contract is meant to allow the owner
+ * to take advantage of this leftover gas. Once all the slots are used,
+ * this contract can be removed from TrueCurrency.
+ *
+ * Utilitzes the gas refund mechanism in EVM. Each time an non-empty
+ * storage slot is set to 0, evm will refund 15,000 to the sender.
+ * Also utilized the refund for selfdestruct, see gasRefund39
+ */
+abstract contract GasRefund {
+    /**
+     * @dev Refund 15,000 gas per slot.
+     * @param amount number of slots to free
+     */
+    function gasRefund15(uint256 amount) internal {
+        assembly {
+            // get number of free slots
+            let offset := sload(0xfffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // get location of first slot
+            let location := add(offset, 0xfffff)
+            // loop until end is reached
+            for {
+                let end := sub(location, amount)
+            } gt(location, end) {
+                location := sub(location, 1)
+            } {
+                // set storage location to zero
+                // this refunds 15,000 gas
+                sstore(location, 0)
+            }
+            // store new number of free slots
+            sstore(0xfffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev use smart contract self-destruct to refund gas
+     * will refund 39,000 * amount gas
+     */
+    function gasRefund39(uint256 amount) internal {
+        assembly {
+            // get amount of gas slots
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // first sheep pointer
+            let location := sub(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, offset)
+            // loop from location to end
+            for {
+                let end := add(location, amount)
+            } lt(location, end) {
+                location := add(location, 1)
+            } {
+                // load sheep address
+                let sheep := sload(location)
+                // call selfdestruct on sheep
+                pop(call(gas(), sheep, 0, 0, 0, 0, 0))
+                // clear sheep address
+                sstore(location, 0)
+            }
+            // store new number of sheep
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev Return the remaining sponsored gas slots
+     */
+    function remainingGasRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xfffff)
+        }
+    }
+
+    /**
+     * @dev Return the remaining sheep slots
+     */
+    function remainingSheepRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrencyWithGasRefund.sol
+
+// pragma solidity 0.6.10;
+
+// import {GasRefund} from "contracts/true-currencies/common/GasRefund.sol";
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+abstract contract TrueCurrencyWithGasRefund is GasRefund, TrueCurrency {
+    /**
+     * @dev reclaim gas from legacy gas refund #1
+     * will refund 15,000 * amount gas to sender (minus exection cost)
+     * If gas pool is empty, refund 39,000 * amount gas by calling selfdestruct
+     */
+    function refundGas(uint256 amount) external onlyOwner {
+        if (remainingGasRefundPool() > 0) {
+            gasRefund15(amount);
+        } else {
+            gasRefund39(amount.div(3));
+        }
+    }
+}
+
+
+// Root file: contracts/true-currencies/mocks/MockTrueCurrencyWithGasRefund.sol
+
+pragma solidity 0.6.10;
+
+// import {TrueCurrencyWithGasRefund} from "contracts/true-currencies/TrueCurrencyWithGasRefund.sol";
+
+contract MockTrueCurrencyWithGasRefund is TrueCurrencyWithGasRefund {
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function initialize() external {
+        require(!initialized);
+        owner = msg.sender;
+        initialized = true;
+    }
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueCurrency";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TCUR";
+    }
+}

--- a/flatten/MockTrueCurrencyWithLegacyAutosweep.sol
+++ b/flatten/MockTrueCurrencyWithLegacyAutosweep.sol
@@ -1,0 +1,1350 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/mocks/MockTrueCurrencyWithDelegate.sol
+
+// pragma solidity 0.6.10;
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+/**
+ * @title DelegateERC20
+ * Accept forwarding delegation calls from the old TrueUSD (V1) contract.
+ * This way the all the ERC20 functions in the old contract still works
+ * (except Burn).
+ *
+ * The original contract is at 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E.
+ * Lines 497-574 on-chain call these delegate functions to forward calls
+ * This gives the delegate contract the power to change the state of the TrueUSD
+ * contract. The owner of this contract is the TrueUSD TokenController
+ * at 0x0000000000075efbee23fe2de1bd0b7690883cc9.
+ *
+ * Our audits for TrueCurrency can be found here: github.com/trusttoken/audits
+ */
+abstract contract MockTrueCurrencyWithDelegate is TrueCurrency {
+    address delegateFrom;
+
+    // set delegate address for forwarding ERC20 calls
+    function setDelegateAddress(address _delegateFrom) external {
+        delegateFrom = _delegateFrom;
+    }
+
+    // require msg.sender is the delegate smart contract
+    modifier onlyDelegateFrom() {
+        require(msg.sender == delegateFrom);
+        _;
+    }
+
+    /**
+     * @dev Delegate call to get total supply
+     * @return Total supply
+     */
+    function delegateTotalSupply() public view returns (uint256) {
+        return totalSupply();
+    }
+
+    /**
+     * @dev Delegate call to get balance
+     * @param who Address to get balance for
+     * @return balance of account
+     */
+    function delegateBalanceOf(address who) public view returns (uint256) {
+        return balanceOf(who);
+    }
+
+    /**
+     * @dev Delegate call to transfer
+     * @param to address to transfer to
+     * @param value amount to transfer
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateTransfer(
+        address to,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        _transfer(origSender, to, value);
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to get allowance
+     * @param owner acconut owner
+     * @param spender account to check allowance for
+     * @return allowance
+     */
+    function delegateAllowance(address owner, address spender) public view returns (uint256) {
+        return allowance(owner, spender);
+    }
+
+    /**
+     * @dev Delegate call to transfer from
+     * @param from account to transfer funds from
+     * @param to account to transfer funds to
+     * @param value value to transfer
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateTransferFrom(
+        address from,
+        address to,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 transferFrom with _msgSender() replaced by origSender
+        _transfer(from, to, value);
+        _approve(from, origSender, _allowances[from][origSender].sub(value, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to approve
+     * @param spender account to approve for
+     * @param value amount to approve
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateApprove(
+        address spender,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        _approve(origSender, spender, value);
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to increase approval
+     * @param spender account to increase approval for
+     * @param addedValue amount of approval to add
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateIncreaseApproval(
+        address spender,
+        uint256 addedValue,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 increaseAllowance() with _msgSender() replaced by origSender
+        _approve(origSender, spender, _allowances[origSender][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to decrease approval
+     * @param spender spender to decrease approval for
+     * @param subtractedValue value to subtract from approval
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateDecreaseApproval(
+        address spender,
+        uint256 subtractedValue,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 decreaseAllowance() with _msgSender() replaced by origSender
+        _approve(origSender, spender, _allowances[origSender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+}
+
+
+// Root file: contracts/true-currencies/mocks/MockTrueCurrencyWithLegacyAutosweep.sol
+
+pragma solidity 0.6.10;
+
+// import {MockTrueCurrencyWithDelegate} from "contracts/true-currencies/mocks/MockTrueCurrencyWithDelegate.sol";
+
+/**
+ * @dev Contract that prevents addresses that were previously using autosweep addresses from
+ * making transfers on them.
+ *
+ * In older versions TrueCurrencies had a feature called Autosweep.
+ * Given a single deposit address, it was possible to generate 16^5-1 autosweep addresses.
+ * E.g. having deposit address 0xc257274276a4e539741ca11b590b9447b26a8051, you could generate
+ * - 0xc257274276a4e539741ca11b590b9447b2600000
+ * - 0xc257274276a4e539741ca11b590b9447b2600001
+ * - ...
+ * - 0xc257274276a4e539741ca11b590b9447b26fffff
+ * Every transfer to an autosweep address resulted as a transfer to deposit address.
+ * This feature got deprecated, but there were 4 addresses that still actively using the feature.
+ *
+ * This contract will reject a transfer to these 4*(16^5-1) addresses to prevent accidental token freeze.
+ */
+abstract contract MockTrueCurrencyWithLegacyAutosweep is MockTrueCurrencyWithDelegate {
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal override {
+        requireNotAutosweepAddress(recipient, 0x33091DE8341533468D13A80C5A670f4f47cC649f);
+        requireNotAutosweepAddress(recipient, 0x50E2719208914764087e68C32bC5AaC321f5B04d);
+        requireNotAutosweepAddress(recipient, 0x71d69e5481A9B7Be515E20B38a3f62Dab7170D78);
+        requireNotAutosweepAddress(recipient, 0x90fdaA85D52dB6065D466B86f16bF840D514a488);
+
+        super._transfer(sender, recipient, amount);
+    }
+
+    function requireNotAutosweepAddress(address recipient, address depositAddress) internal pure {
+        return
+            require(uint256(recipient) >> 20 != uint256(depositAddress) >> 20 || recipient == depositAddress, "Autosweep is disabled");
+    }
+}

--- a/flatten/MockTrueLender.sol
+++ b/flatten/MockTrueLender.sol
@@ -1,0 +1,1060 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueFiPool.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * TruePool is an ERC20 which represents a share of a pool
+ *
+ * This contract can be used to wrap opportunities to be compatible
+ * with TrueFi and allow users to directly opt-in through the TUSD contract
+ *
+ * Each TruePool is also a staking opportunity for TRU
+ */
+interface ITrueFiPool is IERC20 {
+    /// @dev pool token (TUSD)
+    function currencyToken() external view returns (IERC20);
+
+    /// @dev stake token (TRU)
+    function stakeToken() external view returns (IERC20);
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Mint pool tokens based on value to sender
+     */
+    function join(uint256 amount) external;
+
+    /**
+     * @dev exit pool
+     * 1. Transfer pool tokens from sender
+     * 2. Burn pool tokens
+     * 3. Transfer value of pool tokens in TUSD to sender
+     */
+    function exit(uint256 amount) external;
+
+    /**
+     * @dev borrow from pool
+     * 1. Transfer TUSD to sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function borrow(uint256 amount, uint256 amountWithoutFee) external;
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function repay(uint256 amount) external;
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueRatingAgency.sol
+
+// pragma solidity 0.6.10;
+
+interface ITrueRatingAgency {
+    function getResults(address id)
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function submit(address id) external;
+
+    function retract(address id) external;
+
+    function yes(address id, uint256 stake) external;
+
+    function no(address id, uint256 stake) external;
+
+    function withdraw(address id, uint256 stake) external;
+
+    function claim(address id, address voter) external;
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Dependency file: contracts/truefi/common/UpgradeableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is Initializable, Context {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function initialize() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Dependency file: contracts/truefi/interface/ILoanToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ILoanToken is IERC20 {
+    enum Status {Awaiting, Funded, Withdrawn, Settled, Defaulted}
+
+    function borrower() external view returns (address);
+
+    function amount() external view returns (uint256);
+
+    function term() external view returns (uint256);
+
+    function apy() external view returns (uint256);
+
+    function start() external view returns (uint256);
+
+    function lender() external view returns (address);
+
+    function debt() external view returns (uint256);
+
+    function profit() external view returns (uint256);
+
+    function status() external view returns (Status);
+
+    function borrowerFee() external view returns (uint256);
+
+    function receivedAmount() external view returns (uint256);
+
+    function isLoanToken() external pure returns (bool);
+
+    function getParameters()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function fund() external;
+
+    function withdraw(address _beneficiary) external;
+
+    function close() external;
+
+    function redeem(uint256 _amount) external;
+
+    function repay(address _sender, uint256 _amount) external;
+
+    function reclaim() external;
+
+    function allowTransfer(address account, bool _status) external;
+
+    function repaid() external view returns (uint256);
+
+    function balance() external view returns (uint256);
+
+    function value(uint256 _balance) external view returns (uint256);
+
+    function currencyToken() external view returns (IERC20);
+
+    function version() external pure returns (uint8);
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueLender.sol
+
+// pragma solidity 0.6.10;
+
+interface ITrueLender {
+    function value() external view returns (uint256);
+
+    function distribute(
+        address recipient,
+        uint256 numerator,
+        uint256 denominator
+    ) external;
+}
+
+
+// Dependency file: contracts/truefi/TrueLender.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {Ownable} from "contracts/truefi/common/UpgradeableOwnable.sol";
+// import {ILoanToken} from "contracts/truefi/interface/ILoanToken.sol";
+// import {ITrueFiPool} from "contracts/truefi/interface/ITrueFiPool.sol";
+// import {ITrueLender} from "contracts/truefi/interface/ITrueLender.sol";
+// import {ITrueRatingAgency} from "contracts/truefi/interface/ITrueRatingAgency.sol";
+
+/**
+ * @title TrueLender v1.0
+ * @dev TrueFi Lending Strategy
+ * This contract implements the lending strategy for the TrueFi pool
+ * The strategy takes into account several parameters and consumes
+ * information from the prediction market in order to approve loans
+ *
+ * This strategy is conservative to avoid defaults.
+ * See: https://github.com/trusttoken/truefi-spec
+ *
+ * 1. Only approve loans which have the following inherent properties:
+ * - minAPY <= loanAPY <= maxAPY
+ * - minSize <= loanSize <= maxSize
+ * - minTerm <= loanTerm <= maxTerm
+ *
+ * 2. Only approve loans which have been rated in the prediction market under the conditions:
+ * - timeInMarket >= votingPeriod
+ * - stakedTRU > (participationFactor * loanSize)
+ * - 1 < ( interest * P(loan_repaid) - (loanSize * riskAversion * P(loan_defaults))
+ *
+ * Once a loan meets these requirements, fund() can be called to transfer
+ * funds from the pool to the LoanToken contract
+ */
+contract TrueLender is ITrueLender, Ownable {
+    using SafeMath for uint256;
+
+    // ================ WARNING ==================
+    // ===== THIS CONTRACT IS INITIALIZABLE ======
+    // === STORAGE VARIABLES ARE DECLARED BELOW ==
+    // REMOVAL OR REORDER OF VARIABLES WILL RESULT
+    // ========= IN STORAGE CORRUPTION ===========
+
+    mapping(address => bool) public allowedBorrowers;
+    ILoanToken[] _loans;
+
+    ITrueFiPool public pool;
+    IERC20 public currencyToken;
+    ITrueRatingAgency public ratingAgency;
+
+    uint256 private constant TOKEN_PRECISION_DIFFERENCE = 10**10;
+
+    // ===== Pool parameters =====
+
+    // bound on APY
+    uint256 public minApy;
+    uint256 public maxApy;
+
+    // How many votes in predction market
+    uint256 public participationFactor;
+
+    // How much worse is it to lose $1 TUSD than it is to gain $1 TUSD
+    uint256 public riskAversion;
+
+    // bound on min & max loan sizes
+    uint256 public minSize;
+    uint256 public maxSize;
+
+    // bound on min & max loan terms
+    uint256 public minTerm;
+    uint256 public maxTerm;
+
+    // minimum prediction market voting period
+    uint256 public votingPeriod;
+
+    // maximum amount of loans lender can handle at once
+    uint256 public maxLoans;
+
+    // ======= STORAGE DECLARATION END ============
+
+    /**
+     * @dev Emitted when a borrower's whitelist status changes
+     * @param who Address for which whitelist status has changed
+     * @param status New whitelist status
+     */
+    event Allowed(address indexed who, bool status);
+
+    /**
+     * @dev Emitted when APY bounds have changed
+     * @param minApy New minimum APY
+     * @param maxApy New maximum APY
+     */
+    event ApyLimitsChanged(uint256 minApy, uint256 maxApy);
+
+    /**
+     * @dev Emitted when participation factor changed
+     * @param participationFactor New participation factor
+     */
+    event ParticipationFactorChanged(uint256 participationFactor);
+
+    /**
+     * @dev Emitted when risk aversion changed
+     * @param riskAversion New risk aversion factor
+     */
+    event RiskAversionChanged(uint256 riskAversion);
+
+    /**
+     * @dev Emitted when the minimum voting period is changed
+     * @param votingPeriod New voting period
+     */
+    event VotingPeriodChanged(uint256 votingPeriod);
+
+    /**
+     * @dev Emitted when the loan size bounds are changed
+     * @param minSize New minimum loan size
+     * @param maxSize New maximum loan size
+     */
+    event SizeLimitsChanged(uint256 minSize, uint256 maxSize);
+
+    /**
+     * @dev Emitted when loan term bounds are changed
+     * @param minTerm New minimum loan term
+     * @param maxTerm New minimum loan term
+     */
+    event TermLimitsChanged(uint256 minTerm, uint256 maxTerm);
+
+    /**
+     * @dev Emitted when loans limit is change
+     * @param maxLoans new maximum amount of loans
+     */
+    event LoansLimitChanged(uint256 maxLoans);
+
+    /**
+     * @dev Emitted when a loan is funded
+     * @param loanToken LoanToken contract which was funded
+     * @param amount Amount funded
+     */
+    event Funded(address indexed loanToken, uint256 amount);
+
+    /**
+     * @dev Emitted when funds are reclaimed from the LoanToken contract
+     * @param loanToken LoanToken from which funds were reclaimed
+     * @param amount Amount repaid
+     */
+    event Reclaimed(address indexed loanToken, uint256 amount);
+
+    /**
+     * @dev Modifier for only lending pool
+     */
+    modifier onlyPool() {
+        require(msg.sender == address(pool), "TrueLender: Sender is not a pool");
+        _;
+    }
+
+    /**
+     * @dev Initalize the contract with parameters
+     * @param _pool Lending pool address
+     * @param _ratingAgency Prediction market address
+     */
+    function initialize(ITrueFiPool _pool, ITrueRatingAgency _ratingAgency) public initializer {
+        Ownable.initialize();
+
+        pool = _pool;
+        currencyToken = _pool.currencyToken();
+        currencyToken.approve(address(_pool), uint256(-1));
+        ratingAgency = _ratingAgency;
+
+        minApy = 1000;
+        maxApy = 3000;
+        participationFactor = 10000;
+        riskAversion = 15000;
+        minSize = 1000000 ether;
+        maxSize = 10000000 ether;
+        minTerm = 182 days;
+        maxTerm = 3650 days;
+        votingPeriod = 7 days;
+
+        maxLoans = 100;
+    }
+
+    /**
+     * @dev Set new bounds on loan size. Only owner can change parameters.
+     * @param min New minimum loan size
+     * @param max New maximum loan size
+     */
+    function setSizeLimits(uint256 min, uint256 max) external onlyOwner {
+        require(min > 0, "TrueLender: Minimal loan size cannot be 0");
+        require(max >= min, "TrueLender: Maximal loan size is smaller than minimal");
+        minSize = min;
+        maxSize = max;
+        emit SizeLimitsChanged(min, max);
+    }
+
+    /**
+     * @dev Set new bounds on loan term length. Only owner can change parameters.
+     * @param min New minimum loan term
+     * @param max New maximum loan term
+     */
+    function setTermLimits(uint256 min, uint256 max) external onlyOwner {
+        require(max >= min, "TrueLender: Maximal loan term is smaller than minimal");
+        minTerm = min;
+        maxTerm = max;
+        emit TermLimitsChanged(min, max);
+    }
+
+    /**
+     * @dev Set new bounds on loan APY. Only owner can change parameters.
+     * @param newMinApy New minimum loan APY
+     * @param newMaxApy New maximum loan APY
+     */
+    function setApyLimits(uint256 newMinApy, uint256 newMaxApy) external onlyOwner {
+        require(newMaxApy >= newMinApy, "TrueLender: Maximal APY is smaller than minimal");
+        minApy = newMinApy;
+        maxApy = newMaxApy;
+        emit ApyLimitsChanged(newMinApy, newMaxApy);
+    }
+
+    /**
+     * @dev Set new minimum voting period in credit rating market.
+     * Only owner can change parameters
+     * @param newVotingPeriod new minimum voting period
+     */
+    function setVotingPeriod(uint256 newVotingPeriod) external onlyOwner {
+        votingPeriod = newVotingPeriod;
+        emit VotingPeriodChanged(newVotingPeriod);
+    }
+
+    /**
+     * @dev Set new participation factor. Only owner can change parameters.
+     * @param newParticipationFactor New participation factor.
+     */
+    function setParticipationFactor(uint256 newParticipationFactor) external onlyOwner {
+        participationFactor = newParticipationFactor;
+        emit ParticipationFactorChanged(newParticipationFactor);
+    }
+
+    /**
+     * @dev Set new risk aversion factor. Only owner can change parameters.
+     * @param newRiskAversion New risk aversion factor
+     */
+    function setRiskAversion(uint256 newRiskAversion) external onlyOwner {
+        riskAversion = newRiskAversion;
+        emit RiskAversionChanged(newRiskAversion);
+    }
+
+    /**
+     * @dev Set new loans limit. Only owner can change parameters.
+     * @param newLoansLimit New loans limit
+     */
+    function setLoansLimit(uint256 newLoansLimit) external onlyOwner {
+        maxLoans = newLoansLimit;
+        emit LoansLimitChanged(maxLoans);
+    }
+
+    /**
+     * @dev Get currently funded loans
+     * @return result Array of loans currently funded
+     */
+    function loans() public view returns (ILoanToken[] memory result) {
+        result = _loans;
+    }
+
+    /**
+     * @dev Fund a loan which meets the strategy requirements
+     * @param loanToken LoanToken to fund
+     */
+    function fund(ILoanToken loanToken) external {
+        require(loanToken.borrower() == msg.sender, "TrueLender: Sender is not borrower");
+        require(loanToken.isLoanToken(), "TrueLender: Only LoanTokens can be funded");
+        require(loanToken.currencyToken() == currencyToken, "TrueLender: Only the same currency LoanTokens can be funded");
+        require(_loans.length < maxLoans, "TrueLender: Loans number has reached the limit");
+
+        (uint256 amount, uint256 apy, uint256 term) = loanToken.getParameters();
+        uint256 receivedAmount = loanToken.receivedAmount();
+        (uint256 start, uint256 no, uint256 yes) = ratingAgency.getResults(address(loanToken));
+
+        require(loanSizeWithinBounds(amount), "TrueLender: Loan size is out of bounds");
+        require(loanTermWithinBounds(term), "TrueLender: Loan term is out of bounds");
+        require(loanIsAttractiveEnough(apy), "TrueLender: APY is out of bounds");
+        require(votingLastedLongEnough(start), "TrueLender: Voting time is below minimum");
+        require(votesThresholdReached(amount, yes), "TrueLender: Not enough votes given for the loan");
+        require(loanIsCredible(apy, term, yes, no), "TrueLender: Loan risk is too high");
+
+        _loans.push(loanToken);
+        pool.borrow(amount, receivedAmount);
+        currencyToken.approve(address(loanToken), receivedAmount);
+        loanToken.fund();
+        emit Funded(address(loanToken), receivedAmount);
+    }
+
+    /**
+     * @dev Temporary fix for old LoanTokens with incorrect value calculation
+     */
+    function loanValue(ILoanToken loan) public view returns (uint256) {
+        uint256 _balance = loan.balanceOf(address(this));
+        if (_balance == 0) {
+            return 0;
+        }
+
+        uint256 passed = block.timestamp.sub(loan.start());
+        if (passed > loan.term()) {
+            passed = loan.term();
+        }
+
+        uint256 helper = loan.amount().mul(loan.apy()).mul(passed).mul(_balance);
+        // assume month is 30 days
+        uint256 interest = helper.div(365 days).div(10000).div(loan.debt());
+
+        return loan.amount().mul(_balance).div(loan.debt()).add(interest);
+    }
+
+    /**
+     * @dev Loop through loan tokens and calculate theoretical value of all loans
+     * There should never be too many loans in the pool to run out of gas
+     * @return Theoretical value of all the loans funded by this strategy
+     */
+    function value() external override view returns (uint256) {
+        uint256 totalValue;
+        for (uint256 index = 0; index < _loans.length; index++) {
+            totalValue = totalValue.add(loanValue(_loans[index]));
+        }
+        return totalValue;
+    }
+
+    /**
+     * @dev For settled loans, redeem LoanTokens for underlying funds
+     * @param loanToken Loan to reclaim capital from
+     */
+    function reclaim(ILoanToken loanToken) external onlyOwner {
+        require(loanToken.isLoanToken(), "TrueLender: Only LoanTokens can be used to reclaimed");
+        require(
+            loanToken.status() == ILoanToken.Status.Settled || loanToken.status() == ILoanToken.Status.Defaulted,
+            "TrueLender: LoanToken is not closed yet"
+        );
+
+        // call redeem function on LoanToken
+        uint256 balanceBefore = currencyToken.balanceOf(address(this));
+        loanToken.redeem(loanToken.balanceOf(address(this)));
+        uint256 balanceAfter = currencyToken.balanceOf(address(this));
+
+        // gets reclaimed amount and pays back to pool
+        uint256 fundsReclaimed = balanceAfter.sub(balanceBefore);
+        pool.repay(fundsReclaimed);
+
+        // remove loan from loan array
+        for (uint256 index = 0; index < _loans.length; index++) {
+            if (_loans[index] == loanToken) {
+                _loans[index] = _loans[_loans.length - 1];
+                _loans.pop();
+                break;
+            }
+        }
+
+        emit Reclaimed(address(loanToken), fundsReclaimed);
+    }
+
+    /**
+     * @dev Withdraw a basket of tokens held by the pool
+     * When exiting the pool, the pool contract calls this function
+     * to withdraw a fraction of all the loans held by the pool
+     * Loop through recipient's share of LoanTokens and calculate versus total per loan.
+     * There should never be too many loans in the pool to run out of gas
+     *
+     * @param recipient Recipient of basket
+     * @param numerator Numerator of fraction to withdraw
+     * @param denominator Denominator of fraction to withdraw
+     */
+    function distribute(
+        address recipient,
+        uint256 numerator,
+        uint256 denominator
+    ) external override onlyPool {
+        for (uint256 index = 0; index < _loans.length; index++) {
+            _loans[index].transfer(recipient, numerator.mul(_loans[index].balanceOf(address(this))).div(denominator));
+        }
+    }
+
+    /**
+     * @dev Check if a loan is within APY bounds
+     * @param apy APY of loan
+     * @return Whether a loan is within APY bounds
+     */
+    function loanIsAttractiveEnough(uint256 apy) public view returns (bool) {
+        return apy >= minApy && apy <= maxApy;
+    }
+
+    /**
+     * @dev Check if a loan has been in the credit market long enough
+     * @param start Timestamp at which rating began
+     * @return Whether a loan has been rated for long enough
+     */
+    function votingLastedLongEnough(uint256 start) public view returns (bool) {
+        return start.add(votingPeriod) <= block.timestamp;
+    }
+
+    /**
+     * @dev Check if a loan is within size bounds
+     * @param amount Size of loan
+     * @return Whether a loan is within size bounds
+     */
+    function loanSizeWithinBounds(uint256 amount) public view returns (bool) {
+        return amount >= minSize && amount <= maxSize;
+    }
+
+    /**
+     * @dev Check if loan term is within term bounds
+     * @param term Term of loan
+     * @return Whether loan term is within term bounds
+     */
+    function loanTermWithinBounds(uint256 term) public view returns (bool) {
+        return term >= minTerm && term <= maxTerm;
+    }
+
+    /**
+     * @dev Check if a loan is within APY bounds
+     * Minimum absolute value of yes votes, rather than ratio of yes to no
+     * @param amount Size of loan
+     * @param yesVotes Number of yes votes
+     * @return Whether a loan has reached the required voting threshold
+     */
+    function votesThresholdReached(uint256 amount, uint256 yesVotes) public view returns (bool) {
+        return amount.mul(participationFactor) <= yesVotes.mul(10000).mul(TOKEN_PRECISION_DIFFERENCE);
+    }
+
+    /**
+     * @dev Use APY and term of loan to check expected value of a loan
+     * Expected value = profit - (default_loss * (no / yes))
+     * e.g. riskAversion = 10,000 => expected value of 1
+     * @param apy APY of loan
+     * @param term Term length of loan
+     * @param yesVotes Number of YES votes in credit market
+     * @param noVotes Number of NO votes in credit market
+     */
+    function loanIsCredible(
+        uint256 apy,
+        uint256 term,
+        uint256 yesVotes,
+        uint256 noVotes
+    ) public view returns (bool) {
+        return apy.mul(term).mul(yesVotes).div(365 days) >= noVotes.mul(riskAversion);
+    }
+}
+
+
+// Root file: contracts/truefi/mocks/MockTrueLender.sol
+
+pragma solidity 0.6.10;
+
+// import {ITrueFiPool} from "contracts/truefi/interface/ITrueFiPool.sol";
+// import {ITrueRatingAgency} from "contracts/truefi/interface/ITrueRatingAgency.sol";
+
+// import {TrueLender} from "contracts/truefi/TrueLender.sol";
+
+contract MockTrueLender is TrueLender {
+    function setPool(ITrueFiPool newPool) external {
+        pool = newPool;
+    }
+}

--- a/flatten/Ownable.sol
+++ b/flatten/Ownable.sol
@@ -1,0 +1,201 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-gold/interface/IOwnable.sol
+
+// SPDX-License-Identifier: UNLICENSED
+// pragma solidity 0.6.10;
+
+interface IOwnable {
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/true-gold/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+contract ProxyStorage {
+    // Initializable.sol
+    bool _initialized;
+    bool _initializing;
+
+    // Ownable.sol
+    address _owner;
+
+    // ERC20.sol
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    uint256 _totalSupply;
+
+    // TrueMintableBurnable.sol
+    uint256 _minBurnAmount;
+    uint256 _maxBurnAmount;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 20         "trueGold.proxy.owner"                                        Proxy Owner
+     ** 28         "trueGold.pending.proxy.owner"                                Pending Proxy Owner
+     ** 29         "trueGold.proxy.implementation"                               Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   _balances
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       _allowances
+     **/
+}
+
+
+// Dependency file: contracts/true-gold/common/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable is ProxyStorage {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    // bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    // bool private _initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(_initializing || isConstructor() || !_initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+}
+
+
+// Root file: contracts/true-gold/common/Ownable.sol
+
+pragma solidity 0.6.10;
+
+// import "contracts/true-gold/interface/IOwnable.sol";
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+// import "contracts/true-gold/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is ProxyStorage, Initializable, IOwnable {
+    // address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function __Ownable_init_unchained() internal initializer {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == msg.sender, "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual override onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}

--- a/flatten/OwnableMock.sol
+++ b/flatten/OwnableMock.sol
@@ -1,0 +1,135 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/access/Ownable.sol
+
+
+// pragma solidity ^0.6.0;
+
+// import "@openzeppelin/contracts/GSN/Context.sol";
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is Context {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor () internal {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Root file: contracts/true-gold/mocks/OwnableMock.sol
+
+pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/access/Ownable.sol";
+
+// solhint-disable-next-line no-empty-blocks
+contract OwnableMock is Ownable {
+
+}

--- a/flatten/OwnedUpgradeabilityProxy.sol
+++ b/flatten/OwnedUpgradeabilityProxy.sol
@@ -1,0 +1,204 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Root file: contracts/proxy/OwnedUpgradeabilityProxy.sol
+
+// SPDX-License-Identifier: MIT
+// solhint-disable const-name-snakecase
+pragma solidity 0.6.10;
+
+/**
+ * @title OwnedUpgradeabilityProxy
+ * @dev This contract combines an upgradeability proxy with basic authorization control functionalities
+ */
+contract OwnedUpgradeabilityProxy {
+    /**
+     * @dev Event to show ownership has been transferred
+     * @param previousOwner representing the address of the previous owner
+     * @param newOwner representing the address of the new owner
+     */
+    event ProxyOwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Event to show ownership transfer is pending
+     * @param currentOwner representing the address of the current owner
+     * @param pendingOwner representing the address of the pending owner
+     */
+    event NewPendingOwner(address currentOwner, address pendingOwner);
+
+    // Storage position of the owner and pendingOwner of the contract
+    bytes32 private constant proxyOwnerPosition = 0x6279e8199720cf3557ecd8b58d667c8edc486bd1cf3ad59ea9ebdfcae0d0dfac; //keccak256("trueUSD.proxy.owner");
+    bytes32 private constant pendingProxyOwnerPosition = 0x8ddbac328deee8d986ec3a7b933a196f96986cb4ee030d86cc56431c728b83f4; //keccak256("trueUSD.pending.proxy.owner");
+
+    /**
+     * @dev the constructor sets the original owner of the contract to the sender account.
+     */
+    constructor() public {
+        _setUpgradeabilityOwner(msg.sender);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyProxyOwner() {
+        require(msg.sender == proxyOwner(), "only Proxy Owner");
+        _;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the pending owner.
+     */
+    modifier onlyPendingProxyOwner() {
+        require(msg.sender == pendingProxyOwner(), "only pending Proxy Owner");
+        _;
+    }
+
+    /**
+     * @dev Tells the address of the owner
+     * @return owner the address of the owner
+     */
+    function proxyOwner() public view returns (address owner) {
+        bytes32 position = proxyOwnerPosition;
+        assembly {
+            owner := sload(position)
+        }
+    }
+
+    /**
+     * @dev Tells the address of the owner
+     * @return pendingOwner the address of the pending owner
+     */
+    function pendingProxyOwner() public view returns (address pendingOwner) {
+        bytes32 position = pendingProxyOwnerPosition;
+        assembly {
+            pendingOwner := sload(position)
+        }
+    }
+
+    /**
+     * @dev Sets the address of the owner
+     */
+    function _setUpgradeabilityOwner(address newProxyOwner) internal {
+        bytes32 position = proxyOwnerPosition;
+        assembly {
+            sstore(position, newProxyOwner)
+        }
+    }
+
+    /**
+     * @dev Sets the address of the owner
+     */
+    function _setPendingUpgradeabilityOwner(address newPendingProxyOwner) internal {
+        bytes32 position = pendingProxyOwnerPosition;
+        assembly {
+            sstore(position, newPendingProxyOwner)
+        }
+    }
+
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     *changes the pending owner to newOwner. But doesn't actually transfer
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferProxyOwnership(address newOwner) external onlyProxyOwner {
+        require(newOwner != address(0));
+        _setPendingUpgradeabilityOwner(newOwner);
+        emit NewPendingOwner(proxyOwner(), newOwner);
+    }
+
+    /**
+     * @dev Allows the pendingOwner to claim ownership of the proxy
+     */
+    function claimProxyOwnership() external onlyPendingProxyOwner {
+        emit ProxyOwnershipTransferred(proxyOwner(), pendingProxyOwner());
+        _setUpgradeabilityOwner(pendingProxyOwner());
+        _setPendingUpgradeabilityOwner(address(0));
+    }
+
+    /**
+     * @dev Allows the proxy owner to upgrade the current version of the proxy.
+     * @param implementation representing the address of the new implementation to be set.
+     */
+    function upgradeTo(address implementation) public virtual onlyProxyOwner {
+        address currentImplementation;
+        bytes32 position = implementationPosition;
+        assembly {
+            currentImplementation := sload(position)
+        }
+        require(currentImplementation != implementation);
+        assembly {
+            sstore(position, implementation)
+        }
+        emit Upgraded(implementation);
+    }
+
+    /**
+     * @dev This event will be emitted every time the implementation gets upgraded
+     * @param implementation representing the address of the upgraded implementation
+     */
+    event Upgraded(address indexed implementation);
+
+    // Storage position of the address of the current implementation
+    bytes32 private constant implementationPosition = 0x6e41e0fbe643dfdb6043698bf865aada82dc46b953f754a3468eaa272a362dc7; //keccak256("trueUSD.proxy.implementation");
+
+    function implementation() public view returns (address impl) {
+        bytes32 position = implementationPosition;
+        assembly {
+            impl := sload(position)
+        }
+    }
+
+    /**
+     * @dev Fallback functions allowing to perform a delegatecall to the given implementation.
+     * This function will return whatever the implementation call returns
+     */
+    fallback() external payable {
+        proxyCall();
+    }
+
+    receive() external payable {
+        proxyCall();
+    }
+
+    function proxyCall() internal {
+        bytes32 position = implementationPosition;
+
+        assembly {
+            let ptr := mload(0x40)
+            calldatacopy(ptr, returndatasize(), calldatasize())
+            let result := delegatecall(gas(), sload(position), ptr, calldatasize(), returndatasize(), returndatasize())
+            returndatacopy(ptr, 0, returndatasize())
+
+            switch result
+                case 0 {
+                    revert(ptr, returndatasize())
+                }
+                default {
+                    return(ptr, returndatasize())
+                }
+        }
+    }
+}

--- a/flatten/PausedTrueGold.sol
+++ b/flatten/PausedTrueGold.sol
@@ -1,0 +1,1098 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-gold/common/ProxyStorage.sol
+
+// SPDX-License-Identifier: UNLICENSED
+// pragma solidity 0.6.10;
+
+contract ProxyStorage {
+    // Initializable.sol
+    bool _initialized;
+    bool _initializing;
+
+    // Ownable.sol
+    address _owner;
+
+    // ERC20.sol
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    uint256 _totalSupply;
+
+    // TrueMintableBurnable.sol
+    uint256 _minBurnAmount;
+    uint256 _maxBurnAmount;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 20         "trueGold.proxy.owner"                                        Proxy Owner
+     ** 28         "trueGold.pending.proxy.owner"                                Pending Proxy Owner
+     ** 29         "trueGold.proxy.implementation"                               Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   _balances
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       _allowances
+     **/
+}
+
+
+// Dependency file: contracts/true-gold/common/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable is ProxyStorage {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    // bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    // bool private _initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(_initializing || isConstructor() || !_initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+}
+
+
+// Dependency file: contracts/true-gold/interface/IOwnable.sol
+
+// pragma solidity 0.6.10;
+
+interface IOwnable {
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/true-gold/common/Ownable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/interface/IOwnable.sol";
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+// import "contracts/true-gold/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is ProxyStorage, Initializable, IOwnable {
+    // address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function __Ownable_init_unchained() internal initializer {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == msg.sender, "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual override onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/true-gold/Reclaimable.sol
+
+// pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import "contracts/true-gold/common/Ownable.sol";
+// import "contracts/true-gold/common/ProxyStorage.sol";
+// import "contracts/true-gold/interface/IOwnable.sol";
+
+contract Reclaimable is Ownable {
+    function reclaimEther(address payable to) public onlyOwner {
+        to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address to) public onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(to, balance);
+    }
+
+    function reclaimContract(IOwnable ownable) public onlyOwner {
+        ownable.transferOwnership(_owner);
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/ERC20.sol
+
+// pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+// import "@openzeppelin/contracts/utils/Address.sol";
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20MinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ProxyStorage, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    // mapping (address => uint256) private _balances;
+    // mapping (address => mapping (address => uint256)) private _allowances;
+    // uint256 private _totalSupply;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8);
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public override view returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public override view returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(msg.sender, recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public virtual override view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(msg.sender, spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/ERC20Burnable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ERC20.sol";
+
+/**
+ * @dev Extension of {ERC20} that allows token holders to destroy both their own
+ * tokens and those that they have an allowance for, in a way that can be
+ * recognized off-chain (via event analysis).
+ */
+abstract contract ERC20Burnable is ERC20 {
+    /**
+     * @dev Destroys `amount` tokens from the caller.
+     *
+     * See {ERC20-_burn}.
+     */
+    function burn(uint256 amount) public virtual {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, deducting from the caller's
+     * allowance.
+     *
+     * See {ERC20-_burn} and {ERC20-allowance}.
+     *
+     * Requirements:
+     *
+     * - the caller must have allowance for ``accounts``'s tokens of at least
+     * `amount`.
+     */
+    function burnFrom(address account, uint256 amount) public virtual {
+        uint256 decreasedAllowance = allowance(account, msg.sender).sub(amount, "ERC20Burnable: burn amount exceeds allowance");
+
+        _approve(account, msg.sender, decreasedAllowance);
+        _burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-gold/TrueMintableBurnable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ERC20Burnable.sol";
+// import "contracts/true-gold/common/Initializable.sol";
+// import "contracts/true-gold/common/Ownable.sol";
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+abstract contract TrueMintableBurnable is ProxyStorage, Initializable, Ownable, ERC20Burnable {
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    event Mint(address indexed to, uint256 value);
+    event Burn(address indexed burner, uint256 value);
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    // solhint-disable-next-line func-name-mixedcase
+    function __TrueMintableBurnable_init_unchained(uint256 minBurnAmount, uint256 maxBurnAmount) internal initializer {
+        setBurnBounds(minBurnAmount, maxBurnAmount);
+    }
+
+    function burnMin() public view returns (uint256) {
+        return _minBurnAmount;
+    }
+
+    function burnMax() public view returns (uint256) {
+        return _maxBurnAmount;
+    }
+
+    // Change the minimum and maximum amount that can be burned at once. Burning may be disabled by setting both to 0
+    // (this will not be done under normal operation, but we can't add checks to disallow it without losing a lot of
+    // flexibility since burning could also be as good as disabled by setting the minimum extremely high, and we don't
+    // want to lock in any particular cap for the minimum)
+    function setBurnBounds(uint256 minAmount, uint256 maxAmount) public virtual onlyOwner {
+        require(minAmount <= maxAmount, "TrueMintableBurnable: min is greater then max");
+        _minBurnAmount = minAmount;
+        _maxBurnAmount = maxAmount;
+        emit SetBurnBounds(minAmount, maxAmount);
+    }
+
+    function mint(address account, uint256 amount) public virtual onlyOwner {
+        require(uint256(account) > REDEMPTION_ADDRESS_COUNT, "TrueMintableBurnable: mint to a redemption or zero address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        require(super.transfer(recipient, amount));
+        if (uint256(recipient) <= REDEMPTION_ADDRESS_COUNT) {
+            _burn(recipient, amount);
+        }
+        return true;
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        require(super.transferFrom(sender, recipient, amount));
+        if (uint256(recipient) <= REDEMPTION_ADDRESS_COUNT) {
+            _burn(recipient, amount);
+        }
+        return true;
+    }
+
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= _minBurnAmount, "TrueMintableBurnable: burn amount below min bound");
+        require(amount <= _maxBurnAmount, "TrueMintableBurnable: burn amount exceeds max bound");
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-gold/TrueGold.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/Initializable.sol";
+// import "contracts/true-gold/common/Ownable.sol";
+
+// import "contracts/true-gold/Reclaimable.sol";
+// import "contracts/true-gold/TrueMintableBurnable.sol";
+
+contract TrueGold is Initializable, Ownable, TrueMintableBurnable, Reclaimable {
+    using SafeMath for uint256;
+
+    uint8 private constant DECIMALS = 6;
+    uint256 private constant BURN_AMOUNT_MULTIPLIER = 12_500_000;
+
+    function initialize(uint256 minBurnAmount, uint256 maxBurnAmount) public initializer {
+        __Ownable_init_unchained();
+        __TrueMintableBurnable_init_unchained(minBurnAmount, maxBurnAmount);
+    }
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueGold";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TGLD";
+    }
+
+    function setBurnBounds(uint256 minAmount, uint256 maxAmount) public override onlyOwner {
+        require(minAmount.mod(BURN_AMOUNT_MULTIPLIER) == 0, "TrueGold: min amount is not a multiple of 12,500,000");
+        require(maxAmount.mod(BURN_AMOUNT_MULTIPLIER) == 0, "TrueGold: max amount is not a multiple of 12,500,000");
+        super.setBurnBounds(minAmount, maxAmount);
+    }
+
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount.mod(BURN_AMOUNT_MULTIPLIER) == 0, "TrueGold: burn amount is not a multiple of 12,500,000");
+        super._burn(account, amount);
+    }
+}
+
+
+// Root file: contracts/true-gold/PausedTrueGold.sol
+
+pragma solidity 0.6.10;
+
+// import "contracts/true-gold/TrueGold.sol";
+
+contract PausedTrueGold is TrueGold {
+    function transfer(
+        address, /*recipient*/
+        uint256 /*amount*/
+    ) public override returns (bool) {
+        revert("Token Paused");
+    }
+
+    function transferFrom(
+        address, /*sender*/
+        address, /*recipient*/
+        uint256 /*amount*/
+    ) public override returns (bool) {
+        revert("Token Paused");
+    }
+
+    function burn(
+        uint256 /*amount*/
+    ) public override {
+        revert("Token Paused");
+    }
+
+    function burnFrom(
+        address, /*account*/
+        uint256 /*amount*/
+    ) public override {
+        revert("Token Paused");
+    }
+
+    function mint(
+        address, /*account*/
+        uint256 /*amount*/
+    ) public override {
+        revert("Token Paused");
+    }
+
+    function approve(
+        address, /*spender*/
+        uint256 /*amount*/
+    ) public override returns (bool) {
+        revert("Token Paused");
+    }
+
+    function increaseAllowance(
+        address, /*spender*/
+        uint256 /*addedValue*/
+    ) public override returns (bool) {
+        revert("Token Paused");
+    }
+
+    function decreaseAllowance(
+        address, /*spender*/
+        uint256 /*subtractedValue*/
+    ) public override returns (bool) {
+        revert("Token Paused");
+    }
+}

--- a/flatten/PoolArbitrageTest.sol
+++ b/flatten/PoolArbitrageTest.sol
@@ -1,0 +1,174 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueFiPool.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * TruePool is an ERC20 which represents a share of a pool
+ *
+ * This contract can be used to wrap opportunities to be compatible
+ * with TrueFi and allow users to directly opt-in through the TUSD contract
+ *
+ * Each TruePool is also a staking opportunity for TRU
+ */
+interface ITrueFiPool is IERC20 {
+    /// @dev pool token (TUSD)
+    function currencyToken() external view returns (IERC20);
+
+    /// @dev stake token (TRU)
+    function stakeToken() external view returns (IERC20);
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Mint pool tokens based on value to sender
+     */
+    function join(uint256 amount) external;
+
+    /**
+     * @dev exit pool
+     * 1. Transfer pool tokens from sender
+     * 2. Burn pool tokens
+     * 3. Transfer value of pool tokens in TUSD to sender
+     */
+    function exit(uint256 amount) external;
+
+    /**
+     * @dev borrow from pool
+     * 1. Transfer TUSD to sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function borrow(uint256 amount, uint256 amountWithoutFee) external;
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function repay(uint256 amount) external;
+}
+
+
+// Root file: contracts/truefi/mocks/PoolArbitrageTest.sol
+
+pragma solidity 0.6.10;
+
+// import {ITrueFiPool, IERC20} from "contracts/truefi/interface/ITrueFiPool.sol";
+
+contract PoolArbitrageTest {
+    function joinExit(ITrueFiPool pool) external {
+        IERC20 token = pool.currencyToken();
+        uint256 balance = token.balanceOf(address(this));
+        token.approve(address(pool), balance);
+        pool.join(balance);
+        pool.exit(pool.balanceOf(address(this)));
+    }
+}

--- a/flatten/ProvisionalRegistry.sol
+++ b/flatten/ProvisionalRegistry.sol
@@ -1,0 +1,353 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: contracts/registry/Registry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+contract Registry {
+    struct AttributeData {
+        uint256 value;
+        bytes32 notes;
+        address adminAddr;
+        uint256 timestamp;
+    }
+
+    // never remove any storage variables
+    address public owner;
+    address public pendingOwner;
+    bool initialized;
+
+    // Stores arbitrary attributes for users. An example use case is an IERC20
+    // token that requires its users to go through a KYC/AML check - in this case
+    // a validator can set an account's "hasPassedKYC/AML" attribute to 1 to indicate
+    // that account can use the token. This mapping stores that value (1, in the
+    // example) as well as which validator last set the value and at what time,
+    // so that e.g. the check can be renewed at appropriate intervals.
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
+    // The logic governing who is allowed to set what attributes is abstracted as
+    // this accessManager, so that it may be replaced by the owner as needed
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    mapping(bytes32 => RegistryClone[]) subscribers;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetManager(address indexed oldManager, address indexed newManager);
+    event StartSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+    event StopSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+
+    // Allows a write if either a) the writer is that Registry's owner, or
+    // b) the writer is writing to attribute foo and that writer already has
+    // the canWriteTo-foo attribute set (in that same Registry)
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
+        return (_admin == owner || hasAttribute(_admin, keccak256(abi.encodePacked(WRITE_PERMISSION ^ _attribute))));
+    }
+
+    // Writes are allowed only if the accessManager approves
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
+
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    function subscribe(bytes32 _attribute, RegistryClone _syncer) external onlyOwner {
+        subscribers[_attribute].push(_syncer);
+        emit StartSubscription(_attribute, _syncer);
+    }
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external onlyOwner {
+        uint256 length = subscribers[_attribute].length;
+        require(_index < length);
+        emit StopSubscription(_attribute, subscribers[_attribute][_index]);
+        subscribers[_attribute][_index] = subscribers[_attribute][length - 1];
+        subscribers[_attribute].pop();
+    }
+
+    function subscriberCount(bytes32 _attribute) public view returns (uint256) {
+        return subscribers[_attribute].length;
+    }
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, "", msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, "", msg.sender);
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    // Returns true if the uint256 value stored for this attribute is non-zero
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
+        return attributes[_who][_attribute].value != 0;
+    }
+
+    // Returns the exact value of the attribute, as well as its metadata
+    function getAttribute(address _who, bytes32 _attribute)
+        public
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        )
+    {
+        AttributeData memory data = attributes[_who][_attribute];
+        return (data.value, data.notes, data.adminAddr, data.timestamp);
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].value;
+    }
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) public view returns (address) {
+        return attributes[_who][_attribute].adminAddr;
+    }
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].timestamp;
+    }
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external {
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > _startIndex) {
+            RegistryClone target = targets[index];
+            for (uint256 i = _addresses.length; i-- > 0; ) {
+                address who = _addresses[i];
+                target.syncAttributeValue(who, _attribute, attributes[who][_attribute].value);
+            }
+        }
+    }
+
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Root file: contracts/registry/mocks/ProvisionalRegistry.sol
+
+pragma solidity 0.6.10;
+
+// import {Registry} from "contracts/registry/Registry.sol";
+
+contract ProvisionalRegistry is Registry {
+    bytes32 constant IS_BLACKLISTED = "isBlacklisted";
+    bytes32 constant IS_DEPOSIT_ADDRESS = "isDepositAddress";
+    bytes32 constant IS_REGISTERED_CONTRACT = "isRegisteredContract";
+    bytes32 constant CAN_BURN = "canBurn";
+
+    function requireCanTransfer(address _from, address _to) public view returns (address, bool) {
+        require(attributes[_from][IS_BLACKLISTED].value == 0, "blacklisted");
+        uint256 depositAddressValue = attributes[address(uint256(_to) >> 20)][IS_DEPOSIT_ADDRESS].value;
+        if (depositAddressValue != 0) {
+            _to = address(depositAddressValue);
+        }
+        require(attributes[_to][IS_BLACKLISTED].value == 0, "blacklisted");
+        return (_to, attributes[_to][IS_REGISTERED_CONTRACT].value != 0);
+    }
+
+    function requireCanTransferFrom(
+        address _sender,
+        address _from,
+        address _to
+    ) public view returns (address, bool) {
+        require(attributes[_sender][IS_BLACKLISTED].value == 0, "blacklisted");
+        return requireCanTransfer(_from, _to);
+    }
+
+    function requireCanMint(address _to) public view returns (address, bool) {
+        require(attributes[_to][IS_BLACKLISTED].value == 0, "blacklisted");
+        uint256 depositAddressValue = attributes[address(uint256(_to) >> 20)][IS_DEPOSIT_ADDRESS].value;
+        if (depositAddressValue != 0) {
+            _to = address(depositAddressValue);
+        }
+        return (_to, attributes[_to][IS_REGISTERED_CONTRACT].value != 0);
+    }
+
+    function requireCanBurn(address _from) public view {
+        require(attributes[_from][CAN_BURN].value != 0);
+        require(attributes[_from][IS_BLACKLISTED].value == 0);
+    }
+}

--- a/flatten/ProxyStorage.sol
+++ b/flatten/ProxyStorage.sol
@@ -1,0 +1,104 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Root file: contracts/true-currencies/common/ProxyStorage.sol
+
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}

--- a/flatten/Reclaimable.sol
+++ b/flatten/Reclaimable.sol
@@ -1,0 +1,307 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/true-gold/interface/IOwnable.sol
+
+// pragma solidity 0.6.10;
+
+interface IOwnable {
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/true-gold/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+contract ProxyStorage {
+    // Initializable.sol
+    bool _initialized;
+    bool _initializing;
+
+    // Ownable.sol
+    address _owner;
+
+    // ERC20.sol
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    uint256 _totalSupply;
+
+    // TrueMintableBurnable.sol
+    uint256 _minBurnAmount;
+    uint256 _maxBurnAmount;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 20         "trueGold.proxy.owner"                                        Proxy Owner
+     ** 28         "trueGold.pending.proxy.owner"                                Pending Proxy Owner
+     ** 29         "trueGold.proxy.implementation"                               Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   _balances
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       _allowances
+     **/
+}
+
+
+// Dependency file: contracts/true-gold/common/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable is ProxyStorage {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    // bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    // bool private _initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(_initializing || isConstructor() || !_initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/Ownable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/interface/IOwnable.sol";
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+// import "contracts/true-gold/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is ProxyStorage, Initializable, IOwnable {
+    // address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function __Ownable_init_unchained() internal initializer {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == msg.sender, "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual override onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Root file: contracts/true-gold/Reclaimable.sol
+
+pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import "contracts/true-gold/common/Ownable.sol";
+// import "contracts/true-gold/common/ProxyStorage.sol";
+// import "contracts/true-gold/interface/IOwnable.sol";
+
+contract Reclaimable is Ownable {
+    function reclaimEther(address payable to) public onlyOwner {
+        to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address to) public onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(to, balance);
+    }
+
+    function reclaimContract(IOwnable ownable) public onlyOwner {
+        ownable.transferOwnership(_owner);
+    }
+}

--- a/flatten/ReclaimerToken.sol
+++ b/flatten/ReclaimerToken.sol
@@ -1,0 +1,903 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Root file: contracts/true-currencies/common/ReclaimerToken.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}

--- a/flatten/Registry.sol
+++ b/flatten/Registry.sol
@@ -1,0 +1,306 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Root file: contracts/registry/Registry.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+contract Registry {
+    struct AttributeData {
+        uint256 value;
+        bytes32 notes;
+        address adminAddr;
+        uint256 timestamp;
+    }
+
+    // never remove any storage variables
+    address public owner;
+    address public pendingOwner;
+    bool initialized;
+
+    // Stores arbitrary attributes for users. An example use case is an IERC20
+    // token that requires its users to go through a KYC/AML check - in this case
+    // a validator can set an account's "hasPassedKYC/AML" attribute to 1 to indicate
+    // that account can use the token. This mapping stores that value (1, in the
+    // example) as well as which validator last set the value and at what time,
+    // so that e.g. the check can be renewed at appropriate intervals.
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
+    // The logic governing who is allowed to set what attributes is abstracted as
+    // this accessManager, so that it may be replaced by the owner as needed
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    mapping(bytes32 => RegistryClone[]) subscribers;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetManager(address indexed oldManager, address indexed newManager);
+    event StartSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+    event StopSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+
+    // Allows a write if either a) the writer is that Registry's owner, or
+    // b) the writer is writing to attribute foo and that writer already has
+    // the canWriteTo-foo attribute set (in that same Registry)
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
+        return (_admin == owner || hasAttribute(_admin, keccak256(abi.encodePacked(WRITE_PERMISSION ^ _attribute))));
+    }
+
+    // Writes are allowed only if the accessManager approves
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
+
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    function subscribe(bytes32 _attribute, RegistryClone _syncer) external onlyOwner {
+        subscribers[_attribute].push(_syncer);
+        emit StartSubscription(_attribute, _syncer);
+    }
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external onlyOwner {
+        uint256 length = subscribers[_attribute].length;
+        require(_index < length);
+        emit StopSubscription(_attribute, subscribers[_attribute][_index]);
+        subscribers[_attribute][_index] = subscribers[_attribute][length - 1];
+        subscribers[_attribute].pop();
+    }
+
+    function subscriberCount(bytes32 _attribute) public view returns (uint256) {
+        return subscribers[_attribute].length;
+    }
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, "", msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, "", msg.sender);
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    // Returns true if the uint256 value stored for this attribute is non-zero
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
+        return attributes[_who][_attribute].value != 0;
+    }
+
+    // Returns the exact value of the attribute, as well as its metadata
+    function getAttribute(address _who, bytes32 _attribute)
+        public
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        )
+    {
+        AttributeData memory data = attributes[_who][_attribute];
+        return (data.value, data.notes, data.adminAddr, data.timestamp);
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].value;
+    }
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) public view returns (address) {
+        return attributes[_who][_attribute].adminAddr;
+    }
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].timestamp;
+    }
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external {
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > _startIndex) {
+            RegistryClone target = targets[index];
+            for (uint256 i = _addresses.length; i-- > 0; ) {
+                address who = _addresses[i];
+                target.syncAttributeValue(who, _attribute, attributes[who][_attribute].value);
+            }
+        }
+    }
+
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}

--- a/flatten/RegistryMock.sol
+++ b/flatten/RegistryMock.sol
@@ -1,0 +1,383 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: contracts/registry/Registry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+contract Registry {
+    struct AttributeData {
+        uint256 value;
+        bytes32 notes;
+        address adminAddr;
+        uint256 timestamp;
+    }
+
+    // never remove any storage variables
+    address public owner;
+    address public pendingOwner;
+    bool initialized;
+
+    // Stores arbitrary attributes for users. An example use case is an IERC20
+    // token that requires its users to go through a KYC/AML check - in this case
+    // a validator can set an account's "hasPassedKYC/AML" attribute to 1 to indicate
+    // that account can use the token. This mapping stores that value (1, in the
+    // example) as well as which validator last set the value and at what time,
+    // so that e.g. the check can be renewed at appropriate intervals.
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
+    // The logic governing who is allowed to set what attributes is abstracted as
+    // this accessManager, so that it may be replaced by the owner as needed
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    mapping(bytes32 => RegistryClone[]) subscribers;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetManager(address indexed oldManager, address indexed newManager);
+    event StartSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+    event StopSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+
+    // Allows a write if either a) the writer is that Registry's owner, or
+    // b) the writer is writing to attribute foo and that writer already has
+    // the canWriteTo-foo attribute set (in that same Registry)
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
+        return (_admin == owner || hasAttribute(_admin, keccak256(abi.encodePacked(WRITE_PERMISSION ^ _attribute))));
+    }
+
+    // Writes are allowed only if the accessManager approves
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
+
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    function subscribe(bytes32 _attribute, RegistryClone _syncer) external onlyOwner {
+        subscribers[_attribute].push(_syncer);
+        emit StartSubscription(_attribute, _syncer);
+    }
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external onlyOwner {
+        uint256 length = subscribers[_attribute].length;
+        require(_index < length);
+        emit StopSubscription(_attribute, subscribers[_attribute][_index]);
+        subscribers[_attribute][_index] = subscribers[_attribute][length - 1];
+        subscribers[_attribute].pop();
+    }
+
+    function subscriberCount(bytes32 _attribute) public view returns (uint256) {
+        return subscribers[_attribute].length;
+    }
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, "", msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, "", msg.sender);
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    // Returns true if the uint256 value stored for this attribute is non-zero
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
+        return attributes[_who][_attribute].value != 0;
+    }
+
+    // Returns the exact value of the attribute, as well as its metadata
+    function getAttribute(address _who, bytes32 _attribute)
+        public
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        )
+    {
+        AttributeData memory data = attributes[_who][_attribute];
+        return (data.value, data.notes, data.adminAddr, data.timestamp);
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].value;
+    }
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) public view returns (address) {
+        return attributes[_who][_attribute].adminAddr;
+    }
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].timestamp;
+    }
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external {
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > _startIndex) {
+            RegistryClone target = targets[index];
+            for (uint256 i = _addresses.length; i-- > 0; ) {
+                address who = _addresses[i];
+                target.syncAttributeValue(who, _attribute, attributes[who][_attribute].value);
+            }
+        }
+    }
+
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/registry/mocks/ProvisionalRegistry.sol
+
+// pragma solidity 0.6.10;
+
+// import {Registry} from "contracts/registry/Registry.sol";
+
+contract ProvisionalRegistry is Registry {
+    bytes32 constant IS_BLACKLISTED = "isBlacklisted";
+    bytes32 constant IS_DEPOSIT_ADDRESS = "isDepositAddress";
+    bytes32 constant IS_REGISTERED_CONTRACT = "isRegisteredContract";
+    bytes32 constant CAN_BURN = "canBurn";
+
+    function requireCanTransfer(address _from, address _to) public view returns (address, bool) {
+        require(attributes[_from][IS_BLACKLISTED].value == 0, "blacklisted");
+        uint256 depositAddressValue = attributes[address(uint256(_to) >> 20)][IS_DEPOSIT_ADDRESS].value;
+        if (depositAddressValue != 0) {
+            _to = address(depositAddressValue);
+        }
+        require(attributes[_to][IS_BLACKLISTED].value == 0, "blacklisted");
+        return (_to, attributes[_to][IS_REGISTERED_CONTRACT].value != 0);
+    }
+
+    function requireCanTransferFrom(
+        address _sender,
+        address _from,
+        address _to
+    ) public view returns (address, bool) {
+        require(attributes[_sender][IS_BLACKLISTED].value == 0, "blacklisted");
+        return requireCanTransfer(_from, _to);
+    }
+
+    function requireCanMint(address _to) public view returns (address, bool) {
+        require(attributes[_to][IS_BLACKLISTED].value == 0, "blacklisted");
+        uint256 depositAddressValue = attributes[address(uint256(_to) >> 20)][IS_DEPOSIT_ADDRESS].value;
+        if (depositAddressValue != 0) {
+            _to = address(depositAddressValue);
+        }
+        return (_to, attributes[_to][IS_REGISTERED_CONTRACT].value != 0);
+    }
+
+    function requireCanBurn(address _from) public view {
+        require(attributes[_from][CAN_BURN].value != 0);
+        require(attributes[_from][IS_BLACKLISTED].value == 0);
+    }
+}
+
+
+// Root file: contracts/registry/mocks/RegistryMock.sol
+
+pragma solidity 0.6.10;
+
+// import {Registry} from "contracts/registry/Registry.sol";
+// import {ProvisionalRegistry} from "contracts/registry/mocks/ProvisionalRegistry.sol";
+
+contract RegistryMock is Registry {
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    function initialize() public {
+        require(!initialized, "already initialized");
+        owner = msg.sender;
+        initialized = true;
+    }
+}
+
+// solhint-disable-next-line no-empty-blocks
+contract ProvisionalRegistryMock is RegistryMock, ProvisionalRegistry {
+
+}

--- a/flatten/TimeLockRegistry.sol
+++ b/flatten/TimeLockRegistry.sol
@@ -1,0 +1,1576 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: contracts/registry/Registry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+contract Registry {
+    struct AttributeData {
+        uint256 value;
+        bytes32 notes;
+        address adminAddr;
+        uint256 timestamp;
+    }
+
+    // never remove any storage variables
+    address public owner;
+    address public pendingOwner;
+    bool initialized;
+
+    // Stores arbitrary attributes for users. An example use case is an IERC20
+    // token that requires its users to go through a KYC/AML check - in this case
+    // a validator can set an account's "hasPassedKYC/AML" attribute to 1 to indicate
+    // that account can use the token. This mapping stores that value (1, in the
+    // example) as well as which validator last set the value and at what time,
+    // so that e.g. the check can be renewed at appropriate intervals.
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
+    // The logic governing who is allowed to set what attributes is abstracted as
+    // this accessManager, so that it may be replaced by the owner as needed
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    mapping(bytes32 => RegistryClone[]) subscribers;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetManager(address indexed oldManager, address indexed newManager);
+    event StartSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+    event StopSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+
+    // Allows a write if either a) the writer is that Registry's owner, or
+    // b) the writer is writing to attribute foo and that writer already has
+    // the canWriteTo-foo attribute set (in that same Registry)
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
+        return (_admin == owner || hasAttribute(_admin, keccak256(abi.encodePacked(WRITE_PERMISSION ^ _attribute))));
+    }
+
+    // Writes are allowed only if the accessManager approves
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
+
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    function subscribe(bytes32 _attribute, RegistryClone _syncer) external onlyOwner {
+        subscribers[_attribute].push(_syncer);
+        emit StartSubscription(_attribute, _syncer);
+    }
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external onlyOwner {
+        uint256 length = subscribers[_attribute].length;
+        require(_index < length);
+        emit StopSubscription(_attribute, subscribers[_attribute][_index]);
+        subscribers[_attribute][_index] = subscribers[_attribute][length - 1];
+        subscribers[_attribute].pop();
+    }
+
+    function subscriberCount(bytes32 _attribute) public view returns (uint256) {
+        return subscribers[_attribute].length;
+    }
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, "", msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, "", msg.sender);
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    // Returns true if the uint256 value stored for this attribute is non-zero
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
+        return attributes[_who][_attribute].value != 0;
+    }
+
+    // Returns the exact value of the attribute, as well as its metadata
+    function getAttribute(address _who, bytes32 _attribute)
+        public
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        )
+    {
+        AttributeData memory data = attributes[_who][_attribute];
+        return (data.value, data.notes, data.adminAddr, data.timestamp);
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].value;
+    }
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) public view returns (address) {
+        return attributes[_who][_attribute].adminAddr;
+    }
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].timestamp;
+    }
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external {
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > _startIndex) {
+            RegistryClone target = targets[index];
+            for (uint256 i = _addresses.length; i-- > 0; ) {
+                address who = _addresses[i];
+                target.syncAttributeValue(who, _attribute, attributes[who][_attribute].value);
+            }
+        }
+    }
+
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/trusttoken/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// import {Registry} from "contracts/registry/Registry.sol";
+
+/**
+ * All storage must be declared here
+ * New storage must be appended to the end
+ * Never remove items from this list
+ */
+contract ProxyStorage {
+    bool initalized;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    mapping(uint144 => uint256) attributes; // see RegistrySubscriber
+
+    address owner_;
+    address pendingOwner_;
+
+    mapping(address => address) public delegates; // A record of votes checkpoints for each account, by index
+    struct Checkpoint {
+        // A checkpoint for marking number of votes from a given block
+        uint32 fromBlock;
+        uint96 votes;
+    }
+    mapping(address => mapping(uint32 => Checkpoint)) public checkpoints; // A record of votes checkpoints for each account, by index
+    mapping(address => uint32) public numCheckpoints; // The number of checkpoints for each account
+    mapping(address => uint256) public nonces;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(3))                attributes
+     **/
+}
+
+
+// Dependency file: contracts/trusttoken/common/ClaimableContract.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/trusttoken/common/ProxyStorage.sol";
+
+/**
+ * @title ClaimableContract
+ * @dev The ClaimableContract contract is a copy of Claimable Contract by Zeppelin.
+ and provides basic authorization control functions. Inherits storage layout of
+ ProxyStorage.
+ */
+contract ClaimableContract is ProxyStorage {
+    function owner() public view returns (address) {
+        return owner_;
+    }
+
+    function pendingOwner() public view returns (address) {
+        return pendingOwner_;
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner_ = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner_, "only owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner_);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner_ = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        address _pendingOwner = pendingOwner_;
+        emit OwnershipTransferred(owner_, _pendingOwner);
+        owner_ = _pendingOwner;
+        pendingOwner_ = address(0);
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/trusttoken/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables balances, allowances, totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ * - Remove inheritance from IERC20 because of ProxyStorage name conflicts
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ProxyStorage} from "contracts/trusttoken/common/ProxyStorage.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ProxyStorage, Context {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), allowance[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        balanceOf[sender] = balanceOf[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        balanceOf[recipient] = balanceOf[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        totalSupply = totalSupply.add(amount);
+        balanceOf[account] = balanceOf[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        balanceOf[account] = balanceOf[account].sub(amount, "ERC20: burn amount exceeds balance");
+        totalSupply = totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        allowance[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/governance/interface/IVoteToken.sol
+
+
+// pragma solidity ^0.6.10;
+
+interface IVoteToken {
+    function delegate(address delegatee) external;
+    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s) external;
+    function getCurrentVotes(address account) external view returns (uint96);
+    function getPriorVotes(address account, uint blockNumber) external view returns (uint96);
+}
+
+// Dependency file: contracts/governance/VoteToken.sol
+
+// AND COPIED FROM https://github.com/compound-finance/compound-protocol/blob/master/contracts/Governance/GovernorAlpha.sol
+// Copyright 2020 Compound Labs, Inc.
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Ctrl+f for OLD to see all the modifications.
+
+// OLD: // pragma solidity ^0.5.16;
+// pragma solidity 0.6.10;
+
+// import {ClaimableContract} from "contracts/trusttoken/common/ClaimableContract.sol";
+// import {ERC20} from "contracts/trusttoken/common/ERC20.sol";
+// import {IVoteToken} from "contracts/governance/interface/IVoteToken.sol";
+
+abstract contract VoteToken is ERC20, IVoteToken {
+    bytes32 public constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+    bytes32 public constant DELEGATION_TYPEHASH = keccak256("Delegation(address delegatee,uint256 nonce,uint256 expiry)");
+    
+    event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
+    event DelegateVotesChanged(address indexed delegate, uint previousBalance, uint newBalance);
+
+    function delegate(address delegatee) public override {
+        return _delegate(msg.sender, delegatee);
+    }
+
+    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s) public override {
+        //OLD: bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name)), getChainId(), address(this)));
+        bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH,keccak256(bytes(name())),getChainId(),address(this)));
+        bytes32 structHash = keccak256(abi.encode(DELEGATION_TYPEHASH, delegatee, nonce, expiry));
+        bytes32 digest = keccak256(abi.encodePacked("", domainSeparator, structHash));
+        address signatory = ecrecover(digest, v, r, s);
+        require(signatory != address(0), "TrustToken::delegateBySig: invalid signature");
+        require(nonce == nonces[signatory]++, "TrustToken::delegateBySig: invalid nonce");
+        require(now <= expiry, "TrustToken::delegateBySig: signature expired");
+        return _delegate(signatory, delegatee);
+    }
+
+    function getCurrentVotes(address account) external view override returns (uint96) {
+        uint32 nCheckpoints = numCheckpoints[account];
+        return nCheckpoints > 0 ? checkpoints[account][nCheckpoints - 1].votes : 0;
+    }
+
+    function getPriorVotes(address account, uint blockNumber) public view override returns (uint96) {
+        require(blockNumber < block.number, "TrustToken::getPriorVotes: not yet determined");
+
+        uint32 nCheckpoints = numCheckpoints[account];
+        if (nCheckpoints == 0) {
+            return 0;
+        }
+
+        // First check most recent balance
+        if (checkpoints[account][nCheckpoints - 1].fromBlock <= blockNumber) {
+            return checkpoints[account][nCheckpoints - 1].votes;
+        }
+
+        // Next check implicit zero balance
+        if (checkpoints[account][0].fromBlock > blockNumber) {
+            return 0;
+        }
+
+        uint32 lower = 0;
+        uint32 upper = nCheckpoints - 1;
+        while (upper > lower) {
+            uint32 center = upper - (upper - lower) / 2; // ceil, avoiding overflow
+            Checkpoint memory cp = checkpoints[account][center];
+            if (cp.fromBlock == blockNumber) {
+                return cp.votes;
+            } else if (cp.fromBlock < blockNumber) {
+                lower = center;
+            } else {
+                upper = center - 1;
+            }
+        }
+        return checkpoints[account][lower].votes;
+    }
+
+    function _delegate(address delegator, address delegatee) internal {
+        address currentDelegate = delegates[delegator];
+        // OLD: uint96 delegatorBalance = balanceOf(delegator);
+        uint96 delegatorBalance = uint96(_balanceOf(delegator));
+        delegates[delegator] = delegatee;
+
+        emit DelegateChanged(delegator, currentDelegate, delegatee);
+
+        _moveDelegates(currentDelegate, delegatee, delegatorBalance);
+    }
+
+    function _balanceOf(address account) internal virtual returns(uint256) {
+        return balanceOf[account];
+    }
+
+    function _transfer( address _from, address _to, uint256 _value) internal override virtual {
+        super._transfer(_from, _to, _value);
+        _moveDelegates(delegates[_from], delegates[_to], uint96(_value));
+    }
+
+    function _moveDelegates(address srcRep, address dstRep, uint96 amount) internal {
+        if (srcRep != dstRep && amount > 0) {
+            if (srcRep != address(0)) {
+                uint32 srcRepNum = numCheckpoints[srcRep];
+                uint96 srcRepOld = srcRepNum > 0 ? checkpoints[srcRep][srcRepNum - 1].votes : 0;
+                uint96 srcRepNew = sub96(srcRepOld, amount, "TrustToken::_moveVotes: vote amount underflows");
+                _writeCheckpoint(srcRep, srcRepNum, srcRepOld, srcRepNew);
+            }
+
+            if (dstRep != address(0)) {
+                uint32 dstRepNum = numCheckpoints[dstRep];
+                uint96 dstRepOld = dstRepNum > 0 ? checkpoints[dstRep][dstRepNum - 1].votes : 0;
+                uint96 dstRepNew = add96(dstRepOld, amount, "TrustToken::_moveVotes: vote amount overflows");
+                _writeCheckpoint(dstRep, dstRepNum, dstRepOld, dstRepNew);
+            }
+        }
+    }
+
+    function _writeCheckpoint(address delegatee, uint32 nCheckpoints, uint96 oldVotes, uint96 newVotes) internal {
+        uint32 blockNumber = safe32(block.number, "TrustToken::_writeCheckpoint: block number exceeds 32 bits");
+
+        if (nCheckpoints > 0 && checkpoints[delegatee][nCheckpoints - 1].fromBlock == blockNumber) {
+            checkpoints[delegatee][nCheckpoints - 1].votes = newVotes;
+        } else {
+            checkpoints[delegatee][nCheckpoints] = Checkpoint(blockNumber, newVotes);
+            numCheckpoints[delegatee] = nCheckpoints + 1;
+        }
+
+        emit DelegateVotesChanged(delegatee, oldVotes, newVotes);
+    }
+
+    function safe32(uint n, string memory errorMessage) internal pure returns (uint32) {
+        require(n < 2**32, errorMessage);
+        return uint32(n);
+    }
+
+    function safe96(uint n, string memory errorMessage) internal pure returns (uint96) {
+        require(n < 2**96, errorMessage);
+        return uint96(n);
+    }
+
+    function add96(uint96 a, uint96 b, string memory errorMessage) internal pure returns (uint96) {
+        uint96 c = a + b;
+        require(c >= a, errorMessage);
+        return c;
+    }
+
+    function sub96(uint96 a, uint96 b, string memory errorMessage) internal pure returns (uint96) {
+        require(b <= a, errorMessage);
+        return a - b;
+    }
+
+    function getChainId() internal pure returns (uint) {
+        uint256 chainId;
+        assembly { chainId := chainid() }
+        return chainId;
+    }
+}
+
+
+
+
+// Dependency file: contracts/trusttoken/TimeLockedToken.sol
+
+// pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {VoteToken} from "contracts/governance/VoteToken.sol";
+// import {ClaimableContract} from "contracts/trusttoken/common/ClaimableContract.sol";
+
+/**
+ * @title TimeLockedToken
+ * @notice Time Locked ERC20 Token
+ * @author Harold Hyatt
+ * @dev Contract which gives the ability to time-lock tokens
+ *
+ * The registerLockup() function allows an account to transfer
+ * its tokens to another account, locking them according to the
+ * distribution epoch periods
+ *
+ * By overriding the balanceOf(), transfer(), and transferFrom()
+ * functions in ERC20, an account can show its full, post-distribution
+ * balance but only transfer or spend up to an allowed amount
+ *
+ * Every time an epoch passes, a portion of previously non-spendable tokens
+ * are allowed to be transferred, and after all epochs have passed, the full
+ * account balance is unlocked
+ */
+abstract contract TimeLockedToken is VoteToken, ClaimableContract {
+    using SafeMath for uint256;
+
+    // represents total distribution for locked balances
+    mapping(address => uint256) distribution;
+
+    // start of the lockup period
+    // Friday, July 24, 2020 4:58:31 PM GMT
+    uint256 constant LOCK_START = 1595609911;
+    // length of time to delay first epoch
+    uint256 constant FIRST_EPOCH_DELAY = 30 days;
+    // how long does an epoch last
+    uint256 constant EPOCH_DURATION = 90 days;
+    // number of epochs
+    uint256 constant TOTAL_EPOCHS = 8;
+    // registry of locked addresses
+    address public timeLockRegistry;
+    // allow unlocked transfers to special account
+    bool public returnsLocked;
+
+    modifier onlyTimeLockRegistry() {
+        require(msg.sender == timeLockRegistry, "only TimeLockRegistry");
+        _;
+    }
+
+    /**
+     * @dev Set TimeLockRegistry address
+     * @param newTimeLockRegistry Address of TimeLockRegistry contract
+     */
+    function setTimeLockRegistry(address newTimeLockRegistry) external onlyOwner {
+        require(newTimeLockRegistry != address(0), "cannot be zero address");
+        require(newTimeLockRegistry != timeLockRegistry, "must be new TimeLockRegistry");
+        timeLockRegistry = newTimeLockRegistry;
+    }
+
+    /**
+     * @dev Permanently lock transfers to return address
+     * Lock returns so there isn't always a way to send locked tokens
+     */
+    function lockReturns() external onlyOwner {
+        returnsLocked = true;
+    }
+
+    /**
+     * @dev Transfer function which includes unlocked tokens
+     * Locked tokens can always be transfered back to the returns address
+     * Transferring to owner allows re-issuance of funds through registry
+     *
+     * @param _from The address to send tokens from
+     * @param _to The address that will receive the tokens
+     * @param _value The amount of tokens to be transferred
+     */
+    function _transfer(
+        address _from,
+        address _to,
+        uint256 _value
+    ) internal virtual override {
+        require(balanceOf[_from] >= _value, "insufficient balance");
+
+        // transfers to owner proceed as normal when returns allowed
+        if (!returnsLocked && _to == owner_) {
+            transferToOwner(_from, _value);
+            return;
+        }
+        // check if enough unlocked balance to transfer
+        require(unlockedBalance(_from) >= _value, "attempting to transfer locked funds");
+        super._transfer(_from, _to, _value);
+    }
+
+    /**
+     * @dev Transfer tokens to owner. Used only when returns allowed.
+     * @param _from The address to send tokens from
+     * @param _value The amount of tokens to be transferred
+     */
+    function transferToOwner(address _from, uint256 _value) internal {
+        uint256 unlocked = unlockedBalance(_from);
+
+        if (unlocked < _value) {
+            // We want to have unlocked = value, i.e.
+            // value = balance - distribution * epochsLeft / totalEpochs
+            // distribution = (balance - value) * totalEpochs / epochsLeft
+            distribution[_from] = balanceOf[_from].sub(_value).mul(TOTAL_EPOCHS).div(epochsLeft());
+        }
+        super._transfer(_from, owner_, _value);
+    }
+
+    /**
+     * @dev Check if amount we want to burn is unlocked before burning
+     * @param _from The address whose tokens will burn
+     * @param _value The amount of tokens to be burnt
+     */
+    function _burn(address _from, uint256 _value) internal override {
+        require(balanceOf[_from] >= _value, "insufficient balance");
+        require(unlockedBalance(_from) >= _value, "attempting to burn locked funds");
+
+        super._burn(_from, _value);
+    }
+
+    /**
+     * @dev Transfer tokens to another account under the lockup schedule
+     * Emits a transfer event showing a transfer to the recipient
+     * Only the registry can call this function
+     * @param receiver Address to receive the tokens
+     * @param amount Tokens to be transferred
+     */
+    function registerLockup(address receiver, uint256 amount) external onlyTimeLockRegistry {
+        require(balanceOf[msg.sender] >= amount, "insufficient balance");
+
+        // add amount to locked distribution
+        distribution[receiver] = distribution[receiver].add(amount);
+
+        // transfer to recipient
+        _transfer(msg.sender, receiver, amount);
+    }
+
+    /**
+     * @dev Get locked balance for an account
+     * @param account Account to check
+     * @return Amount locked
+     */
+    function lockedBalance(address account) public view returns (uint256) {
+        // distribution * (epochsLeft / totalEpochs)
+        return distribution[account].mul(epochsLeft()).div(TOTAL_EPOCHS);
+    }
+
+    /**
+     * @dev Get unlocked balance for an account
+     * @param account Account to check
+     * @return Amount that is unlocked and available eg. to transfer
+     */
+    function unlockedBalance(address account) public view returns (uint256) {
+        // totalBalance - lockedBalance
+        return balanceOf[account].sub(lockedBalance(account));
+    }
+
+    function _balanceOf(address account) internal override returns (uint256) {
+        return unlockedBalance(account);
+    }
+
+    /*
+     * @dev Get number of epochs passed
+     * @return Value between 0 and 8 of lockup epochs already passed
+     */
+    function epochsPassed() public view returns (uint256) {
+        // return 0 if timestamp is lower than start time
+        if (block.timestamp < LOCK_START) {
+            return 0;
+        }
+
+        // how long it has been since the beginning of lockup period
+        uint256 timePassed = block.timestamp.sub(LOCK_START);
+
+        // 1st epoch is FIRST_EPOCH_DELAY longer; we check to prevent subtraction underflow
+        if (timePassed < FIRST_EPOCH_DELAY) {
+            return 0;
+        }
+
+        // subtract the FIRST_EPOCH_DELAY, so that we can count all epochs as lasting EPOCH_DURATION
+        uint256 totalEpochsPassed = timePassed.sub(FIRST_EPOCH_DELAY).div(EPOCH_DURATION);
+
+        // epochs don't count over TOTAL_EPOCHS
+        if (totalEpochsPassed > TOTAL_EPOCHS) {
+            return TOTAL_EPOCHS;
+        }
+
+        return totalEpochsPassed;
+    }
+
+    function epochsLeft() public view returns (uint256) {
+        return TOTAL_EPOCHS.sub(epochsPassed());
+    }
+
+    /**
+     * @dev Get timestamp of next epoch
+     * Will revert if all epochs have passed
+     * @return Timestamp of when the next epoch starts
+     */
+    function nextEpoch() public view returns (uint256) {
+        // get number of epochs passed
+        uint256 passed = epochsPassed();
+
+        // if all epochs passed, return
+        if (passed == TOTAL_EPOCHS) {
+            // return INT_MAX
+            return uint256(-1);
+        }
+
+        // if no epochs passed, return latest epoch + delay + standard duration
+        if (passed == 0) {
+            return latestEpoch().add(FIRST_EPOCH_DELAY).add(EPOCH_DURATION);
+        }
+
+        // otherwise return latest epoch + epoch duration
+        return latestEpoch().add(EPOCH_DURATION);
+    }
+
+    /**
+     * @dev Get timestamp of latest epoch
+     * @return Timestamp of when the current epoch has started
+     */
+    function latestEpoch() public view returns (uint256) {
+        // get number of epochs passed
+        uint256 passed = epochsPassed();
+
+        // if no epochs passed, return lock start time
+        if (passed == 0) {
+            return LOCK_START;
+        }
+
+        // accounts for first epoch being longer
+        // lockStart + firstEpochDelay + (epochsPassed * epochDuration)
+        return LOCK_START.add(FIRST_EPOCH_DELAY).add(passed.mul(EPOCH_DURATION));
+    }
+
+    /**
+     * @dev Get timestamp of final epoch
+     * @return Timestamp of when the last epoch ends and all funds are released
+     */
+    function finalEpoch() public pure returns (uint256) {
+        // lockStart + firstEpochDelay + (epochDuration * totalEpochs)
+        return LOCK_START.add(FIRST_EPOCH_DELAY).add(EPOCH_DURATION.mul(TOTAL_EPOCHS));
+    }
+
+    /**
+     * @dev Get timestamp of locking period start
+     * @return Timestamp of locking period start
+     */
+    function lockStart() public pure returns (uint256) {
+        return LOCK_START;
+    }
+}
+
+
+// Root file: contracts/trusttoken/TimeLockRegistry.sol
+
+pragma solidity 0.6.10;
+
+// import {ClaimableContract} from "contracts/trusttoken/common/ClaimableContract.sol";
+
+// import {TimeLockedToken} from "contracts/trusttoken/TimeLockedToken.sol";
+
+/**
+ * @title TimeLockRegistry
+ * @notice Register Lockups for TimeLocked ERC20 Token
+ * @author Harold Hyatt
+ * @dev This contract allows owner to register distributions for a TimeLockedToken
+ *
+ * To register a distribution, register method should be called by the owner.
+ * claim() should then be called by account registered to recieve tokens under lockup period
+ * If case of a mistake, owner can cancel registration
+ *
+ * Note this contract must be setup in TimeLockedToken's setTimeLockRegistry() function
+ */
+contract TimeLockRegistry is ClaimableContract {
+    // time locked token
+    TimeLockedToken public token;
+
+    // mapping from SAFT address to TRU due amount
+    mapping(address => uint256) public registeredDistributions;
+
+    event Register(address receiver, uint256 distribution);
+    event Cancel(address receiver, uint256 distribution);
+    event Claim(address account, uint256 distribution);
+
+    /**
+     * @dev Initalize function so this contract can be behind a proxy
+     * @param _token TimeLockedToken contract to use in this registry
+     */
+    function initialize(TimeLockedToken _token) external {
+        require(!initalized, "Already initialized");
+        token = _token;
+        owner_ = msg.sender;
+        initalized = true;
+    }
+
+    /**
+     * @dev Register new SAFT account
+     * @param receiver Address belonging to SAFT purchaser
+     * @param distribution Tokens amount that receiver is due to get
+     */
+    function register(address receiver, uint256 distribution) external onlyOwner {
+        require(receiver != address(0), "Zero address");
+        require(distribution != 0, "Distribution = 0");
+        require(registeredDistributions[receiver] == 0, "Distribution for this address is already registered");
+
+        // register distribution in mapping
+        registeredDistributions[receiver] = distribution;
+
+        // transfer tokens from owner
+        require(token.transferFrom(msg.sender, address(this), distribution), "Transfer failed");
+
+        // emit register event
+        emit Register(receiver, distribution);
+    }
+
+    /**
+     * @dev Cancel distribution registration
+     * @param receiver Address that should have it's distribution removed
+     */
+    function cancel(address receiver) external onlyOwner {
+        require(registeredDistributions[receiver] != 0, "Not registered");
+
+        // get amount from distributions
+        uint256 amount = registeredDistributions[receiver];
+
+        // set distribution mapping to 0
+        delete registeredDistributions[receiver];
+
+        // transfer tokens back to owner
+        require(token.transfer(msg.sender, amount), "Transfer failed");
+
+        // emit cancel event
+        emit Cancel(receiver, amount);
+    }
+
+    /// @dev Claim tokens due amount
+    function claim() external {
+        require(registeredDistributions[msg.sender] != 0, "Not registered");
+
+        // get amount from distributions
+        uint256 amount = registeredDistributions[msg.sender];
+
+        // set distribution mapping to 0
+        delete registeredDistributions[msg.sender];
+
+        // register lockup in TimeLockedToken
+        // this will transfer funds from this contract and lock them for sender
+        token.registerLockup(msg.sender, amount);
+
+        // emit claim event
+        emit Claim(msg.sender, amount);
+    }
+}

--- a/flatten/TimeLockedToken.sol
+++ b/flatten/TimeLockedToken.sol
@@ -1,0 +1,1474 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: contracts/registry/Registry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+contract Registry {
+    struct AttributeData {
+        uint256 value;
+        bytes32 notes;
+        address adminAddr;
+        uint256 timestamp;
+    }
+
+    // never remove any storage variables
+    address public owner;
+    address public pendingOwner;
+    bool initialized;
+
+    // Stores arbitrary attributes for users. An example use case is an IERC20
+    // token that requires its users to go through a KYC/AML check - in this case
+    // a validator can set an account's "hasPassedKYC/AML" attribute to 1 to indicate
+    // that account can use the token. This mapping stores that value (1, in the
+    // example) as well as which validator last set the value and at what time,
+    // so that e.g. the check can be renewed at appropriate intervals.
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
+    // The logic governing who is allowed to set what attributes is abstracted as
+    // this accessManager, so that it may be replaced by the owner as needed
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    mapping(bytes32 => RegistryClone[]) subscribers;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetManager(address indexed oldManager, address indexed newManager);
+    event StartSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+    event StopSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+
+    // Allows a write if either a) the writer is that Registry's owner, or
+    // b) the writer is writing to attribute foo and that writer already has
+    // the canWriteTo-foo attribute set (in that same Registry)
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
+        return (_admin == owner || hasAttribute(_admin, keccak256(abi.encodePacked(WRITE_PERMISSION ^ _attribute))));
+    }
+
+    // Writes are allowed only if the accessManager approves
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
+
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    function subscribe(bytes32 _attribute, RegistryClone _syncer) external onlyOwner {
+        subscribers[_attribute].push(_syncer);
+        emit StartSubscription(_attribute, _syncer);
+    }
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external onlyOwner {
+        uint256 length = subscribers[_attribute].length;
+        require(_index < length);
+        emit StopSubscription(_attribute, subscribers[_attribute][_index]);
+        subscribers[_attribute][_index] = subscribers[_attribute][length - 1];
+        subscribers[_attribute].pop();
+    }
+
+    function subscriberCount(bytes32 _attribute) public view returns (uint256) {
+        return subscribers[_attribute].length;
+    }
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, "", msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, "", msg.sender);
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    // Returns true if the uint256 value stored for this attribute is non-zero
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
+        return attributes[_who][_attribute].value != 0;
+    }
+
+    // Returns the exact value of the attribute, as well as its metadata
+    function getAttribute(address _who, bytes32 _attribute)
+        public
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        )
+    {
+        AttributeData memory data = attributes[_who][_attribute];
+        return (data.value, data.notes, data.adminAddr, data.timestamp);
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].value;
+    }
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) public view returns (address) {
+        return attributes[_who][_attribute].adminAddr;
+    }
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].timestamp;
+    }
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external {
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > _startIndex) {
+            RegistryClone target = targets[index];
+            for (uint256 i = _addresses.length; i-- > 0; ) {
+                address who = _addresses[i];
+                target.syncAttributeValue(who, _attribute, attributes[who][_attribute].value);
+            }
+        }
+    }
+
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/trusttoken/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// import {Registry} from "contracts/registry/Registry.sol";
+
+/**
+ * All storage must be declared here
+ * New storage must be appended to the end
+ * Never remove items from this list
+ */
+contract ProxyStorage {
+    bool initalized;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    mapping(uint144 => uint256) attributes; // see RegistrySubscriber
+
+    address owner_;
+    address pendingOwner_;
+
+    mapping(address => address) public delegates; // A record of votes checkpoints for each account, by index
+    struct Checkpoint {
+        // A checkpoint for marking number of votes from a given block
+        uint32 fromBlock;
+        uint96 votes;
+    }
+    mapping(address => mapping(uint32 => Checkpoint)) public checkpoints; // A record of votes checkpoints for each account, by index
+    mapping(address => uint32) public numCheckpoints; // The number of checkpoints for each account
+    mapping(address => uint256) public nonces;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(3))                attributes
+     **/
+}
+
+
+// Dependency file: contracts/trusttoken/common/ClaimableContract.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/trusttoken/common/ProxyStorage.sol";
+
+/**
+ * @title ClaimableContract
+ * @dev The ClaimableContract contract is a copy of Claimable Contract by Zeppelin.
+ and provides basic authorization control functions. Inherits storage layout of
+ ProxyStorage.
+ */
+contract ClaimableContract is ProxyStorage {
+    function owner() public view returns (address) {
+        return owner_;
+    }
+
+    function pendingOwner() public view returns (address) {
+        return pendingOwner_;
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner_ = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner_, "only owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner_);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner_ = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        address _pendingOwner = pendingOwner_;
+        emit OwnershipTransferred(owner_, _pendingOwner);
+        owner_ = _pendingOwner;
+        pendingOwner_ = address(0);
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/trusttoken/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables balances, allowances, totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ * - Remove inheritance from IERC20 because of ProxyStorage name conflicts
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ProxyStorage} from "contracts/trusttoken/common/ProxyStorage.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ProxyStorage, Context {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), allowance[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        balanceOf[sender] = balanceOf[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        balanceOf[recipient] = balanceOf[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        totalSupply = totalSupply.add(amount);
+        balanceOf[account] = balanceOf[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        balanceOf[account] = balanceOf[account].sub(amount, "ERC20: burn amount exceeds balance");
+        totalSupply = totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        allowance[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/governance/interface/IVoteToken.sol
+
+
+// pragma solidity ^0.6.10;
+
+interface IVoteToken {
+    function delegate(address delegatee) external;
+    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s) external;
+    function getCurrentVotes(address account) external view returns (uint96);
+    function getPriorVotes(address account, uint blockNumber) external view returns (uint96);
+}
+
+// Dependency file: contracts/governance/VoteToken.sol
+
+// AND COPIED FROM https://github.com/compound-finance/compound-protocol/blob/master/contracts/Governance/GovernorAlpha.sol
+// Copyright 2020 Compound Labs, Inc.
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Ctrl+f for OLD to see all the modifications.
+
+// OLD: // pragma solidity ^0.5.16;
+// pragma solidity 0.6.10;
+
+// import {ClaimableContract} from "contracts/trusttoken/common/ClaimableContract.sol";
+// import {ERC20} from "contracts/trusttoken/common/ERC20.sol";
+// import {IVoteToken} from "contracts/governance/interface/IVoteToken.sol";
+
+abstract contract VoteToken is ERC20, IVoteToken {
+    bytes32 public constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+    bytes32 public constant DELEGATION_TYPEHASH = keccak256("Delegation(address delegatee,uint256 nonce,uint256 expiry)");
+    
+    event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
+    event DelegateVotesChanged(address indexed delegate, uint previousBalance, uint newBalance);
+
+    function delegate(address delegatee) public override {
+        return _delegate(msg.sender, delegatee);
+    }
+
+    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s) public override {
+        //OLD: bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name)), getChainId(), address(this)));
+        bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH,keccak256(bytes(name())),getChainId(),address(this)));
+        bytes32 structHash = keccak256(abi.encode(DELEGATION_TYPEHASH, delegatee, nonce, expiry));
+        bytes32 digest = keccak256(abi.encodePacked("", domainSeparator, structHash));
+        address signatory = ecrecover(digest, v, r, s);
+        require(signatory != address(0), "TrustToken::delegateBySig: invalid signature");
+        require(nonce == nonces[signatory]++, "TrustToken::delegateBySig: invalid nonce");
+        require(now <= expiry, "TrustToken::delegateBySig: signature expired");
+        return _delegate(signatory, delegatee);
+    }
+
+    function getCurrentVotes(address account) external view override returns (uint96) {
+        uint32 nCheckpoints = numCheckpoints[account];
+        return nCheckpoints > 0 ? checkpoints[account][nCheckpoints - 1].votes : 0;
+    }
+
+    function getPriorVotes(address account, uint blockNumber) public view override returns (uint96) {
+        require(blockNumber < block.number, "TrustToken::getPriorVotes: not yet determined");
+
+        uint32 nCheckpoints = numCheckpoints[account];
+        if (nCheckpoints == 0) {
+            return 0;
+        }
+
+        // First check most recent balance
+        if (checkpoints[account][nCheckpoints - 1].fromBlock <= blockNumber) {
+            return checkpoints[account][nCheckpoints - 1].votes;
+        }
+
+        // Next check implicit zero balance
+        if (checkpoints[account][0].fromBlock > blockNumber) {
+            return 0;
+        }
+
+        uint32 lower = 0;
+        uint32 upper = nCheckpoints - 1;
+        while (upper > lower) {
+            uint32 center = upper - (upper - lower) / 2; // ceil, avoiding overflow
+            Checkpoint memory cp = checkpoints[account][center];
+            if (cp.fromBlock == blockNumber) {
+                return cp.votes;
+            } else if (cp.fromBlock < blockNumber) {
+                lower = center;
+            } else {
+                upper = center - 1;
+            }
+        }
+        return checkpoints[account][lower].votes;
+    }
+
+    function _delegate(address delegator, address delegatee) internal {
+        address currentDelegate = delegates[delegator];
+        // OLD: uint96 delegatorBalance = balanceOf(delegator);
+        uint96 delegatorBalance = uint96(_balanceOf(delegator));
+        delegates[delegator] = delegatee;
+
+        emit DelegateChanged(delegator, currentDelegate, delegatee);
+
+        _moveDelegates(currentDelegate, delegatee, delegatorBalance);
+    }
+
+    function _balanceOf(address account) internal virtual returns(uint256) {
+        return balanceOf[account];
+    }
+
+    function _transfer( address _from, address _to, uint256 _value) internal override virtual {
+        super._transfer(_from, _to, _value);
+        _moveDelegates(delegates[_from], delegates[_to], uint96(_value));
+    }
+
+    function _moveDelegates(address srcRep, address dstRep, uint96 amount) internal {
+        if (srcRep != dstRep && amount > 0) {
+            if (srcRep != address(0)) {
+                uint32 srcRepNum = numCheckpoints[srcRep];
+                uint96 srcRepOld = srcRepNum > 0 ? checkpoints[srcRep][srcRepNum - 1].votes : 0;
+                uint96 srcRepNew = sub96(srcRepOld, amount, "TrustToken::_moveVotes: vote amount underflows");
+                _writeCheckpoint(srcRep, srcRepNum, srcRepOld, srcRepNew);
+            }
+
+            if (dstRep != address(0)) {
+                uint32 dstRepNum = numCheckpoints[dstRep];
+                uint96 dstRepOld = dstRepNum > 0 ? checkpoints[dstRep][dstRepNum - 1].votes : 0;
+                uint96 dstRepNew = add96(dstRepOld, amount, "TrustToken::_moveVotes: vote amount overflows");
+                _writeCheckpoint(dstRep, dstRepNum, dstRepOld, dstRepNew);
+            }
+        }
+    }
+
+    function _writeCheckpoint(address delegatee, uint32 nCheckpoints, uint96 oldVotes, uint96 newVotes) internal {
+        uint32 blockNumber = safe32(block.number, "TrustToken::_writeCheckpoint: block number exceeds 32 bits");
+
+        if (nCheckpoints > 0 && checkpoints[delegatee][nCheckpoints - 1].fromBlock == blockNumber) {
+            checkpoints[delegatee][nCheckpoints - 1].votes = newVotes;
+        } else {
+            checkpoints[delegatee][nCheckpoints] = Checkpoint(blockNumber, newVotes);
+            numCheckpoints[delegatee] = nCheckpoints + 1;
+        }
+
+        emit DelegateVotesChanged(delegatee, oldVotes, newVotes);
+    }
+
+    function safe32(uint n, string memory errorMessage) internal pure returns (uint32) {
+        require(n < 2**32, errorMessage);
+        return uint32(n);
+    }
+
+    function safe96(uint n, string memory errorMessage) internal pure returns (uint96) {
+        require(n < 2**96, errorMessage);
+        return uint96(n);
+    }
+
+    function add96(uint96 a, uint96 b, string memory errorMessage) internal pure returns (uint96) {
+        uint96 c = a + b;
+        require(c >= a, errorMessage);
+        return c;
+    }
+
+    function sub96(uint96 a, uint96 b, string memory errorMessage) internal pure returns (uint96) {
+        require(b <= a, errorMessage);
+        return a - b;
+    }
+
+    function getChainId() internal pure returns (uint) {
+        uint256 chainId;
+        assembly { chainId := chainid() }
+        return chainId;
+    }
+}
+
+
+
+
+// Root file: contracts/trusttoken/TimeLockedToken.sol
+
+pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {VoteToken} from "contracts/governance/VoteToken.sol";
+// import {ClaimableContract} from "contracts/trusttoken/common/ClaimableContract.sol";
+
+/**
+ * @title TimeLockedToken
+ * @notice Time Locked ERC20 Token
+ * @author Harold Hyatt
+ * @dev Contract which gives the ability to time-lock tokens
+ *
+ * The registerLockup() function allows an account to transfer
+ * its tokens to another account, locking them according to the
+ * distribution epoch periods
+ *
+ * By overriding the balanceOf(), transfer(), and transferFrom()
+ * functions in ERC20, an account can show its full, post-distribution
+ * balance but only transfer or spend up to an allowed amount
+ *
+ * Every time an epoch passes, a portion of previously non-spendable tokens
+ * are allowed to be transferred, and after all epochs have passed, the full
+ * account balance is unlocked
+ */
+abstract contract TimeLockedToken is VoteToken, ClaimableContract {
+    using SafeMath for uint256;
+
+    // represents total distribution for locked balances
+    mapping(address => uint256) distribution;
+
+    // start of the lockup period
+    // Friday, July 24, 2020 4:58:31 PM GMT
+    uint256 constant LOCK_START = 1595609911;
+    // length of time to delay first epoch
+    uint256 constant FIRST_EPOCH_DELAY = 30 days;
+    // how long does an epoch last
+    uint256 constant EPOCH_DURATION = 90 days;
+    // number of epochs
+    uint256 constant TOTAL_EPOCHS = 8;
+    // registry of locked addresses
+    address public timeLockRegistry;
+    // allow unlocked transfers to special account
+    bool public returnsLocked;
+
+    modifier onlyTimeLockRegistry() {
+        require(msg.sender == timeLockRegistry, "only TimeLockRegistry");
+        _;
+    }
+
+    /**
+     * @dev Set TimeLockRegistry address
+     * @param newTimeLockRegistry Address of TimeLockRegistry contract
+     */
+    function setTimeLockRegistry(address newTimeLockRegistry) external onlyOwner {
+        require(newTimeLockRegistry != address(0), "cannot be zero address");
+        require(newTimeLockRegistry != timeLockRegistry, "must be new TimeLockRegistry");
+        timeLockRegistry = newTimeLockRegistry;
+    }
+
+    /**
+     * @dev Permanently lock transfers to return address
+     * Lock returns so there isn't always a way to send locked tokens
+     */
+    function lockReturns() external onlyOwner {
+        returnsLocked = true;
+    }
+
+    /**
+     * @dev Transfer function which includes unlocked tokens
+     * Locked tokens can always be transfered back to the returns address
+     * Transferring to owner allows re-issuance of funds through registry
+     *
+     * @param _from The address to send tokens from
+     * @param _to The address that will receive the tokens
+     * @param _value The amount of tokens to be transferred
+     */
+    function _transfer(
+        address _from,
+        address _to,
+        uint256 _value
+    ) internal virtual override {
+        require(balanceOf[_from] >= _value, "insufficient balance");
+
+        // transfers to owner proceed as normal when returns allowed
+        if (!returnsLocked && _to == owner_) {
+            transferToOwner(_from, _value);
+            return;
+        }
+        // check if enough unlocked balance to transfer
+        require(unlockedBalance(_from) >= _value, "attempting to transfer locked funds");
+        super._transfer(_from, _to, _value);
+    }
+
+    /**
+     * @dev Transfer tokens to owner. Used only when returns allowed.
+     * @param _from The address to send tokens from
+     * @param _value The amount of tokens to be transferred
+     */
+    function transferToOwner(address _from, uint256 _value) internal {
+        uint256 unlocked = unlockedBalance(_from);
+
+        if (unlocked < _value) {
+            // We want to have unlocked = value, i.e.
+            // value = balance - distribution * epochsLeft / totalEpochs
+            // distribution = (balance - value) * totalEpochs / epochsLeft
+            distribution[_from] = balanceOf[_from].sub(_value).mul(TOTAL_EPOCHS).div(epochsLeft());
+        }
+        super._transfer(_from, owner_, _value);
+    }
+
+    /**
+     * @dev Check if amount we want to burn is unlocked before burning
+     * @param _from The address whose tokens will burn
+     * @param _value The amount of tokens to be burnt
+     */
+    function _burn(address _from, uint256 _value) internal override {
+        require(balanceOf[_from] >= _value, "insufficient balance");
+        require(unlockedBalance(_from) >= _value, "attempting to burn locked funds");
+
+        super._burn(_from, _value);
+    }
+
+    /**
+     * @dev Transfer tokens to another account under the lockup schedule
+     * Emits a transfer event showing a transfer to the recipient
+     * Only the registry can call this function
+     * @param receiver Address to receive the tokens
+     * @param amount Tokens to be transferred
+     */
+    function registerLockup(address receiver, uint256 amount) external onlyTimeLockRegistry {
+        require(balanceOf[msg.sender] >= amount, "insufficient balance");
+
+        // add amount to locked distribution
+        distribution[receiver] = distribution[receiver].add(amount);
+
+        // transfer to recipient
+        _transfer(msg.sender, receiver, amount);
+    }
+
+    /**
+     * @dev Get locked balance for an account
+     * @param account Account to check
+     * @return Amount locked
+     */
+    function lockedBalance(address account) public view returns (uint256) {
+        // distribution * (epochsLeft / totalEpochs)
+        return distribution[account].mul(epochsLeft()).div(TOTAL_EPOCHS);
+    }
+
+    /**
+     * @dev Get unlocked balance for an account
+     * @param account Account to check
+     * @return Amount that is unlocked and available eg. to transfer
+     */
+    function unlockedBalance(address account) public view returns (uint256) {
+        // totalBalance - lockedBalance
+        return balanceOf[account].sub(lockedBalance(account));
+    }
+
+    function _balanceOf(address account) internal override returns (uint256) {
+        return unlockedBalance(account);
+    }
+
+    /*
+     * @dev Get number of epochs passed
+     * @return Value between 0 and 8 of lockup epochs already passed
+     */
+    function epochsPassed() public view returns (uint256) {
+        // return 0 if timestamp is lower than start time
+        if (block.timestamp < LOCK_START) {
+            return 0;
+        }
+
+        // how long it has been since the beginning of lockup period
+        uint256 timePassed = block.timestamp.sub(LOCK_START);
+
+        // 1st epoch is FIRST_EPOCH_DELAY longer; we check to prevent subtraction underflow
+        if (timePassed < FIRST_EPOCH_DELAY) {
+            return 0;
+        }
+
+        // subtract the FIRST_EPOCH_DELAY, so that we can count all epochs as lasting EPOCH_DURATION
+        uint256 totalEpochsPassed = timePassed.sub(FIRST_EPOCH_DELAY).div(EPOCH_DURATION);
+
+        // epochs don't count over TOTAL_EPOCHS
+        if (totalEpochsPassed > TOTAL_EPOCHS) {
+            return TOTAL_EPOCHS;
+        }
+
+        return totalEpochsPassed;
+    }
+
+    function epochsLeft() public view returns (uint256) {
+        return TOTAL_EPOCHS.sub(epochsPassed());
+    }
+
+    /**
+     * @dev Get timestamp of next epoch
+     * Will revert if all epochs have passed
+     * @return Timestamp of when the next epoch starts
+     */
+    function nextEpoch() public view returns (uint256) {
+        // get number of epochs passed
+        uint256 passed = epochsPassed();
+
+        // if all epochs passed, return
+        if (passed == TOTAL_EPOCHS) {
+            // return INT_MAX
+            return uint256(-1);
+        }
+
+        // if no epochs passed, return latest epoch + delay + standard duration
+        if (passed == 0) {
+            return latestEpoch().add(FIRST_EPOCH_DELAY).add(EPOCH_DURATION);
+        }
+
+        // otherwise return latest epoch + epoch duration
+        return latestEpoch().add(EPOCH_DURATION);
+    }
+
+    /**
+     * @dev Get timestamp of latest epoch
+     * @return Timestamp of when the current epoch has started
+     */
+    function latestEpoch() public view returns (uint256) {
+        // get number of epochs passed
+        uint256 passed = epochsPassed();
+
+        // if no epochs passed, return lock start time
+        if (passed == 0) {
+            return LOCK_START;
+        }
+
+        // accounts for first epoch being longer
+        // lockStart + firstEpochDelay + (epochsPassed * epochDuration)
+        return LOCK_START.add(FIRST_EPOCH_DELAY).add(passed.mul(EPOCH_DURATION));
+    }
+
+    /**
+     * @dev Get timestamp of final epoch
+     * @return Timestamp of when the last epoch ends and all funds are released
+     */
+    function finalEpoch() public pure returns (uint256) {
+        // lockStart + firstEpochDelay + (epochDuration * totalEpochs)
+        return LOCK_START.add(FIRST_EPOCH_DELAY).add(EPOCH_DURATION.mul(TOTAL_EPOCHS));
+    }
+
+    /**
+     * @dev Get timestamp of locking period start
+     * @return Timestamp of locking period start
+     */
+    function lockStart() public pure returns (uint256) {
+        return LOCK_START;
+    }
+}

--- a/flatten/TimeOwnedUpgradeabilityProxy.sol
+++ b/flatten/TimeOwnedUpgradeabilityProxy.sol
@@ -1,0 +1,265 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/proxy/OwnedUpgradeabilityProxy.sol
+
+// SPDX-License-Identifier: MIT
+// solhint-disable const-name-snakecase
+// pragma solidity 0.6.10;
+
+/**
+ * @title OwnedUpgradeabilityProxy
+ * @dev This contract combines an upgradeability proxy with basic authorization control functionalities
+ */
+contract OwnedUpgradeabilityProxy {
+    /**
+     * @dev Event to show ownership has been transferred
+     * @param previousOwner representing the address of the previous owner
+     * @param newOwner representing the address of the new owner
+     */
+    event ProxyOwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Event to show ownership transfer is pending
+     * @param currentOwner representing the address of the current owner
+     * @param pendingOwner representing the address of the pending owner
+     */
+    event NewPendingOwner(address currentOwner, address pendingOwner);
+
+    // Storage position of the owner and pendingOwner of the contract
+    bytes32 private constant proxyOwnerPosition = 0x6279e8199720cf3557ecd8b58d667c8edc486bd1cf3ad59ea9ebdfcae0d0dfac; //keccak256("trueUSD.proxy.owner");
+    bytes32 private constant pendingProxyOwnerPosition = 0x8ddbac328deee8d986ec3a7b933a196f96986cb4ee030d86cc56431c728b83f4; //keccak256("trueUSD.pending.proxy.owner");
+
+    /**
+     * @dev the constructor sets the original owner of the contract to the sender account.
+     */
+    constructor() public {
+        _setUpgradeabilityOwner(msg.sender);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyProxyOwner() {
+        require(msg.sender == proxyOwner(), "only Proxy Owner");
+        _;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the pending owner.
+     */
+    modifier onlyPendingProxyOwner() {
+        require(msg.sender == pendingProxyOwner(), "only pending Proxy Owner");
+        _;
+    }
+
+    /**
+     * @dev Tells the address of the owner
+     * @return owner the address of the owner
+     */
+    function proxyOwner() public view returns (address owner) {
+        bytes32 position = proxyOwnerPosition;
+        assembly {
+            owner := sload(position)
+        }
+    }
+
+    /**
+     * @dev Tells the address of the owner
+     * @return pendingOwner the address of the pending owner
+     */
+    function pendingProxyOwner() public view returns (address pendingOwner) {
+        bytes32 position = pendingProxyOwnerPosition;
+        assembly {
+            pendingOwner := sload(position)
+        }
+    }
+
+    /**
+     * @dev Sets the address of the owner
+     */
+    function _setUpgradeabilityOwner(address newProxyOwner) internal {
+        bytes32 position = proxyOwnerPosition;
+        assembly {
+            sstore(position, newProxyOwner)
+        }
+    }
+
+    /**
+     * @dev Sets the address of the owner
+     */
+    function _setPendingUpgradeabilityOwner(address newPendingProxyOwner) internal {
+        bytes32 position = pendingProxyOwnerPosition;
+        assembly {
+            sstore(position, newPendingProxyOwner)
+        }
+    }
+
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     *changes the pending owner to newOwner. But doesn't actually transfer
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferProxyOwnership(address newOwner) external onlyProxyOwner {
+        require(newOwner != address(0));
+        _setPendingUpgradeabilityOwner(newOwner);
+        emit NewPendingOwner(proxyOwner(), newOwner);
+    }
+
+    /**
+     * @dev Allows the pendingOwner to claim ownership of the proxy
+     */
+    function claimProxyOwnership() external onlyPendingProxyOwner {
+        emit ProxyOwnershipTransferred(proxyOwner(), pendingProxyOwner());
+        _setUpgradeabilityOwner(pendingProxyOwner());
+        _setPendingUpgradeabilityOwner(address(0));
+    }
+
+    /**
+     * @dev Allows the proxy owner to upgrade the current version of the proxy.
+     * @param implementation representing the address of the new implementation to be set.
+     */
+    function upgradeTo(address implementation) public virtual onlyProxyOwner {
+        address currentImplementation;
+        bytes32 position = implementationPosition;
+        assembly {
+            currentImplementation := sload(position)
+        }
+        require(currentImplementation != implementation);
+        assembly {
+            sstore(position, implementation)
+        }
+        emit Upgraded(implementation);
+    }
+
+    /**
+     * @dev This event will be emitted every time the implementation gets upgraded
+     * @param implementation representing the address of the upgraded implementation
+     */
+    event Upgraded(address indexed implementation);
+
+    // Storage position of the address of the current implementation
+    bytes32 private constant implementationPosition = 0x6e41e0fbe643dfdb6043698bf865aada82dc46b953f754a3468eaa272a362dc7; //keccak256("trueUSD.proxy.implementation");
+
+    function implementation() public view returns (address impl) {
+        bytes32 position = implementationPosition;
+        assembly {
+            impl := sload(position)
+        }
+    }
+
+    /**
+     * @dev Fallback functions allowing to perform a delegatecall to the given implementation.
+     * This function will return whatever the implementation call returns
+     */
+    fallback() external payable {
+        proxyCall();
+    }
+
+    receive() external payable {
+        proxyCall();
+    }
+
+    function proxyCall() internal {
+        bytes32 position = implementationPosition;
+
+        assembly {
+            let ptr := mload(0x40)
+            calldatacopy(ptr, returndatasize(), calldatasize())
+            let result := delegatecall(gas(), sload(position), ptr, calldatasize(), returndatasize(), returndatasize())
+            returndatacopy(ptr, 0, returndatasize())
+
+            switch result
+                case 0 {
+                    revert(ptr, returndatasize())
+                }
+                default {
+                    return(ptr, returndatasize())
+                }
+        }
+    }
+}
+
+
+// Root file: contracts/proxy/TimeOwnedUpgradeabilityProxy.sol
+
+pragma solidity 0.6.10;
+
+// import {OwnedUpgradeabilityProxy} from "contracts/proxy/OwnedUpgradeabilityProxy.sol";
+
+/**
+ * @title TimeOwnedUpgradeabilityProxy
+ * @dev This contract combines an upgradeability proxy with
+ * basic authorization control functionalities
+ *
+ * This contract allows us to specify a time at which the proxy can no longer
+ * be upgraded
+ */
+contract TimeOwnedUpgradeabilityProxy is OwnedUpgradeabilityProxy {
+    // solhint-disable-next-line const-name-snakecase
+    bytes32 private constant expirationPosition = bytes32(uint256(keccak256("trusttoken.expiration")) - 1);
+
+    /**
+     * @dev the constructor sets the original owner of the contract to the sender account.
+     */
+    constructor() public {
+        _setUpgradeabilityOwner(msg.sender);
+        // set expiration to ~4 months from now
+        _setExpiration(block.timestamp + 124 days);
+    }
+
+    /**
+     * @dev sets new expiration time
+     */
+    function setExpiration(uint256 newExpirationTime) external onlyProxyOwner {
+        require(block.timestamp < expiration(), "after expiration time");
+        require(block.timestamp < newExpirationTime, "new expiration time must be in the future");
+        _setExpiration(newExpirationTime);
+    }
+
+    function _setExpiration(uint256 newExpirationTime) internal onlyProxyOwner {
+        bytes32 position = expirationPosition;
+        assembly {
+            sstore(position, newExpirationTime)
+        }
+    }
+
+    function expiration() public view returns (uint256 _expiration) {
+        bytes32 position = expirationPosition;
+        assembly {
+            _expiration := sload(position)
+        }
+    }
+
+    /**
+     * @dev Allows the proxy owner to upgrade the current version of the proxy.
+     * @param implementation representing the address of the new implementation to be set.
+     */
+    function upgradeTo(address implementation) public override onlyProxyOwner {
+        require(block.timestamp < expiration(), "after expiration date");
+        super.upgradeTo(implementation);
+    }
+}

--- a/flatten/Timelock.sol
+++ b/flatten/Timelock.sol
@@ -1,0 +1,444 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: contracts/governance/common/ClaimableContract.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title ClaimableContract
+ * @dev The ClaimableContract contract is a copy of Claimable Contract by Zeppelin.
+ and provides basic authorization control functions. Inherits storage layout of
+ ProxyStorage.
+ */
+contract ClaimableContract  {
+    address owner_;
+    address pendingOwner_;
+    bool initalized;
+
+
+    function owner() public view returns (address) {
+        return owner_;
+    }
+
+    function pendingOwner() public view returns (address) {
+        return pendingOwner_;
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner_ = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner_, "only owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner_);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner_ = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        address _pendingOwner = pendingOwner_;
+        emit OwnershipTransferred(owner_, _pendingOwner);
+        owner_ = _pendingOwner;
+        pendingOwner_ = address(0);
+    }
+}
+
+
+// Root file: contracts/governance/Timelock.sol
+
+// AND COPIED FROM https://github.com/compound-finance/compound-protocol/blob/master/contracts/Governance/GovernorAlpha.sol
+// Copyright 2020 Compound Labs, Inc.
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Ctrl+f for OLD to see all the modifications.
+
+// OLD: pragma solidity ^0.5.16;
+pragma solidity ^0.6.10;
+
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+// import "contracts/governance/common/ClaimableContract.sol";
+
+contract Timelock is ClaimableContract{
+    using SafeMath for uint;
+
+    event NewAdmin(address indexed newAdmin);
+    event NewPendingAdmin(address indexed newPendingAdmin);
+    event NewDelay(uint indexed newDelay);
+    event CancelTransaction(bytes32 indexed txHash, address indexed target, uint value, string signature,  bytes data, uint eta);
+    event ExecuteTransaction(bytes32 indexed txHash, address indexed target, uint value, string signature,  bytes data, uint eta);
+    event QueueTransaction(bytes32 indexed txHash, address indexed target, uint value, string signature, bytes data, uint eta);
+
+    uint public constant GRACE_PERIOD = 14 days;
+    uint public constant MINIMUM_DELAY = 2 days;
+    uint public constant MAXIMUM_DELAY = 30 days;
+
+    address public admin;
+    address public pendingAdmin;
+    uint public delay;
+    // OLD: N/A
+    bool public admin_initialized;
+
+    mapping (bytes32 => bool) public queuedTransactions;
+
+    /**
+     * @dev Initialize sets the addresses of admin and the delay timestamp
+     * @param admin_ The address of admin
+     * @param delay_ The timestamp of delay for timelock contract
+     */
+    function initialize(address admin_, uint delay_) external {
+        require(!initalized, "Already initialized");
+        require(delay_ >= MINIMUM_DELAY, "Timelock::constructor: Delay must exceed minimum delay.");
+        require(delay_ <= MAXIMUM_DELAY, "Timelock::setDelay: Delay must not exceed maximum delay.");
+
+        admin = admin_;
+        delay = delay_;
+
+        owner_ = msg.sender;
+        initalized = true;
+        // OLD: N/A
+        admin_initialized = false;
+    }
+
+    // OLD: function() external payable { }
+    receive() external payable { }
+
+    /**
+     * @dev Set the timelock delay to a new timestamp
+     * @param delay_ The timestamp of delay for timelock contract
+     */
+    function setDelay(uint delay_) public {
+        require(msg.sender == address(this), "Timelock::setDelay: Call must come from Timelock.");
+        require(delay_ >= MINIMUM_DELAY, "Timelock::setDelay: Delay must exceed minimum delay.");
+        require(delay_ <= MAXIMUM_DELAY, "Timelock::setDelay: Delay must not exceed maximum delay.");
+        delay = delay_;
+
+        emit NewDelay(delay);
+    }
+
+    /**
+     * @dev Accept the pendingAdmin as the admin address
+     */
+    function acceptAdmin() public {
+        require(msg.sender == pendingAdmin, "Timelock::acceptAdmin: Call must come from pendingAdmin.");
+        admin = msg.sender;
+        pendingAdmin = address(0);
+
+        emit NewAdmin(admin);
+    }
+
+    /**
+     * @dev Set the pendingAdmin address to a new address
+     * @param pendingAdmin_ The address of the new pendingAdmin
+     */
+    function setPendingAdmin(address pendingAdmin_) public {
+        // allows one time setting of admin for deployment purposes
+        if (admin_initialized) {
+            require(msg.sender == address(this), "Timelock::setPendingAdmin: Call must come from Timelock.");
+        } else {
+            require(msg.sender == admin, "Timelock::setPendingAdmin: First call must come from admin.");
+            admin_initialized = true;
+        }
+        pendingAdmin = pendingAdmin_;
+
+        emit NewPendingAdmin(pendingAdmin);
+    }
+
+    /**
+     * @dev Queue one single proposal transaction
+     * @param target The target address for call to be made during proposal execution
+     * @param value The value to be passed to the calls made during proposal execution
+     * @param signature The function signature to be passed during execution
+     * @param data The data to be passed to the individual function call
+     * @param eta The current timestamp plus the timelock delay
+     */
+    function queueTransaction(address target, uint value, string memory signature, bytes memory data, uint eta) public returns (bytes32) {
+        require(msg.sender == admin, "Timelock::queueTransaction: Call must come from admin.");
+        require(eta >= getBlockTimestamp().add(delay), "Timelock::queueTransaction: Estimated execution block must satisfy delay.");
+
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        queuedTransactions[txHash] = true;
+
+        emit QueueTransaction(txHash, target, value, signature, data, eta);
+        return txHash;
+    }
+
+    /**
+     * @dev Cancel one single proposal transaction
+     * @param target The target address for call to be made during proposal execution
+     * @param value The value to be passed to the calls made during proposal execution
+     * @param signature The function signature to be passed during execution
+     * @param data The data to be passed to the individual function call
+     * @param eta The current timestamp plus the timelock delay
+     */
+    function cancelTransaction(address target, uint value, string memory signature, bytes memory data, uint eta) public {
+        require(msg.sender == admin, "Timelock::cancelTransaction: Call must come from admin.");
+
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        queuedTransactions[txHash] = false;
+
+        emit CancelTransaction(txHash, target, value, signature, data, eta);
+    }
+
+    /**
+     * @dev Execute one single proposal transaction
+     * @param target The target address for call to be made during proposal execution
+     * @param value The value to be passed to the calls made during proposal execution
+     * @param signature The function signature to be passed during execution
+     * @param data The data to be passed to the individual function call
+     * @param eta The current timestamp plus the timelock delay
+     */
+    function executeTransaction(address target, uint value, string memory signature, bytes memory data, uint eta) public payable returns (bytes memory) {
+        require(msg.sender == admin, "Timelock::executeTransaction: Call must come from admin.");
+
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        require(queuedTransactions[txHash], "Timelock::executeTransaction: Transaction hasn't been queued.");
+        require(getBlockTimestamp() >= eta, "Timelock::executeTransaction: Transaction hasn't surpassed time lock.");
+        require(getBlockTimestamp() <= eta.add(GRACE_PERIOD), "Timelock::executeTransaction: Transaction is stale.");
+
+        queuedTransactions[txHash] = false;
+
+        bytes memory callData;
+
+        if (bytes(signature).length == 0) {
+            callData = data;
+        } else {
+            callData = abi.encodePacked(bytes4(keccak256(bytes(signature))), data);
+        }
+
+        // OLD: (bool success, bytes memory returnData) = target.call.value(value)(callData);
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returnData) = target.call{value:value}(callData);
+        require(success, "Timelock::executeTransaction: Transaction execution reverted.");
+
+        emit ExecuteTransaction(txHash, target, value, signature, data, eta);
+
+        return returnData;
+    }
+
+    /**
+     * @dev Get the current block timestamp
+     * @return The timestamp of current block
+     */
+    function getBlockTimestamp() internal view returns (uint) {
+        // solium-disable-next-line security/no-block-members
+        return block.timestamp;
+    }
+}

--- a/flatten/TokenController.sol
+++ b/flatten/TokenController.sol
@@ -1,0 +1,2094 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/proxy/interface/IOwnedUpgradeabilityProxy.sol
+
+// pragma solidity 0.6.10;
+
+interface IOwnedUpgradeabilityProxy {
+    function proxyOwner() external view returns (address owner);
+
+    function pendingProxyOwner() external view returns (address pendingOwner);
+
+    function transferProxyOwnership(address newOwner) external;
+
+    function claimProxyOwnership() external;
+
+    function upgradeTo(address implementation) external;
+
+    function implementation() external view returns (address impl);
+}
+
+
+// Dependency file: contracts/registry/interface/IHasOwner.sol
+
+// pragma solidity 0.6.10;
+
+interface IHasOwner {
+    function claimOwnership() external;
+
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IReclaimerToken {
+    function reclaimToken(IERC20 token, address _to) external;
+
+    function reclaimEther(address payable _to) external;
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IHasOwner} from "contracts/registry/interface/IHasOwner.sol";
+// import {IRegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+// import {IReclaimerToken} from "contracts/true-currencies/interface/IReclaimerToken.sol";
+
+interface IRegistry is IHasOwner, IReclaimerToken {
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) external;
+
+    function subscribe(bytes32 _attribute, IRegistryClone _syncer) external;
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external;
+
+    function subscriberCount(bytes32 _attribute) external view returns (uint256);
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+
+    function hasAttribute(address _who, bytes32 _attribute) external view returns (bool);
+
+    function getAttribute(address _who, bytes32 _attribute)
+        external
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        );
+
+    function getAttributeValue(address _who, bytes32 _attribute) external view returns (uint256);
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) external view returns (address);
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) external view returns (uint256);
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external;
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IHasOwner.sol
+
+// pragma solidity 0.6.10;
+
+interface IHasOwner {
+    function claimOwnership() external;
+
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IHook.sol
+
+// pragma solidity 0.6.10;
+
+interface IHook {
+    function hook() external;
+}
+
+
+// Dependency file: contracts/true-currencies/interface/ITrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IHasOwner} from "contracts/true-currencies/interface/IHasOwner.sol";
+// import {IReclaimerToken} from "contracts/true-currencies/interface/IReclaimerToken.sol";
+
+interface ITrueCurrency is IERC20, IReclaimerToken, IHasOwner {
+    function refundGas(uint256 amount) external;
+
+    function setBlacklisted(address account, bool _isBlacklisted) external;
+
+    function setCanBurn(address account, bool _canBurn) external;
+
+    function setBurnBounds(uint256 _min, uint256 _max) external;
+
+    function mint(address account, uint256 amount) external;
+}
+
+
+// Dependency file: contracts/true-currencies/common/GasRefund.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Gas Reclaim Legacy
+ *
+ * Note: this contract does not affect any of the token logic. It merely
+ * exists so the TokenController (owner) can reclaim the sponsored gas
+ *
+ * Previously TrueCurrency has a feature called "gas boost" which allowed
+ * us to sponsor gas by setting non-empty storage slots to 1.
+ * We are depricating this feature, but there is a bunch of gas saved
+ * from years of sponsoring gas. This contract is meant to allow the owner
+ * to take advantage of this leftover gas. Once all the slots are used,
+ * this contract can be removed from TrueCurrency.
+ *
+ * Utilitzes the gas refund mechanism in EVM. Each time an non-empty
+ * storage slot is set to 0, evm will refund 15,000 to the sender.
+ * Also utilized the refund for selfdestruct, see gasRefund39
+ */
+abstract contract GasRefund {
+    /**
+     * @dev Refund 15,000 gas per slot.
+     * @param amount number of slots to free
+     */
+    function gasRefund15(uint256 amount) internal {
+        assembly {
+            // get number of free slots
+            let offset := sload(0xfffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // get location of first slot
+            let location := add(offset, 0xfffff)
+            // loop until end is reached
+            for {
+                let end := sub(location, amount)
+            } gt(location, end) {
+                location := sub(location, 1)
+            } {
+                // set storage location to zero
+                // this refunds 15,000 gas
+                sstore(location, 0)
+            }
+            // store new number of free slots
+            sstore(0xfffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev use smart contract self-destruct to refund gas
+     * will refund 39,000 * amount gas
+     */
+    function gasRefund39(uint256 amount) internal {
+        assembly {
+            // get amount of gas slots
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // first sheep pointer
+            let location := sub(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, offset)
+            // loop from location to end
+            for {
+                let end := add(location, amount)
+            } lt(location, end) {
+                location := add(location, 1)
+            } {
+                // load sheep address
+                let sheep := sload(location)
+                // call selfdestruct on sheep
+                pop(call(gas(), sheep, 0, 0, 0, 0, 0))
+                // clear sheep address
+                sstore(location, 0)
+            }
+            // store new number of sheep
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev Return the remaining sponsored gas slots
+     */
+    function remainingGasRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xfffff)
+        }
+    }
+
+    /**
+     * @dev Return the remaining sheep slots
+     */
+    function remainingSheepRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrencyWithGasRefund.sol
+
+// pragma solidity 0.6.10;
+
+// import {GasRefund} from "contracts/true-currencies/common/GasRefund.sol";
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+abstract contract TrueCurrencyWithGasRefund is GasRefund, TrueCurrency {
+    /**
+     * @dev reclaim gas from legacy gas refund #1
+     * will refund 15,000 * amount gas to sender (minus exection cost)
+     * If gas pool is empty, refund 39,000 * amount gas by calling selfdestruct
+     */
+    function refundGas(uint256 amount) external onlyOwner {
+        if (remainingGasRefundPool() > 0) {
+            gasRefund15(amount);
+        } else {
+            gasRefund39(amount.div(3));
+        }
+    }
+}
+
+
+// Root file: contracts/true-currencies/TokenController.sol
+
+pragma solidity 0.6.10;
+
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IOwnedUpgradeabilityProxy as OwnedUpgradeabilityProxy} from "contracts/proxy/interface/IOwnedUpgradeabilityProxy.sol";
+
+// import {IRegistry as Registry} from "contracts/registry/interface/IRegistry.sol";
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+// import {IHasOwner as HasOwner} from "contracts/true-currencies/interface/IHasOwner.sol";
+// import {IHook as Hook} from "contracts/true-currencies/interface/IHook.sol";
+// import {ITrueCurrency as TrueCurrency} from "contracts/true-currencies/interface/ITrueCurrency.sol";
+
+// import {TrueCurrencyWithGasRefund} from "contracts/true-currencies/TrueCurrencyWithGasRefund.sol";
+
+/** @title TokenController
+ * @dev This contract allows us to split ownership of the TrueCurrency contract
+ * into two addresses. One, called the "owner" address, has unfettered control of the TrueCurrency contract -
+ * it can mint new tokens, transfer ownership of the contract, etc. However to make
+ * extra sure that TrueCurrency is never compromised, this owner key will not be used in
+ * day-to-day operations, allowing it to be stored at a heightened level of security.
+ * Instead, the owner appoints an various "admin" address.
+ * There are 3 different types of admin addresses;  MintKey, MintRatifier, and MintPauser.
+ * MintKey can request and revoke mints one at a time.
+ * MintPausers can pause individual mints or pause all mints.
+ * MintRatifiers can approve and finalize mints with enough approval.
+
+ * There are three levels of mints: instant mint, ratified mint, and multiSig mint. Each have a different threshold
+ * and deduct from a different pool.
+ * Instant mint has the lowest threshold and finalizes instantly without any ratifiers. Deduct from instant mint pool,
+ * which can be refilled by one ratifier.
+ * Ratify mint has the second lowest threshold and finalizes with one ratifier approval. Deduct from ratify mint pool,
+ * which can be refilled by three ratifiers.
+ * MultiSig mint has the highest threshold and finalizes with three ratifier approvals. Deduct from multiSig mint pool,
+ * which can only be refilled by the owner.
+*/
+
+contract TokenController {
+    using SafeMath for uint256;
+
+    struct MintOperation {
+        address to;
+        uint256 value;
+        uint256 requestedBlock;
+        uint256 numberOfApproval;
+        bool paused;
+        mapping(address => bool) approved;
+    }
+
+    address payable public owner;
+    address payable public pendingOwner;
+
+    bool public initialized;
+
+    uint256 public instantMintThreshold;
+    uint256 public ratifiedMintThreshold;
+    uint256 public multiSigMintThreshold;
+
+    uint256 public instantMintLimit;
+    uint256 public ratifiedMintLimit;
+    uint256 public multiSigMintLimit;
+
+    uint256 public instantMintPool;
+    uint256 public ratifiedMintPool;
+    uint256 public multiSigMintPool;
+    address[2] public ratifiedPoolRefillApprovals;
+
+    uint8 public constant RATIFY_MINT_SIGS = 1; //number of approvals needed to finalize a Ratified Mint
+    uint8 public constant MULTISIG_MINT_SIGS = 3; //number of approvals needed to finalize a MultiSig Mint
+
+    bool public mintPaused;
+    uint256 public mintReqInvalidBeforeThisBlock; //all mint request before this block are invalid
+    address public mintKey;
+    MintOperation[] public mintOperations; //list of a mint requests
+
+    TrueCurrency public token;
+    Registry public registry;
+    address public registryAdmin;
+    address public gasRefunder;
+
+    // Registry attributes for admin keys
+    bytes32 public constant IS_MINT_PAUSER = "isTUSDMintPausers";
+    bytes32 public constant IS_MINT_RATIFIER = "isTUSDMintRatifier";
+    bytes32 public constant IS_REDEMPTION_ADMIN = "isTUSDRedemptionAdmin";
+
+    // paused version of TrueCurrency in Production
+    // pausing the contract upgrades the proxy to this implementation
+    address public constant PAUSED_IMPLEMENTATION = 0x3c8984DCE8f68FCDEEEafD9E0eca3598562eD291;
+
+    modifier onlyMintKeyOrOwner() {
+        require(msg.sender == mintKey || msg.sender == owner, "must be mintKey or owner");
+        _;
+    }
+
+    modifier onlyMintPauserOrOwner() {
+        require(registry.hasAttribute(msg.sender, IS_MINT_PAUSER) || msg.sender == owner, "must be pauser or owner");
+        _;
+    }
+
+    modifier onlyMintRatifierOrOwner() {
+        require(registry.hasAttribute(msg.sender, IS_MINT_RATIFIER) || msg.sender == owner, "must be ratifier or owner");
+        _;
+    }
+
+    modifier onlyOwnerOrRedemptionAdmin() {
+        require(registry.hasAttribute(msg.sender, IS_REDEMPTION_ADMIN) || msg.sender == owner, "must be Redemption admin or owner");
+        _;
+    }
+
+    modifier onlyGasRefunder() {
+        require(msg.sender == gasRefunder || msg.sender == owner, "must be gas refunder or owner");
+        _;
+    }
+
+    modifier onlyRegistryAdmin() {
+        require(msg.sender == registryAdmin || msg.sender == owner, "must be registry admin or owner");
+        _;
+    }
+
+    //mint operations by the mintkey cannot be processed on when mints are paused
+    modifier mintNotPaused() {
+        if (msg.sender != owner) {
+            require(!mintPaused, "minting is paused");
+        }
+        _;
+    }
+    /// @dev Emitted when ownership of controller was transferred
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    /// @dev Emitted when ownership of controller transfer procedure was started
+    event NewOwnerPending(address indexed currentOwner, address indexed pendingOwner);
+    /// @dev Emitted when new registry was set
+    event SetRegistry(address indexed registry);
+    /// @dev Emitted when owner was transferred for child contract
+    event TransferChild(address indexed child, address indexed newOwner);
+    /// @dev Emitted when child ownership was claimed
+    event RequestReclaimContract(address indexed other);
+    /// @dev Emitted when child token was changed
+    event SetToken(TrueCurrency newContract);
+    /// @dev Emitted when canBurn status of the `burner` was changed to `canBurn`
+    event CanBurn(address burner, bool canBurn);
+
+    /// @dev Emitted when mint was requested
+    event RequestMint(address indexed to, uint256 indexed value, uint256 opIndex, address mintKey);
+    /// @dev Emitted when mint was finalized
+    event FinalizeMint(address indexed to, uint256 indexed value, uint256 opIndex, address mintKey);
+    /// @dev Emitted on instant mint
+    event InstantMint(address indexed to, uint256 indexed value, address indexed mintKey);
+
+    /// @dev Emitted when mint key was replaced
+    event TransferMintKey(address indexed previousMintKey, address indexed newMintKey);
+    /// @dev Emitted when mint was ratified
+    event MintRatified(uint256 indexed opIndex, address indexed ratifier);
+    /// @dev Emitted when mint is revoked
+    event RevokeMint(uint256 opIndex);
+    /// @dev Emitted when all mining is paused (status=true) or unpaused (status=false)
+    event AllMintsPaused(bool status);
+    /// @dev Emitted when opIndex mint is paused (status=true) or unpaused (status=false)
+    event MintPaused(uint256 opIndex, bool status);
+    /// @dev Emitted when mint is approved
+    event MintApproved(address approver, uint256 opIndex);
+    /// @dev Emitted when fast pause contract is changed
+    event FastPauseSet(address _newFastPause);
+
+    /// @dev Emitted when mint threshold changes
+    event MintThresholdChanged(uint256 instant, uint256 ratified, uint256 multiSig);
+    /// @dev Emitted when mint limits change
+    event MintLimitsChanged(uint256 instant, uint256 ratified, uint256 multiSig);
+    /// @dev Emitted when instant mint pool is refilled
+    event InstantPoolRefilled();
+    /// @dev Emitted when instant mint pool is ratified
+    event RatifyPoolRefilled();
+    /// @dev Emitted when multisig mint pool is ratified
+    event MultiSigPoolRefilled();
+
+    /*
+    ========================================
+    Ownership functions
+    ========================================
+    */
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address payable newOwner) external onlyOwner {
+        pendingOwner = newOwner;
+        emit NewOwnerPending(address(owner), address(pendingOwner));
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() external onlyPendingOwner {
+        emit OwnershipTransferred(address(owner), address(pendingOwner));
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+
+    /*
+    ========================================
+    proxy functions
+    ========================================
+    */
+
+    function transferTrueCurrencyProxyOwnership(address _newOwner) external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).transferProxyOwnership(_newOwner);
+    }
+
+    function claimTrueCurrencyProxyOwnership() external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).claimProxyOwnership();
+    }
+
+    function upgradeTrueCurrencyProxyImplTo(address _implementation) external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(_implementation);
+    }
+
+    /*
+    ========================================
+    Minting functions
+    ========================================
+    */
+
+    /**
+     * @dev set the threshold for a mint to be considered an instant mint,
+     * ratify mint and multiSig mint. Instant mint requires no approval,
+     * ratify mint requires 1 approval and multiSig mint requires 3 approvals
+     */
+    function setMintThresholds(
+        uint256 _instant,
+        uint256 _ratified,
+        uint256 _multiSig
+    ) external onlyOwner {
+        require(_instant <= _ratified && _ratified <= _multiSig);
+        instantMintThreshold = _instant;
+        ratifiedMintThreshold = _ratified;
+        multiSigMintThreshold = _multiSig;
+        emit MintThresholdChanged(_instant, _ratified, _multiSig);
+    }
+
+    /**
+     * @dev set the limit of each mint pool. For example can only instant mint up to the instant mint pool limit
+     * before needing to refill
+     */
+    function setMintLimits(
+        uint256 _instant,
+        uint256 _ratified,
+        uint256 _multiSig
+    ) external onlyOwner {
+        require(_instant <= _ratified && _ratified <= _multiSig);
+        instantMintLimit = _instant;
+        if (instantMintPool > instantMintLimit) {
+            instantMintPool = instantMintLimit;
+        }
+        ratifiedMintLimit = _ratified;
+        if (ratifiedMintPool > ratifiedMintLimit) {
+            ratifiedMintPool = ratifiedMintLimit;
+        }
+        multiSigMintLimit = _multiSig;
+        if (multiSigMintPool > multiSigMintLimit) {
+            multiSigMintPool = multiSigMintLimit;
+        }
+        emit MintLimitsChanged(_instant, _ratified, _multiSig);
+    }
+
+    /**
+     * @dev Ratifier can refill instant mint pool
+     */
+    function refillInstantMintPool() external onlyMintRatifierOrOwner {
+        ratifiedMintPool = ratifiedMintPool.sub(instantMintLimit.sub(instantMintPool));
+        instantMintPool = instantMintLimit;
+        emit InstantPoolRefilled();
+    }
+
+    /**
+     * @dev Owner or 3 ratifiers can refill Ratified Mint Pool
+     */
+    function refillRatifiedMintPool() external onlyMintRatifierOrOwner {
+        if (msg.sender != owner) {
+            address[2] memory refillApprovals = ratifiedPoolRefillApprovals;
+            require(msg.sender != refillApprovals[0] && msg.sender != refillApprovals[1]);
+            if (refillApprovals[0] == address(0)) {
+                ratifiedPoolRefillApprovals[0] = msg.sender;
+                return;
+            }
+            if (refillApprovals[1] == address(0)) {
+                ratifiedPoolRefillApprovals[1] = msg.sender;
+                return;
+            }
+        }
+        delete ratifiedPoolRefillApprovals; // clears the whole array
+        multiSigMintPool = multiSigMintPool.sub(ratifiedMintLimit.sub(ratifiedMintPool));
+        ratifiedMintPool = ratifiedMintLimit;
+        emit RatifyPoolRefilled();
+    }
+
+    /**
+     * @dev Owner can refill MultiSig Mint Pool
+     */
+    function refillMultiSigMintPool() external onlyOwner {
+        multiSigMintPool = multiSigMintLimit;
+        emit MultiSigPoolRefilled();
+    }
+
+    /**
+     * @dev mintKey initiates a request to mint _value for account _to
+     * @param _to the address to mint to
+     * @param _value the amount requested
+     */
+    function requestMint(address _to, uint256 _value) external mintNotPaused onlyMintKeyOrOwner {
+        MintOperation memory op = MintOperation(_to, _value, block.number, 0, false);
+        emit RequestMint(_to, _value, mintOperations.length, msg.sender);
+        mintOperations.push(op);
+    }
+
+    /**
+     * @dev Instant mint without ratification if the amount is less
+     * than instantMintThreshold and instantMintPool
+     * @param _to the address to mint to
+     * @param _value the amount minted
+     */
+    function instantMint(address _to, uint256 _value) external mintNotPaused onlyMintKeyOrOwner {
+        require(_value <= instantMintThreshold, "over the instant mint threshold");
+        require(_value <= instantMintPool, "instant mint pool is dry");
+        instantMintPool = instantMintPool.sub(_value);
+        emit InstantMint(_to, _value, msg.sender);
+        token.mint(_to, _value);
+    }
+
+    /**
+     * @dev ratifier ratifies a request mint. If the number of
+     * ratifiers that signed off is greater than the number of
+     * approvals required, the request is finalized
+     * @param _index the index of the requestMint to ratify
+     * @param _to the address to mint to
+     * @param _value the amount requested
+     */
+    function ratifyMint(
+        uint256 _index,
+        address _to,
+        uint256 _value
+    ) external mintNotPaused onlyMintRatifierOrOwner {
+        MintOperation memory op = mintOperations[_index];
+        require(op.to == _to, "to address does not match");
+        require(op.value == _value, "amount does not match");
+        require(!mintOperations[_index].approved[msg.sender], "already approved");
+        mintOperations[_index].approved[msg.sender] = true;
+        mintOperations[_index].numberOfApproval = mintOperations[_index].numberOfApproval.add(1);
+        emit MintRatified(_index, msg.sender);
+        if (hasEnoughApproval(mintOperations[_index].numberOfApproval, _value)) {
+            finalizeMint(_index);
+        }
+    }
+
+    /**
+     * @dev finalize a mint request, mint the amount requested to the specified address
+     * @param _index of the request (visible in the RequestMint event accompanying the original request)
+     */
+    function finalizeMint(uint256 _index) public mintNotPaused {
+        MintOperation memory op = mintOperations[_index];
+        address to = op.to;
+        uint256 value = op.value;
+        if (msg.sender != owner) {
+            require(canFinalize(_index));
+            _subtractFromMintPool(value);
+        }
+        delete mintOperations[_index];
+        token.mint(to, value);
+        emit FinalizeMint(to, value, _index, msg.sender);
+    }
+
+    /**
+     * assumption: only invoked when canFinalize
+     */
+    function _subtractFromMintPool(uint256 _value) internal {
+        if (_value <= ratifiedMintPool && _value <= ratifiedMintThreshold) {
+            ratifiedMintPool = ratifiedMintPool.sub(_value);
+        } else {
+            multiSigMintPool = multiSigMintPool.sub(_value);
+        }
+    }
+
+    /**
+     * @dev compute if the number of approvals is enough for a given mint amount
+     */
+    function hasEnoughApproval(uint256 _numberOfApproval, uint256 _value) public view returns (bool) {
+        if (_value <= ratifiedMintPool && _value <= ratifiedMintThreshold) {
+            if (_numberOfApproval >= RATIFY_MINT_SIGS) {
+                return true;
+            }
+        }
+        if (_value <= multiSigMintPool && _value <= multiSigMintThreshold) {
+            if (_numberOfApproval >= MULTISIG_MINT_SIGS) {
+                return true;
+            }
+        }
+        if (msg.sender == owner) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @dev compute if a mint request meets all the requirements to be finalized
+     * utility function for a front end
+     */
+    function canFinalize(uint256 _index) public view returns (bool) {
+        MintOperation memory op = mintOperations[_index];
+        require(op.requestedBlock > mintReqInvalidBeforeThisBlock, "this mint is invalid"); //also checks if request still exists
+        require(!op.paused, "this mint is paused");
+        require(hasEnoughApproval(op.numberOfApproval, op.value), "not enough approvals");
+        return true;
+    }
+
+    /**
+     * @dev revoke a mint request, Delete the mintOperation
+     * @param _index of the request (visible in the RequestMint event accompanying the original request)
+     */
+    function revokeMint(uint256 _index) external onlyMintKeyOrOwner {
+        delete mintOperations[_index];
+        emit RevokeMint(_index);
+    }
+
+    /**
+     * @dev get mint operatino count
+     * @return mint operation count
+     */
+    function mintOperationCount() public view returns (uint256) {
+        return mintOperations.length;
+    }
+
+    /*
+    ========================================
+    Key management
+    ========================================
+    */
+
+    /**
+     * @dev Replace the current mintkey with new mintkey
+     * @param _newMintKey address of the new mintKey
+     */
+    function transferMintKey(address _newMintKey) external onlyOwner {
+        require(_newMintKey != address(0), "new mint key cannot be 0x0");
+        emit TransferMintKey(mintKey, _newMintKey);
+        mintKey = _newMintKey;
+    }
+
+    function setGasRefunder(address refunder) external onlyOwner {
+        gasRefunder = refunder;
+    }
+
+    function setRegistryAdmin(address admin) external onlyOwner {
+        registryAdmin = admin;
+    }
+
+    /*
+    ========================================
+    Mint Pausing
+    ========================================
+    */
+
+    /**
+     * @dev invalidates all mint request initiated before the current block
+     */
+    function invalidateAllPendingMints() external onlyOwner {
+        mintReqInvalidBeforeThisBlock = block.number;
+    }
+
+    /**
+     * @dev pause any further mint request and mint finalizations
+     */
+    function pauseMints() external onlyMintPauserOrOwner {
+        mintPaused = true;
+        emit AllMintsPaused(true);
+    }
+
+    /**
+     * @dev unpause any further mint request and mint finalizations
+     */
+    function unpauseMints() external onlyOwner {
+        mintPaused = false;
+        emit AllMintsPaused(false);
+    }
+
+    /**
+     * @dev pause a specific mint request
+     * @param  _opIndex the index of the mint request the caller wants to pause
+     */
+    function pauseMint(uint256 _opIndex) external onlyMintPauserOrOwner {
+        mintOperations[_opIndex].paused = true;
+        emit MintPaused(_opIndex, true);
+    }
+
+    /**
+     * @dev unpause a specific mint request
+     * @param  _opIndex the index of the mint request the caller wants to unpause
+     */
+    function unpauseMint(uint256 _opIndex) external onlyOwner {
+        mintOperations[_opIndex].paused = false;
+        emit MintPaused(_opIndex, false);
+    }
+
+    /*
+    ========================================
+    set and claim contracts, administrative
+    ========================================
+    */
+
+    /**
+     * @dev Update this contract's token pointer to newContract (e.g. if the
+     * contract is upgraded)
+     */
+    function setToken(TrueCurrency _newContract) external onlyOwner {
+        token = _newContract;
+        emit SetToken(_newContract);
+    }
+
+    /**
+     * @dev Update this contract's registry pointer to _registry
+     */
+    function setRegistry(Registry _registry) external onlyOwner {
+        registry = _registry;
+        emit SetRegistry(address(registry));
+    }
+
+    /**
+     * @dev Claim ownership of an arbitrary HasOwner contract
+     */
+    function issueClaimOwnership(address _other) public onlyOwner {
+        HasOwner other = HasOwner(_other);
+        other.claimOwnership();
+    }
+
+    /**
+     * @dev Transfer ownership of _child to _newOwner.
+     * Can be used e.g. to upgrade this TokenController contract.
+     * @param _child contract that tokenController currently Owns
+     * @param _newOwner new owner/pending owner of _child
+     */
+    function transferChild(HasOwner _child, address _newOwner) external onlyOwner {
+        _child.transferOwnership(_newOwner);
+        emit TransferChild(address(_child), _newOwner);
+    }
+
+    /**
+     * @dev send all ether in token address to the owner of tokenController
+     */
+    function requestReclaimEther() external onlyOwner {
+        token.reclaimEther(owner);
+    }
+
+    /**
+     * @dev transfer all tokens of a particular type in token address to the
+     * owner of tokenController
+     * @param _token token address of the token to transfer
+     */
+    function requestReclaimToken(IERC20 _token) external onlyOwner {
+        token.reclaimToken(_token, owner);
+    }
+
+    /**
+     * @dev pause all pausable actions on TrueCurrency, mints/burn/transfer/approve
+     */
+    function pauseToken() external virtual onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(PAUSED_IMPLEMENTATION);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amounts that TrueCurrency users can
+     * burn to newMin and newMax
+     * @param _min minimum amount user can burn at a time
+     * @param _max maximum amount user can burn at a time
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        token.setBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Owner can send ether balance in contract address
+     * @param _to address to which the funds will be send to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev Owner can send erc20 token balance in contract address
+     * @param _token address of the token to send
+     * @param _to address to which the funds will be send to
+     */
+    function reclaimToken(IERC20 _token, address _to) external onlyOwner {
+        uint256 balance = _token.balanceOf(address(this));
+        _token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Owner can allow address to burn tokens
+     * @param burner address of the token that can burn
+     * @param canBurn true if account is allowed to burn, false otherwise
+     */
+    function setCanBurn(address burner, bool canBurn) external onlyRegistryAdmin {
+        token.setCanBurn(burner, canBurn);
+        emit CanBurn(burner, canBurn);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param isBlacklisted blacklist flag value
+     */
+    function setBlacklisted(address account, bool isBlacklisted) external onlyRegistryAdmin {
+        token.setBlacklisted(account, isBlacklisted);
+    }
+
+    /**
+     * Call hook in `hookContract` with gas refund
+     */
+    function refundGasWithHook(Hook hookContract) external onlyGasRefunder {
+        // calculate start gas amount
+        uint256 startGas = gasleft();
+        // call hook
+        hookContract.hook();
+        // calculate gas used
+        uint256 gasUsed = startGas.sub(gasleft());
+        // 1 refund = 15,000 gas. EVM refunds maximum half of used gas, so divide by 2.
+        // Add 20% to compensate inter contract communication
+        // (x + 20%) / 2 / 15000 = x / 25000
+        token.refundGas(gasUsed.div(25000));
+    }
+}

--- a/flatten/TokenControllerMock.sol
+++ b/flatten/TokenControllerMock.sol
@@ -1,0 +1,2166 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/proxy/interface/IOwnedUpgradeabilityProxy.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+interface IOwnedUpgradeabilityProxy {
+    function proxyOwner() external view returns (address owner);
+
+    function pendingProxyOwner() external view returns (address pendingOwner);
+
+    function transferProxyOwnership(address newOwner) external;
+
+    function claimProxyOwnership() external;
+
+    function upgradeTo(address implementation) external;
+
+    function implementation() external view returns (address impl);
+}
+
+
+// Dependency file: contracts/registry/interface/IHasOwner.sol
+
+// pragma solidity 0.6.10;
+
+interface IHasOwner {
+    function claimOwnership() external;
+
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IReclaimerToken {
+    function reclaimToken(IERC20 token, address _to) external;
+
+    function reclaimEther(address payable _to) external;
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IHasOwner} from "contracts/registry/interface/IHasOwner.sol";
+// import {IRegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+// import {IReclaimerToken} from "contracts/true-currencies/interface/IReclaimerToken.sol";
+
+interface IRegistry is IHasOwner, IReclaimerToken {
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) external;
+
+    function subscribe(bytes32 _attribute, IRegistryClone _syncer) external;
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external;
+
+    function subscriberCount(bytes32 _attribute) external view returns (uint256);
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+
+    function hasAttribute(address _who, bytes32 _attribute) external view returns (bool);
+
+    function getAttribute(address _who, bytes32 _attribute)
+        external
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        );
+
+    function getAttributeValue(address _who, bytes32 _attribute) external view returns (uint256);
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) external view returns (address);
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) external view returns (uint256);
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external;
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IHasOwner.sol
+
+// pragma solidity 0.6.10;
+
+interface IHasOwner {
+    function claimOwnership() external;
+
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/true-currencies/interface/ITrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IHasOwner} from "contracts/true-currencies/interface/IHasOwner.sol";
+// import {IReclaimerToken} from "contracts/true-currencies/interface/IReclaimerToken.sol";
+
+interface ITrueCurrency is IERC20, IReclaimerToken, IHasOwner {
+    function refundGas(uint256 amount) external;
+
+    function setBlacklisted(address account, bool _isBlacklisted) external;
+
+    function setCanBurn(address account, bool _canBurn) external;
+
+    function setBurnBounds(uint256 _min, uint256 _max) external;
+
+    function mint(address account, uint256 amount) external;
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IHook.sol
+
+// pragma solidity 0.6.10;
+
+interface IHook {
+    function hook() external;
+}
+
+
+// Dependency file: contracts/true-currencies/common/GasRefund.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Gas Reclaim Legacy
+ *
+ * Note: this contract does not affect any of the token logic. It merely
+ * exists so the TokenController (owner) can reclaim the sponsored gas
+ *
+ * Previously TrueCurrency has a feature called "gas boost" which allowed
+ * us to sponsor gas by setting non-empty storage slots to 1.
+ * We are depricating this feature, but there is a bunch of gas saved
+ * from years of sponsoring gas. This contract is meant to allow the owner
+ * to take advantage of this leftover gas. Once all the slots are used,
+ * this contract can be removed from TrueCurrency.
+ *
+ * Utilitzes the gas refund mechanism in EVM. Each time an non-empty
+ * storage slot is set to 0, evm will refund 15,000 to the sender.
+ * Also utilized the refund for selfdestruct, see gasRefund39
+ */
+abstract contract GasRefund {
+    /**
+     * @dev Refund 15,000 gas per slot.
+     * @param amount number of slots to free
+     */
+    function gasRefund15(uint256 amount) internal {
+        assembly {
+            // get number of free slots
+            let offset := sload(0xfffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // get location of first slot
+            let location := add(offset, 0xfffff)
+            // loop until end is reached
+            for {
+                let end := sub(location, amount)
+            } gt(location, end) {
+                location := sub(location, 1)
+            } {
+                // set storage location to zero
+                // this refunds 15,000 gas
+                sstore(location, 0)
+            }
+            // store new number of free slots
+            sstore(0xfffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev use smart contract self-destruct to refund gas
+     * will refund 39,000 * amount gas
+     */
+    function gasRefund39(uint256 amount) internal {
+        assembly {
+            // get amount of gas slots
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // first sheep pointer
+            let location := sub(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, offset)
+            // loop from location to end
+            for {
+                let end := add(location, amount)
+            } lt(location, end) {
+                location := add(location, 1)
+            } {
+                // load sheep address
+                let sheep := sload(location)
+                // call selfdestruct on sheep
+                pop(call(gas(), sheep, 0, 0, 0, 0, 0))
+                // clear sheep address
+                sstore(location, 0)
+            }
+            // store new number of sheep
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev Return the remaining sponsored gas slots
+     */
+    function remainingGasRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xfffff)
+        }
+    }
+
+    /**
+     * @dev Return the remaining sheep slots
+     */
+    function remainingSheepRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrencyWithGasRefund.sol
+
+// pragma solidity 0.6.10;
+
+// import {GasRefund} from "contracts/true-currencies/common/GasRefund.sol";
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+abstract contract TrueCurrencyWithGasRefund is GasRefund, TrueCurrency {
+    /**
+     * @dev reclaim gas from legacy gas refund #1
+     * will refund 15,000 * amount gas to sender (minus exection cost)
+     * If gas pool is empty, refund 39,000 * amount gas by calling selfdestruct
+     */
+    function refundGas(uint256 amount) external onlyOwner {
+        if (remainingGasRefundPool() > 0) {
+            gasRefund15(amount);
+        } else {
+            gasRefund39(amount.div(3));
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TokenController.sol
+
+// pragma solidity 0.6.10;
+
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IOwnedUpgradeabilityProxy as OwnedUpgradeabilityProxy} from "contracts/proxy/interface/IOwnedUpgradeabilityProxy.sol";
+
+// import {IRegistry as Registry} from "contracts/registry/interface/IRegistry.sol";
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+// import {IHasOwner as HasOwner} from "contracts/true-currencies/interface/IHasOwner.sol";
+// import {IHook as Hook} from "contracts/true-currencies/interface/IHook.sol";
+// import {ITrueCurrency as TrueCurrency} from "contracts/true-currencies/interface/ITrueCurrency.sol";
+
+// import {TrueCurrencyWithGasRefund} from "contracts/true-currencies/TrueCurrencyWithGasRefund.sol";
+
+/** @title TokenController
+ * @dev This contract allows us to split ownership of the TrueCurrency contract
+ * into two addresses. One, called the "owner" address, has unfettered control of the TrueCurrency contract -
+ * it can mint new tokens, transfer ownership of the contract, etc. However to make
+ * extra sure that TrueCurrency is never compromised, this owner key will not be used in
+ * day-to-day operations, allowing it to be stored at a heightened level of security.
+ * Instead, the owner appoints an various "admin" address.
+ * There are 3 different types of admin addresses;  MintKey, MintRatifier, and MintPauser.
+ * MintKey can request and revoke mints one at a time.
+ * MintPausers can pause individual mints or pause all mints.
+ * MintRatifiers can approve and finalize mints with enough approval.
+
+ * There are three levels of mints: instant mint, ratified mint, and multiSig mint. Each have a different threshold
+ * and deduct from a different pool.
+ * Instant mint has the lowest threshold and finalizes instantly without any ratifiers. Deduct from instant mint pool,
+ * which can be refilled by one ratifier.
+ * Ratify mint has the second lowest threshold and finalizes with one ratifier approval. Deduct from ratify mint pool,
+ * which can be refilled by three ratifiers.
+ * MultiSig mint has the highest threshold and finalizes with three ratifier approvals. Deduct from multiSig mint pool,
+ * which can only be refilled by the owner.
+*/
+
+contract TokenController {
+    using SafeMath for uint256;
+
+    struct MintOperation {
+        address to;
+        uint256 value;
+        uint256 requestedBlock;
+        uint256 numberOfApproval;
+        bool paused;
+        mapping(address => bool) approved;
+    }
+
+    address payable public owner;
+    address payable public pendingOwner;
+
+    bool public initialized;
+
+    uint256 public instantMintThreshold;
+    uint256 public ratifiedMintThreshold;
+    uint256 public multiSigMintThreshold;
+
+    uint256 public instantMintLimit;
+    uint256 public ratifiedMintLimit;
+    uint256 public multiSigMintLimit;
+
+    uint256 public instantMintPool;
+    uint256 public ratifiedMintPool;
+    uint256 public multiSigMintPool;
+    address[2] public ratifiedPoolRefillApprovals;
+
+    uint8 public constant RATIFY_MINT_SIGS = 1; //number of approvals needed to finalize a Ratified Mint
+    uint8 public constant MULTISIG_MINT_SIGS = 3; //number of approvals needed to finalize a MultiSig Mint
+
+    bool public mintPaused;
+    uint256 public mintReqInvalidBeforeThisBlock; //all mint request before this block are invalid
+    address public mintKey;
+    MintOperation[] public mintOperations; //list of a mint requests
+
+    TrueCurrency public token;
+    Registry public registry;
+    address public registryAdmin;
+    address public gasRefunder;
+
+    // Registry attributes for admin keys
+    bytes32 public constant IS_MINT_PAUSER = "isTUSDMintPausers";
+    bytes32 public constant IS_MINT_RATIFIER = "isTUSDMintRatifier";
+    bytes32 public constant IS_REDEMPTION_ADMIN = "isTUSDRedemptionAdmin";
+
+    // paused version of TrueCurrency in Production
+    // pausing the contract upgrades the proxy to this implementation
+    address public constant PAUSED_IMPLEMENTATION = 0x3c8984DCE8f68FCDEEEafD9E0eca3598562eD291;
+
+    modifier onlyMintKeyOrOwner() {
+        require(msg.sender == mintKey || msg.sender == owner, "must be mintKey or owner");
+        _;
+    }
+
+    modifier onlyMintPauserOrOwner() {
+        require(registry.hasAttribute(msg.sender, IS_MINT_PAUSER) || msg.sender == owner, "must be pauser or owner");
+        _;
+    }
+
+    modifier onlyMintRatifierOrOwner() {
+        require(registry.hasAttribute(msg.sender, IS_MINT_RATIFIER) || msg.sender == owner, "must be ratifier or owner");
+        _;
+    }
+
+    modifier onlyOwnerOrRedemptionAdmin() {
+        require(registry.hasAttribute(msg.sender, IS_REDEMPTION_ADMIN) || msg.sender == owner, "must be Redemption admin or owner");
+        _;
+    }
+
+    modifier onlyGasRefunder() {
+        require(msg.sender == gasRefunder || msg.sender == owner, "must be gas refunder or owner");
+        _;
+    }
+
+    modifier onlyRegistryAdmin() {
+        require(msg.sender == registryAdmin || msg.sender == owner, "must be registry admin or owner");
+        _;
+    }
+
+    //mint operations by the mintkey cannot be processed on when mints are paused
+    modifier mintNotPaused() {
+        if (msg.sender != owner) {
+            require(!mintPaused, "minting is paused");
+        }
+        _;
+    }
+    /// @dev Emitted when ownership of controller was transferred
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    /// @dev Emitted when ownership of controller transfer procedure was started
+    event NewOwnerPending(address indexed currentOwner, address indexed pendingOwner);
+    /// @dev Emitted when new registry was set
+    event SetRegistry(address indexed registry);
+    /// @dev Emitted when owner was transferred for child contract
+    event TransferChild(address indexed child, address indexed newOwner);
+    /// @dev Emitted when child ownership was claimed
+    event RequestReclaimContract(address indexed other);
+    /// @dev Emitted when child token was changed
+    event SetToken(TrueCurrency newContract);
+    /// @dev Emitted when canBurn status of the `burner` was changed to `canBurn`
+    event CanBurn(address burner, bool canBurn);
+
+    /// @dev Emitted when mint was requested
+    event RequestMint(address indexed to, uint256 indexed value, uint256 opIndex, address mintKey);
+    /// @dev Emitted when mint was finalized
+    event FinalizeMint(address indexed to, uint256 indexed value, uint256 opIndex, address mintKey);
+    /// @dev Emitted on instant mint
+    event InstantMint(address indexed to, uint256 indexed value, address indexed mintKey);
+
+    /// @dev Emitted when mint key was replaced
+    event TransferMintKey(address indexed previousMintKey, address indexed newMintKey);
+    /// @dev Emitted when mint was ratified
+    event MintRatified(uint256 indexed opIndex, address indexed ratifier);
+    /// @dev Emitted when mint is revoked
+    event RevokeMint(uint256 opIndex);
+    /// @dev Emitted when all mining is paused (status=true) or unpaused (status=false)
+    event AllMintsPaused(bool status);
+    /// @dev Emitted when opIndex mint is paused (status=true) or unpaused (status=false)
+    event MintPaused(uint256 opIndex, bool status);
+    /// @dev Emitted when mint is approved
+    event MintApproved(address approver, uint256 opIndex);
+    /// @dev Emitted when fast pause contract is changed
+    event FastPauseSet(address _newFastPause);
+
+    /// @dev Emitted when mint threshold changes
+    event MintThresholdChanged(uint256 instant, uint256 ratified, uint256 multiSig);
+    /// @dev Emitted when mint limits change
+    event MintLimitsChanged(uint256 instant, uint256 ratified, uint256 multiSig);
+    /// @dev Emitted when instant mint pool is refilled
+    event InstantPoolRefilled();
+    /// @dev Emitted when instant mint pool is ratified
+    event RatifyPoolRefilled();
+    /// @dev Emitted when multisig mint pool is ratified
+    event MultiSigPoolRefilled();
+
+    /*
+    ========================================
+    Ownership functions
+    ========================================
+    */
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address payable newOwner) external onlyOwner {
+        pendingOwner = newOwner;
+        emit NewOwnerPending(address(owner), address(pendingOwner));
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() external onlyPendingOwner {
+        emit OwnershipTransferred(address(owner), address(pendingOwner));
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+
+    /*
+    ========================================
+    proxy functions
+    ========================================
+    */
+
+    function transferTrueCurrencyProxyOwnership(address _newOwner) external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).transferProxyOwnership(_newOwner);
+    }
+
+    function claimTrueCurrencyProxyOwnership() external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).claimProxyOwnership();
+    }
+
+    function upgradeTrueCurrencyProxyImplTo(address _implementation) external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(_implementation);
+    }
+
+    /*
+    ========================================
+    Minting functions
+    ========================================
+    */
+
+    /**
+     * @dev set the threshold for a mint to be considered an instant mint,
+     * ratify mint and multiSig mint. Instant mint requires no approval,
+     * ratify mint requires 1 approval and multiSig mint requires 3 approvals
+     */
+    function setMintThresholds(
+        uint256 _instant,
+        uint256 _ratified,
+        uint256 _multiSig
+    ) external onlyOwner {
+        require(_instant <= _ratified && _ratified <= _multiSig);
+        instantMintThreshold = _instant;
+        ratifiedMintThreshold = _ratified;
+        multiSigMintThreshold = _multiSig;
+        emit MintThresholdChanged(_instant, _ratified, _multiSig);
+    }
+
+    /**
+     * @dev set the limit of each mint pool. For example can only instant mint up to the instant mint pool limit
+     * before needing to refill
+     */
+    function setMintLimits(
+        uint256 _instant,
+        uint256 _ratified,
+        uint256 _multiSig
+    ) external onlyOwner {
+        require(_instant <= _ratified && _ratified <= _multiSig);
+        instantMintLimit = _instant;
+        if (instantMintPool > instantMintLimit) {
+            instantMintPool = instantMintLimit;
+        }
+        ratifiedMintLimit = _ratified;
+        if (ratifiedMintPool > ratifiedMintLimit) {
+            ratifiedMintPool = ratifiedMintLimit;
+        }
+        multiSigMintLimit = _multiSig;
+        if (multiSigMintPool > multiSigMintLimit) {
+            multiSigMintPool = multiSigMintLimit;
+        }
+        emit MintLimitsChanged(_instant, _ratified, _multiSig);
+    }
+
+    /**
+     * @dev Ratifier can refill instant mint pool
+     */
+    function refillInstantMintPool() external onlyMintRatifierOrOwner {
+        ratifiedMintPool = ratifiedMintPool.sub(instantMintLimit.sub(instantMintPool));
+        instantMintPool = instantMintLimit;
+        emit InstantPoolRefilled();
+    }
+
+    /**
+     * @dev Owner or 3 ratifiers can refill Ratified Mint Pool
+     */
+    function refillRatifiedMintPool() external onlyMintRatifierOrOwner {
+        if (msg.sender != owner) {
+            address[2] memory refillApprovals = ratifiedPoolRefillApprovals;
+            require(msg.sender != refillApprovals[0] && msg.sender != refillApprovals[1]);
+            if (refillApprovals[0] == address(0)) {
+                ratifiedPoolRefillApprovals[0] = msg.sender;
+                return;
+            }
+            if (refillApprovals[1] == address(0)) {
+                ratifiedPoolRefillApprovals[1] = msg.sender;
+                return;
+            }
+        }
+        delete ratifiedPoolRefillApprovals; // clears the whole array
+        multiSigMintPool = multiSigMintPool.sub(ratifiedMintLimit.sub(ratifiedMintPool));
+        ratifiedMintPool = ratifiedMintLimit;
+        emit RatifyPoolRefilled();
+    }
+
+    /**
+     * @dev Owner can refill MultiSig Mint Pool
+     */
+    function refillMultiSigMintPool() external onlyOwner {
+        multiSigMintPool = multiSigMintLimit;
+        emit MultiSigPoolRefilled();
+    }
+
+    /**
+     * @dev mintKey initiates a request to mint _value for account _to
+     * @param _to the address to mint to
+     * @param _value the amount requested
+     */
+    function requestMint(address _to, uint256 _value) external mintNotPaused onlyMintKeyOrOwner {
+        MintOperation memory op = MintOperation(_to, _value, block.number, 0, false);
+        emit RequestMint(_to, _value, mintOperations.length, msg.sender);
+        mintOperations.push(op);
+    }
+
+    /**
+     * @dev Instant mint without ratification if the amount is less
+     * than instantMintThreshold and instantMintPool
+     * @param _to the address to mint to
+     * @param _value the amount minted
+     */
+    function instantMint(address _to, uint256 _value) external mintNotPaused onlyMintKeyOrOwner {
+        require(_value <= instantMintThreshold, "over the instant mint threshold");
+        require(_value <= instantMintPool, "instant mint pool is dry");
+        instantMintPool = instantMintPool.sub(_value);
+        emit InstantMint(_to, _value, msg.sender);
+        token.mint(_to, _value);
+    }
+
+    /**
+     * @dev ratifier ratifies a request mint. If the number of
+     * ratifiers that signed off is greater than the number of
+     * approvals required, the request is finalized
+     * @param _index the index of the requestMint to ratify
+     * @param _to the address to mint to
+     * @param _value the amount requested
+     */
+    function ratifyMint(
+        uint256 _index,
+        address _to,
+        uint256 _value
+    ) external mintNotPaused onlyMintRatifierOrOwner {
+        MintOperation memory op = mintOperations[_index];
+        require(op.to == _to, "to address does not match");
+        require(op.value == _value, "amount does not match");
+        require(!mintOperations[_index].approved[msg.sender], "already approved");
+        mintOperations[_index].approved[msg.sender] = true;
+        mintOperations[_index].numberOfApproval = mintOperations[_index].numberOfApproval.add(1);
+        emit MintRatified(_index, msg.sender);
+        if (hasEnoughApproval(mintOperations[_index].numberOfApproval, _value)) {
+            finalizeMint(_index);
+        }
+    }
+
+    /**
+     * @dev finalize a mint request, mint the amount requested to the specified address
+     * @param _index of the request (visible in the RequestMint event accompanying the original request)
+     */
+    function finalizeMint(uint256 _index) public mintNotPaused {
+        MintOperation memory op = mintOperations[_index];
+        address to = op.to;
+        uint256 value = op.value;
+        if (msg.sender != owner) {
+            require(canFinalize(_index));
+            _subtractFromMintPool(value);
+        }
+        delete mintOperations[_index];
+        token.mint(to, value);
+        emit FinalizeMint(to, value, _index, msg.sender);
+    }
+
+    /**
+     * assumption: only invoked when canFinalize
+     */
+    function _subtractFromMintPool(uint256 _value) internal {
+        if (_value <= ratifiedMintPool && _value <= ratifiedMintThreshold) {
+            ratifiedMintPool = ratifiedMintPool.sub(_value);
+        } else {
+            multiSigMintPool = multiSigMintPool.sub(_value);
+        }
+    }
+
+    /**
+     * @dev compute if the number of approvals is enough for a given mint amount
+     */
+    function hasEnoughApproval(uint256 _numberOfApproval, uint256 _value) public view returns (bool) {
+        if (_value <= ratifiedMintPool && _value <= ratifiedMintThreshold) {
+            if (_numberOfApproval >= RATIFY_MINT_SIGS) {
+                return true;
+            }
+        }
+        if (_value <= multiSigMintPool && _value <= multiSigMintThreshold) {
+            if (_numberOfApproval >= MULTISIG_MINT_SIGS) {
+                return true;
+            }
+        }
+        if (msg.sender == owner) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @dev compute if a mint request meets all the requirements to be finalized
+     * utility function for a front end
+     */
+    function canFinalize(uint256 _index) public view returns (bool) {
+        MintOperation memory op = mintOperations[_index];
+        require(op.requestedBlock > mintReqInvalidBeforeThisBlock, "this mint is invalid"); //also checks if request still exists
+        require(!op.paused, "this mint is paused");
+        require(hasEnoughApproval(op.numberOfApproval, op.value), "not enough approvals");
+        return true;
+    }
+
+    /**
+     * @dev revoke a mint request, Delete the mintOperation
+     * @param _index of the request (visible in the RequestMint event accompanying the original request)
+     */
+    function revokeMint(uint256 _index) external onlyMintKeyOrOwner {
+        delete mintOperations[_index];
+        emit RevokeMint(_index);
+    }
+
+    /**
+     * @dev get mint operatino count
+     * @return mint operation count
+     */
+    function mintOperationCount() public view returns (uint256) {
+        return mintOperations.length;
+    }
+
+    /*
+    ========================================
+    Key management
+    ========================================
+    */
+
+    /**
+     * @dev Replace the current mintkey with new mintkey
+     * @param _newMintKey address of the new mintKey
+     */
+    function transferMintKey(address _newMintKey) external onlyOwner {
+        require(_newMintKey != address(0), "new mint key cannot be 0x0");
+        emit TransferMintKey(mintKey, _newMintKey);
+        mintKey = _newMintKey;
+    }
+
+    function setGasRefunder(address refunder) external onlyOwner {
+        gasRefunder = refunder;
+    }
+
+    function setRegistryAdmin(address admin) external onlyOwner {
+        registryAdmin = admin;
+    }
+
+    /*
+    ========================================
+    Mint Pausing
+    ========================================
+    */
+
+    /**
+     * @dev invalidates all mint request initiated before the current block
+     */
+    function invalidateAllPendingMints() external onlyOwner {
+        mintReqInvalidBeforeThisBlock = block.number;
+    }
+
+    /**
+     * @dev pause any further mint request and mint finalizations
+     */
+    function pauseMints() external onlyMintPauserOrOwner {
+        mintPaused = true;
+        emit AllMintsPaused(true);
+    }
+
+    /**
+     * @dev unpause any further mint request and mint finalizations
+     */
+    function unpauseMints() external onlyOwner {
+        mintPaused = false;
+        emit AllMintsPaused(false);
+    }
+
+    /**
+     * @dev pause a specific mint request
+     * @param  _opIndex the index of the mint request the caller wants to pause
+     */
+    function pauseMint(uint256 _opIndex) external onlyMintPauserOrOwner {
+        mintOperations[_opIndex].paused = true;
+        emit MintPaused(_opIndex, true);
+    }
+
+    /**
+     * @dev unpause a specific mint request
+     * @param  _opIndex the index of the mint request the caller wants to unpause
+     */
+    function unpauseMint(uint256 _opIndex) external onlyOwner {
+        mintOperations[_opIndex].paused = false;
+        emit MintPaused(_opIndex, false);
+    }
+
+    /*
+    ========================================
+    set and claim contracts, administrative
+    ========================================
+    */
+
+    /**
+     * @dev Update this contract's token pointer to newContract (e.g. if the
+     * contract is upgraded)
+     */
+    function setToken(TrueCurrency _newContract) external onlyOwner {
+        token = _newContract;
+        emit SetToken(_newContract);
+    }
+
+    /**
+     * @dev Update this contract's registry pointer to _registry
+     */
+    function setRegistry(Registry _registry) external onlyOwner {
+        registry = _registry;
+        emit SetRegistry(address(registry));
+    }
+
+    /**
+     * @dev Claim ownership of an arbitrary HasOwner contract
+     */
+    function issueClaimOwnership(address _other) public onlyOwner {
+        HasOwner other = HasOwner(_other);
+        other.claimOwnership();
+    }
+
+    /**
+     * @dev Transfer ownership of _child to _newOwner.
+     * Can be used e.g. to upgrade this TokenController contract.
+     * @param _child contract that tokenController currently Owns
+     * @param _newOwner new owner/pending owner of _child
+     */
+    function transferChild(HasOwner _child, address _newOwner) external onlyOwner {
+        _child.transferOwnership(_newOwner);
+        emit TransferChild(address(_child), _newOwner);
+    }
+
+    /**
+     * @dev send all ether in token address to the owner of tokenController
+     */
+    function requestReclaimEther() external onlyOwner {
+        token.reclaimEther(owner);
+    }
+
+    /**
+     * @dev transfer all tokens of a particular type in token address to the
+     * owner of tokenController
+     * @param _token token address of the token to transfer
+     */
+    function requestReclaimToken(IERC20 _token) external onlyOwner {
+        token.reclaimToken(_token, owner);
+    }
+
+    /**
+     * @dev pause all pausable actions on TrueCurrency, mints/burn/transfer/approve
+     */
+    function pauseToken() external virtual onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(PAUSED_IMPLEMENTATION);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amounts that TrueCurrency users can
+     * burn to newMin and newMax
+     * @param _min minimum amount user can burn at a time
+     * @param _max maximum amount user can burn at a time
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        token.setBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Owner can send ether balance in contract address
+     * @param _to address to which the funds will be send to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev Owner can send erc20 token balance in contract address
+     * @param _token address of the token to send
+     * @param _to address to which the funds will be send to
+     */
+    function reclaimToken(IERC20 _token, address _to) external onlyOwner {
+        uint256 balance = _token.balanceOf(address(this));
+        _token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Owner can allow address to burn tokens
+     * @param burner address of the token that can burn
+     * @param canBurn true if account is allowed to burn, false otherwise
+     */
+    function setCanBurn(address burner, bool canBurn) external onlyRegistryAdmin {
+        token.setCanBurn(burner, canBurn);
+        emit CanBurn(burner, canBurn);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param isBlacklisted blacklist flag value
+     */
+    function setBlacklisted(address account, bool isBlacklisted) external onlyRegistryAdmin {
+        token.setBlacklisted(account, isBlacklisted);
+    }
+
+    /**
+     * Call hook in `hookContract` with gas refund
+     */
+    function refundGasWithHook(Hook hookContract) external onlyGasRefunder {
+        // calculate start gas amount
+        uint256 startGas = gasleft();
+        // call hook
+        hookContract.hook();
+        // calculate gas used
+        uint256 gasUsed = startGas.sub(gasleft());
+        // 1 refund = 15,000 gas. EVM refunds maximum half of used gas, so divide by 2.
+        // Add 20% to compensate inter contract communication
+        // (x + 20%) / 2 / 15000 = x / 25000
+        token.refundGas(gasUsed.div(25000));
+    }
+}
+
+
+// Root file: contracts/true-currencies/mocks/TokenControllerMock.sol
+
+pragma solidity 0.6.10;
+
+// import {IOwnedUpgradeabilityProxy as OwnedUpgradeabilityProxy} from "contracts/proxy/interface/IOwnedUpgradeabilityProxy.sol";
+// import {IRegistry as Registry} from "contracts/registry/interface/IRegistry.sol";
+
+// import {ITrueCurrency as TrueCurrency} from "contracts/true-currencies/interface/ITrueCurrency.sol";
+
+// import {TokenController} from "contracts/true-currencies/TokenController.sol";
+
+/**
+ * Token Controller with custom init function for testing
+ */
+contract TokenControllerMock is TokenController {
+    // initalize controller. useful for tests
+    function initialize() external {
+        require(!initialized, "already initialized");
+        owner = msg.sender;
+        initialized = true;
+    }
+
+    // initialize with paramaters. useful for tests
+    // sets initial paramaters on testnet
+    function initializeWithParams(TrueCurrency _token, Registry _registry) external {
+        require(!initialized, "already initialized");
+        owner = msg.sender;
+        initialized = true;
+        token = _token;
+        emit SetToken(_token);
+        registry = _registry;
+        emit SetRegistry(address(_registry));
+        gasRefunder = owner;
+        registryAdmin = owner;
+        // set mint limits & thresholds
+        // instant = 1M, ratified = 10M, multisig = 100M
+        uint256 instant = 1000000000000000000000000;
+        uint256 ratified = 10000000000000000000000000;
+        uint256 multiSig = 100000000000000000000000000;
+        instantMintThreshold = instant;
+        ratifiedMintThreshold = ratified;
+        multiSigMintThreshold = multiSig;
+        instantMintLimit = instant;
+        ratifiedMintLimit = ratified;
+        multiSigMintLimit = multiSig;
+        instantMintPool = instant;
+        ratifiedMintPool = ratified;
+        multiSigMintPool = multiSig;
+        emit MintThresholdChanged(instant, ratified, multiSig);
+        emit MintLimitsChanged(instant, ratified, multiSig);
+        emit InstantPoolRefilled();
+        emit RatifyPoolRefilled();
+        emit MultiSigPoolRefilled();
+    }
+}
+
+contract TokenControllerPauseMock is TokenControllerMock {
+    address public pausedImplementation;
+
+    function setPausedImplementation(address _pausedToken) external {
+        pausedImplementation = _pausedToken;
+    }
+
+    /**
+     *@dev pause all pausable actions on TrueUSD, mints/burn/transfer/approve
+     */
+    function pauseToken() external override onlyOwner {
+        OwnedUpgradeabilityProxy(uint160(address(token))).upgradeTo(pausedImplementation);
+    }
+}

--- a/flatten/TokenFaucet.sol
+++ b/flatten/TokenFaucet.sol
@@ -1,0 +1,2181 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/proxy/interface/IOwnedUpgradeabilityProxy.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+interface IOwnedUpgradeabilityProxy {
+    function proxyOwner() external view returns (address owner);
+
+    function pendingProxyOwner() external view returns (address pendingOwner);
+
+    function transferProxyOwnership(address newOwner) external;
+
+    function claimProxyOwnership() external;
+
+    function upgradeTo(address implementation) external;
+
+    function implementation() external view returns (address impl);
+}
+
+
+// Dependency file: contracts/registry/interface/IHasOwner.sol
+
+// pragma solidity 0.6.10;
+
+interface IHasOwner {
+    function claimOwnership() external;
+
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IReclaimerToken {
+    function reclaimToken(IERC20 token, address _to) external;
+
+    function reclaimEther(address payable _to) external;
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IHasOwner} from "contracts/registry/interface/IHasOwner.sol";
+// import {IRegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+// import {IReclaimerToken} from "contracts/true-currencies/interface/IReclaimerToken.sol";
+
+interface IRegistry is IHasOwner, IReclaimerToken {
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) external;
+
+    function subscribe(bytes32 _attribute, IRegistryClone _syncer) external;
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external;
+
+    function subscriberCount(bytes32 _attribute) external view returns (uint256);
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+
+    function hasAttribute(address _who, bytes32 _attribute) external view returns (bool);
+
+    function getAttribute(address _who, bytes32 _attribute)
+        external
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        );
+
+    function getAttributeValue(address _who, bytes32 _attribute) external view returns (uint256);
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) external view returns (address);
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) external view returns (uint256);
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external;
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IHasOwner.sol
+
+// pragma solidity 0.6.10;
+
+interface IHasOwner {
+    function claimOwnership() external;
+
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/true-currencies/interface/ITrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IHasOwner} from "contracts/true-currencies/interface/IHasOwner.sol";
+// import {IReclaimerToken} from "contracts/true-currencies/interface/IReclaimerToken.sol";
+
+interface ITrueCurrency is IERC20, IReclaimerToken, IHasOwner {
+    function refundGas(uint256 amount) external;
+
+    function setBlacklisted(address account, bool _isBlacklisted) external;
+
+    function setCanBurn(address account, bool _canBurn) external;
+
+    function setBurnBounds(uint256 _min, uint256 _max) external;
+
+    function mint(address account, uint256 amount) external;
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/interface/IHook.sol
+
+// pragma solidity 0.6.10;
+
+interface IHook {
+    function hook() external;
+}
+
+
+// Dependency file: contracts/true-currencies/common/GasRefund.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Gas Reclaim Legacy
+ *
+ * Note: this contract does not affect any of the token logic. It merely
+ * exists so the TokenController (owner) can reclaim the sponsored gas
+ *
+ * Previously TrueCurrency has a feature called "gas boost" which allowed
+ * us to sponsor gas by setting non-empty storage slots to 1.
+ * We are depricating this feature, but there is a bunch of gas saved
+ * from years of sponsoring gas. This contract is meant to allow the owner
+ * to take advantage of this leftover gas. Once all the slots are used,
+ * this contract can be removed from TrueCurrency.
+ *
+ * Utilitzes the gas refund mechanism in EVM. Each time an non-empty
+ * storage slot is set to 0, evm will refund 15,000 to the sender.
+ * Also utilized the refund for selfdestruct, see gasRefund39
+ */
+abstract contract GasRefund {
+    /**
+     * @dev Refund 15,000 gas per slot.
+     * @param amount number of slots to free
+     */
+    function gasRefund15(uint256 amount) internal {
+        assembly {
+            // get number of free slots
+            let offset := sload(0xfffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // get location of first slot
+            let location := add(offset, 0xfffff)
+            // loop until end is reached
+            for {
+                let end := sub(location, amount)
+            } gt(location, end) {
+                location := sub(location, 1)
+            } {
+                // set storage location to zero
+                // this refunds 15,000 gas
+                sstore(location, 0)
+            }
+            // store new number of free slots
+            sstore(0xfffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev use smart contract self-destruct to refund gas
+     * will refund 39,000 * amount gas
+     */
+    function gasRefund39(uint256 amount) internal {
+        assembly {
+            // get amount of gas slots
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // first sheep pointer
+            let location := sub(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, offset)
+            // loop from location to end
+            for {
+                let end := add(location, amount)
+            } lt(location, end) {
+                location := add(location, 1)
+            } {
+                // load sheep address
+                let sheep := sload(location)
+                // call selfdestruct on sheep
+                pop(call(gas(), sheep, 0, 0, 0, 0, 0))
+                // clear sheep address
+                sstore(location, 0)
+            }
+            // store new number of sheep
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev Return the remaining sponsored gas slots
+     */
+    function remainingGasRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xfffff)
+        }
+    }
+
+    /**
+     * @dev Return the remaining sheep slots
+     */
+    function remainingSheepRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrencyWithGasRefund.sol
+
+// pragma solidity 0.6.10;
+
+// import {GasRefund} from "contracts/true-currencies/common/GasRefund.sol";
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+abstract contract TrueCurrencyWithGasRefund is GasRefund, TrueCurrency {
+    /**
+     * @dev reclaim gas from legacy gas refund #1
+     * will refund 15,000 * amount gas to sender (minus exection cost)
+     * If gas pool is empty, refund 39,000 * amount gas by calling selfdestruct
+     */
+    function refundGas(uint256 amount) external onlyOwner {
+        if (remainingGasRefundPool() > 0) {
+            gasRefund15(amount);
+        } else {
+            gasRefund39(amount.div(3));
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TokenController.sol
+
+// pragma solidity 0.6.10;
+
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IOwnedUpgradeabilityProxy as OwnedUpgradeabilityProxy} from "contracts/proxy/interface/IOwnedUpgradeabilityProxy.sol";
+
+// import {IRegistry as Registry} from "contracts/registry/interface/IRegistry.sol";
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+// import {IHasOwner as HasOwner} from "contracts/true-currencies/interface/IHasOwner.sol";
+// import {IHook as Hook} from "contracts/true-currencies/interface/IHook.sol";
+// import {ITrueCurrency as TrueCurrency} from "contracts/true-currencies/interface/ITrueCurrency.sol";
+
+// import {TrueCurrencyWithGasRefund} from "contracts/true-currencies/TrueCurrencyWithGasRefund.sol";
+
+/** @title TokenController
+ * @dev This contract allows us to split ownership of the TrueCurrency contract
+ * into two addresses. One, called the "owner" address, has unfettered control of the TrueCurrency contract -
+ * it can mint new tokens, transfer ownership of the contract, etc. However to make
+ * extra sure that TrueCurrency is never compromised, this owner key will not be used in
+ * day-to-day operations, allowing it to be stored at a heightened level of security.
+ * Instead, the owner appoints an various "admin" address.
+ * There are 3 different types of admin addresses;  MintKey, MintRatifier, and MintPauser.
+ * MintKey can request and revoke mints one at a time.
+ * MintPausers can pause individual mints or pause all mints.
+ * MintRatifiers can approve and finalize mints with enough approval.
+
+ * There are three levels of mints: instant mint, ratified mint, and multiSig mint. Each have a different threshold
+ * and deduct from a different pool.
+ * Instant mint has the lowest threshold and finalizes instantly without any ratifiers. Deduct from instant mint pool,
+ * which can be refilled by one ratifier.
+ * Ratify mint has the second lowest threshold and finalizes with one ratifier approval. Deduct from ratify mint pool,
+ * which can be refilled by three ratifiers.
+ * MultiSig mint has the highest threshold and finalizes with three ratifier approvals. Deduct from multiSig mint pool,
+ * which can only be refilled by the owner.
+*/
+
+contract TokenController {
+    using SafeMath for uint256;
+
+    struct MintOperation {
+        address to;
+        uint256 value;
+        uint256 requestedBlock;
+        uint256 numberOfApproval;
+        bool paused;
+        mapping(address => bool) approved;
+    }
+
+    address payable public owner;
+    address payable public pendingOwner;
+
+    bool public initialized;
+
+    uint256 public instantMintThreshold;
+    uint256 public ratifiedMintThreshold;
+    uint256 public multiSigMintThreshold;
+
+    uint256 public instantMintLimit;
+    uint256 public ratifiedMintLimit;
+    uint256 public multiSigMintLimit;
+
+    uint256 public instantMintPool;
+    uint256 public ratifiedMintPool;
+    uint256 public multiSigMintPool;
+    address[2] public ratifiedPoolRefillApprovals;
+
+    uint8 public constant RATIFY_MINT_SIGS = 1; //number of approvals needed to finalize a Ratified Mint
+    uint8 public constant MULTISIG_MINT_SIGS = 3; //number of approvals needed to finalize a MultiSig Mint
+
+    bool public mintPaused;
+    uint256 public mintReqInvalidBeforeThisBlock; //all mint request before this block are invalid
+    address public mintKey;
+    MintOperation[] public mintOperations; //list of a mint requests
+
+    TrueCurrency public token;
+    Registry public registry;
+    address public registryAdmin;
+    address public gasRefunder;
+
+    // Registry attributes for admin keys
+    bytes32 public constant IS_MINT_PAUSER = "isTUSDMintPausers";
+    bytes32 public constant IS_MINT_RATIFIER = "isTUSDMintRatifier";
+    bytes32 public constant IS_REDEMPTION_ADMIN = "isTUSDRedemptionAdmin";
+
+    // paused version of TrueCurrency in Production
+    // pausing the contract upgrades the proxy to this implementation
+    address public constant PAUSED_IMPLEMENTATION = 0x3c8984DCE8f68FCDEEEafD9E0eca3598562eD291;
+
+    modifier onlyMintKeyOrOwner() {
+        require(msg.sender == mintKey || msg.sender == owner, "must be mintKey or owner");
+        _;
+    }
+
+    modifier onlyMintPauserOrOwner() {
+        require(registry.hasAttribute(msg.sender, IS_MINT_PAUSER) || msg.sender == owner, "must be pauser or owner");
+        _;
+    }
+
+    modifier onlyMintRatifierOrOwner() {
+        require(registry.hasAttribute(msg.sender, IS_MINT_RATIFIER) || msg.sender == owner, "must be ratifier or owner");
+        _;
+    }
+
+    modifier onlyOwnerOrRedemptionAdmin() {
+        require(registry.hasAttribute(msg.sender, IS_REDEMPTION_ADMIN) || msg.sender == owner, "must be Redemption admin or owner");
+        _;
+    }
+
+    modifier onlyGasRefunder() {
+        require(msg.sender == gasRefunder || msg.sender == owner, "must be gas refunder or owner");
+        _;
+    }
+
+    modifier onlyRegistryAdmin() {
+        require(msg.sender == registryAdmin || msg.sender == owner, "must be registry admin or owner");
+        _;
+    }
+
+    //mint operations by the mintkey cannot be processed on when mints are paused
+    modifier mintNotPaused() {
+        if (msg.sender != owner) {
+            require(!mintPaused, "minting is paused");
+        }
+        _;
+    }
+    /// @dev Emitted when ownership of controller was transferred
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    /// @dev Emitted when ownership of controller transfer procedure was started
+    event NewOwnerPending(address indexed currentOwner, address indexed pendingOwner);
+    /// @dev Emitted when new registry was set
+    event SetRegistry(address indexed registry);
+    /// @dev Emitted when owner was transferred for child contract
+    event TransferChild(address indexed child, address indexed newOwner);
+    /// @dev Emitted when child ownership was claimed
+    event RequestReclaimContract(address indexed other);
+    /// @dev Emitted when child token was changed
+    event SetToken(TrueCurrency newContract);
+    /// @dev Emitted when canBurn status of the `burner` was changed to `canBurn`
+    event CanBurn(address burner, bool canBurn);
+
+    /// @dev Emitted when mint was requested
+    event RequestMint(address indexed to, uint256 indexed value, uint256 opIndex, address mintKey);
+    /// @dev Emitted when mint was finalized
+    event FinalizeMint(address indexed to, uint256 indexed value, uint256 opIndex, address mintKey);
+    /// @dev Emitted on instant mint
+    event InstantMint(address indexed to, uint256 indexed value, address indexed mintKey);
+
+    /// @dev Emitted when mint key was replaced
+    event TransferMintKey(address indexed previousMintKey, address indexed newMintKey);
+    /// @dev Emitted when mint was ratified
+    event MintRatified(uint256 indexed opIndex, address indexed ratifier);
+    /// @dev Emitted when mint is revoked
+    event RevokeMint(uint256 opIndex);
+    /// @dev Emitted when all mining is paused (status=true) or unpaused (status=false)
+    event AllMintsPaused(bool status);
+    /// @dev Emitted when opIndex mint is paused (status=true) or unpaused (status=false)
+    event MintPaused(uint256 opIndex, bool status);
+    /// @dev Emitted when mint is approved
+    event MintApproved(address approver, uint256 opIndex);
+    /// @dev Emitted when fast pause contract is changed
+    event FastPauseSet(address _newFastPause);
+
+    /// @dev Emitted when mint threshold changes
+    event MintThresholdChanged(uint256 instant, uint256 ratified, uint256 multiSig);
+    /// @dev Emitted when mint limits change
+    event MintLimitsChanged(uint256 instant, uint256 ratified, uint256 multiSig);
+    /// @dev Emitted when instant mint pool is refilled
+    event InstantPoolRefilled();
+    /// @dev Emitted when instant mint pool is ratified
+    event RatifyPoolRefilled();
+    /// @dev Emitted when multisig mint pool is ratified
+    event MultiSigPoolRefilled();
+
+    /*
+    ========================================
+    Ownership functions
+    ========================================
+    */
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address payable newOwner) external onlyOwner {
+        pendingOwner = newOwner;
+        emit NewOwnerPending(address(owner), address(pendingOwner));
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() external onlyPendingOwner {
+        emit OwnershipTransferred(address(owner), address(pendingOwner));
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+
+    /*
+    ========================================
+    proxy functions
+    ========================================
+    */
+
+    function transferTrueCurrencyProxyOwnership(address _newOwner) external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).transferProxyOwnership(_newOwner);
+    }
+
+    function claimTrueCurrencyProxyOwnership() external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).claimProxyOwnership();
+    }
+
+    function upgradeTrueCurrencyProxyImplTo(address _implementation) external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(_implementation);
+    }
+
+    /*
+    ========================================
+    Minting functions
+    ========================================
+    */
+
+    /**
+     * @dev set the threshold for a mint to be considered an instant mint,
+     * ratify mint and multiSig mint. Instant mint requires no approval,
+     * ratify mint requires 1 approval and multiSig mint requires 3 approvals
+     */
+    function setMintThresholds(
+        uint256 _instant,
+        uint256 _ratified,
+        uint256 _multiSig
+    ) external onlyOwner {
+        require(_instant <= _ratified && _ratified <= _multiSig);
+        instantMintThreshold = _instant;
+        ratifiedMintThreshold = _ratified;
+        multiSigMintThreshold = _multiSig;
+        emit MintThresholdChanged(_instant, _ratified, _multiSig);
+    }
+
+    /**
+     * @dev set the limit of each mint pool. For example can only instant mint up to the instant mint pool limit
+     * before needing to refill
+     */
+    function setMintLimits(
+        uint256 _instant,
+        uint256 _ratified,
+        uint256 _multiSig
+    ) external onlyOwner {
+        require(_instant <= _ratified && _ratified <= _multiSig);
+        instantMintLimit = _instant;
+        if (instantMintPool > instantMintLimit) {
+            instantMintPool = instantMintLimit;
+        }
+        ratifiedMintLimit = _ratified;
+        if (ratifiedMintPool > ratifiedMintLimit) {
+            ratifiedMintPool = ratifiedMintLimit;
+        }
+        multiSigMintLimit = _multiSig;
+        if (multiSigMintPool > multiSigMintLimit) {
+            multiSigMintPool = multiSigMintLimit;
+        }
+        emit MintLimitsChanged(_instant, _ratified, _multiSig);
+    }
+
+    /**
+     * @dev Ratifier can refill instant mint pool
+     */
+    function refillInstantMintPool() external onlyMintRatifierOrOwner {
+        ratifiedMintPool = ratifiedMintPool.sub(instantMintLimit.sub(instantMintPool));
+        instantMintPool = instantMintLimit;
+        emit InstantPoolRefilled();
+    }
+
+    /**
+     * @dev Owner or 3 ratifiers can refill Ratified Mint Pool
+     */
+    function refillRatifiedMintPool() external onlyMintRatifierOrOwner {
+        if (msg.sender != owner) {
+            address[2] memory refillApprovals = ratifiedPoolRefillApprovals;
+            require(msg.sender != refillApprovals[0] && msg.sender != refillApprovals[1]);
+            if (refillApprovals[0] == address(0)) {
+                ratifiedPoolRefillApprovals[0] = msg.sender;
+                return;
+            }
+            if (refillApprovals[1] == address(0)) {
+                ratifiedPoolRefillApprovals[1] = msg.sender;
+                return;
+            }
+        }
+        delete ratifiedPoolRefillApprovals; // clears the whole array
+        multiSigMintPool = multiSigMintPool.sub(ratifiedMintLimit.sub(ratifiedMintPool));
+        ratifiedMintPool = ratifiedMintLimit;
+        emit RatifyPoolRefilled();
+    }
+
+    /**
+     * @dev Owner can refill MultiSig Mint Pool
+     */
+    function refillMultiSigMintPool() external onlyOwner {
+        multiSigMintPool = multiSigMintLimit;
+        emit MultiSigPoolRefilled();
+    }
+
+    /**
+     * @dev mintKey initiates a request to mint _value for account _to
+     * @param _to the address to mint to
+     * @param _value the amount requested
+     */
+    function requestMint(address _to, uint256 _value) external mintNotPaused onlyMintKeyOrOwner {
+        MintOperation memory op = MintOperation(_to, _value, block.number, 0, false);
+        emit RequestMint(_to, _value, mintOperations.length, msg.sender);
+        mintOperations.push(op);
+    }
+
+    /**
+     * @dev Instant mint without ratification if the amount is less
+     * than instantMintThreshold and instantMintPool
+     * @param _to the address to mint to
+     * @param _value the amount minted
+     */
+    function instantMint(address _to, uint256 _value) external mintNotPaused onlyMintKeyOrOwner {
+        require(_value <= instantMintThreshold, "over the instant mint threshold");
+        require(_value <= instantMintPool, "instant mint pool is dry");
+        instantMintPool = instantMintPool.sub(_value);
+        emit InstantMint(_to, _value, msg.sender);
+        token.mint(_to, _value);
+    }
+
+    /**
+     * @dev ratifier ratifies a request mint. If the number of
+     * ratifiers that signed off is greater than the number of
+     * approvals required, the request is finalized
+     * @param _index the index of the requestMint to ratify
+     * @param _to the address to mint to
+     * @param _value the amount requested
+     */
+    function ratifyMint(
+        uint256 _index,
+        address _to,
+        uint256 _value
+    ) external mintNotPaused onlyMintRatifierOrOwner {
+        MintOperation memory op = mintOperations[_index];
+        require(op.to == _to, "to address does not match");
+        require(op.value == _value, "amount does not match");
+        require(!mintOperations[_index].approved[msg.sender], "already approved");
+        mintOperations[_index].approved[msg.sender] = true;
+        mintOperations[_index].numberOfApproval = mintOperations[_index].numberOfApproval.add(1);
+        emit MintRatified(_index, msg.sender);
+        if (hasEnoughApproval(mintOperations[_index].numberOfApproval, _value)) {
+            finalizeMint(_index);
+        }
+    }
+
+    /**
+     * @dev finalize a mint request, mint the amount requested to the specified address
+     * @param _index of the request (visible in the RequestMint event accompanying the original request)
+     */
+    function finalizeMint(uint256 _index) public mintNotPaused {
+        MintOperation memory op = mintOperations[_index];
+        address to = op.to;
+        uint256 value = op.value;
+        if (msg.sender != owner) {
+            require(canFinalize(_index));
+            _subtractFromMintPool(value);
+        }
+        delete mintOperations[_index];
+        token.mint(to, value);
+        emit FinalizeMint(to, value, _index, msg.sender);
+    }
+
+    /**
+     * assumption: only invoked when canFinalize
+     */
+    function _subtractFromMintPool(uint256 _value) internal {
+        if (_value <= ratifiedMintPool && _value <= ratifiedMintThreshold) {
+            ratifiedMintPool = ratifiedMintPool.sub(_value);
+        } else {
+            multiSigMintPool = multiSigMintPool.sub(_value);
+        }
+    }
+
+    /**
+     * @dev compute if the number of approvals is enough for a given mint amount
+     */
+    function hasEnoughApproval(uint256 _numberOfApproval, uint256 _value) public view returns (bool) {
+        if (_value <= ratifiedMintPool && _value <= ratifiedMintThreshold) {
+            if (_numberOfApproval >= RATIFY_MINT_SIGS) {
+                return true;
+            }
+        }
+        if (_value <= multiSigMintPool && _value <= multiSigMintThreshold) {
+            if (_numberOfApproval >= MULTISIG_MINT_SIGS) {
+                return true;
+            }
+        }
+        if (msg.sender == owner) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @dev compute if a mint request meets all the requirements to be finalized
+     * utility function for a front end
+     */
+    function canFinalize(uint256 _index) public view returns (bool) {
+        MintOperation memory op = mintOperations[_index];
+        require(op.requestedBlock > mintReqInvalidBeforeThisBlock, "this mint is invalid"); //also checks if request still exists
+        require(!op.paused, "this mint is paused");
+        require(hasEnoughApproval(op.numberOfApproval, op.value), "not enough approvals");
+        return true;
+    }
+
+    /**
+     * @dev revoke a mint request, Delete the mintOperation
+     * @param _index of the request (visible in the RequestMint event accompanying the original request)
+     */
+    function revokeMint(uint256 _index) external onlyMintKeyOrOwner {
+        delete mintOperations[_index];
+        emit RevokeMint(_index);
+    }
+
+    /**
+     * @dev get mint operatino count
+     * @return mint operation count
+     */
+    function mintOperationCount() public view returns (uint256) {
+        return mintOperations.length;
+    }
+
+    /*
+    ========================================
+    Key management
+    ========================================
+    */
+
+    /**
+     * @dev Replace the current mintkey with new mintkey
+     * @param _newMintKey address of the new mintKey
+     */
+    function transferMintKey(address _newMintKey) external onlyOwner {
+        require(_newMintKey != address(0), "new mint key cannot be 0x0");
+        emit TransferMintKey(mintKey, _newMintKey);
+        mintKey = _newMintKey;
+    }
+
+    function setGasRefunder(address refunder) external onlyOwner {
+        gasRefunder = refunder;
+    }
+
+    function setRegistryAdmin(address admin) external onlyOwner {
+        registryAdmin = admin;
+    }
+
+    /*
+    ========================================
+    Mint Pausing
+    ========================================
+    */
+
+    /**
+     * @dev invalidates all mint request initiated before the current block
+     */
+    function invalidateAllPendingMints() external onlyOwner {
+        mintReqInvalidBeforeThisBlock = block.number;
+    }
+
+    /**
+     * @dev pause any further mint request and mint finalizations
+     */
+    function pauseMints() external onlyMintPauserOrOwner {
+        mintPaused = true;
+        emit AllMintsPaused(true);
+    }
+
+    /**
+     * @dev unpause any further mint request and mint finalizations
+     */
+    function unpauseMints() external onlyOwner {
+        mintPaused = false;
+        emit AllMintsPaused(false);
+    }
+
+    /**
+     * @dev pause a specific mint request
+     * @param  _opIndex the index of the mint request the caller wants to pause
+     */
+    function pauseMint(uint256 _opIndex) external onlyMintPauserOrOwner {
+        mintOperations[_opIndex].paused = true;
+        emit MintPaused(_opIndex, true);
+    }
+
+    /**
+     * @dev unpause a specific mint request
+     * @param  _opIndex the index of the mint request the caller wants to unpause
+     */
+    function unpauseMint(uint256 _opIndex) external onlyOwner {
+        mintOperations[_opIndex].paused = false;
+        emit MintPaused(_opIndex, false);
+    }
+
+    /*
+    ========================================
+    set and claim contracts, administrative
+    ========================================
+    */
+
+    /**
+     * @dev Update this contract's token pointer to newContract (e.g. if the
+     * contract is upgraded)
+     */
+    function setToken(TrueCurrency _newContract) external onlyOwner {
+        token = _newContract;
+        emit SetToken(_newContract);
+    }
+
+    /**
+     * @dev Update this contract's registry pointer to _registry
+     */
+    function setRegistry(Registry _registry) external onlyOwner {
+        registry = _registry;
+        emit SetRegistry(address(registry));
+    }
+
+    /**
+     * @dev Claim ownership of an arbitrary HasOwner contract
+     */
+    function issueClaimOwnership(address _other) public onlyOwner {
+        HasOwner other = HasOwner(_other);
+        other.claimOwnership();
+    }
+
+    /**
+     * @dev Transfer ownership of _child to _newOwner.
+     * Can be used e.g. to upgrade this TokenController contract.
+     * @param _child contract that tokenController currently Owns
+     * @param _newOwner new owner/pending owner of _child
+     */
+    function transferChild(HasOwner _child, address _newOwner) external onlyOwner {
+        _child.transferOwnership(_newOwner);
+        emit TransferChild(address(_child), _newOwner);
+    }
+
+    /**
+     * @dev send all ether in token address to the owner of tokenController
+     */
+    function requestReclaimEther() external onlyOwner {
+        token.reclaimEther(owner);
+    }
+
+    /**
+     * @dev transfer all tokens of a particular type in token address to the
+     * owner of tokenController
+     * @param _token token address of the token to transfer
+     */
+    function requestReclaimToken(IERC20 _token) external onlyOwner {
+        token.reclaimToken(_token, owner);
+    }
+
+    /**
+     * @dev pause all pausable actions on TrueCurrency, mints/burn/transfer/approve
+     */
+    function pauseToken() external virtual onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(PAUSED_IMPLEMENTATION);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amounts that TrueCurrency users can
+     * burn to newMin and newMax
+     * @param _min minimum amount user can burn at a time
+     * @param _max maximum amount user can burn at a time
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        token.setBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Owner can send ether balance in contract address
+     * @param _to address to which the funds will be send to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev Owner can send erc20 token balance in contract address
+     * @param _token address of the token to send
+     * @param _to address to which the funds will be send to
+     */
+    function reclaimToken(IERC20 _token, address _to) external onlyOwner {
+        uint256 balance = _token.balanceOf(address(this));
+        _token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Owner can allow address to burn tokens
+     * @param burner address of the token that can burn
+     * @param canBurn true if account is allowed to burn, false otherwise
+     */
+    function setCanBurn(address burner, bool canBurn) external onlyRegistryAdmin {
+        token.setCanBurn(burner, canBurn);
+        emit CanBurn(burner, canBurn);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param isBlacklisted blacklist flag value
+     */
+    function setBlacklisted(address account, bool isBlacklisted) external onlyRegistryAdmin {
+        token.setBlacklisted(account, isBlacklisted);
+    }
+
+    /**
+     * Call hook in `hookContract` with gas refund
+     */
+    function refundGasWithHook(Hook hookContract) external onlyGasRefunder {
+        // calculate start gas amount
+        uint256 startGas = gasleft();
+        // call hook
+        hookContract.hook();
+        // calculate gas used
+        uint256 gasUsed = startGas.sub(gasleft());
+        // 1 refund = 15,000 gas. EVM refunds maximum half of used gas, so divide by 2.
+        // Add 20% to compensate inter contract communication
+        // (x + 20%) / 2 / 15000 = x / 25000
+        token.refundGas(gasUsed.div(25000));
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/mocks/TokenControllerMock.sol
+
+// pragma solidity 0.6.10;
+
+// import {IOwnedUpgradeabilityProxy as OwnedUpgradeabilityProxy} from "contracts/proxy/interface/IOwnedUpgradeabilityProxy.sol";
+// import {IRegistry as Registry} from "contracts/registry/interface/IRegistry.sol";
+
+// import {ITrueCurrency as TrueCurrency} from "contracts/true-currencies/interface/ITrueCurrency.sol";
+
+// import {TokenController} from "contracts/true-currencies/TokenController.sol";
+
+/**
+ * Token Controller with custom init function for testing
+ */
+contract TokenControllerMock is TokenController {
+    // initalize controller. useful for tests
+    function initialize() external {
+        require(!initialized, "already initialized");
+        owner = msg.sender;
+        initialized = true;
+    }
+
+    // initialize with paramaters. useful for tests
+    // sets initial paramaters on testnet
+    function initializeWithParams(TrueCurrency _token, Registry _registry) external {
+        require(!initialized, "already initialized");
+        owner = msg.sender;
+        initialized = true;
+        token = _token;
+        emit SetToken(_token);
+        registry = _registry;
+        emit SetRegistry(address(_registry));
+        gasRefunder = owner;
+        registryAdmin = owner;
+        // set mint limits & thresholds
+        // instant = 1M, ratified = 10M, multisig = 100M
+        uint256 instant = 1000000000000000000000000;
+        uint256 ratified = 10000000000000000000000000;
+        uint256 multiSig = 100000000000000000000000000;
+        instantMintThreshold = instant;
+        ratifiedMintThreshold = ratified;
+        multiSigMintThreshold = multiSig;
+        instantMintLimit = instant;
+        ratifiedMintLimit = ratified;
+        multiSigMintLimit = multiSig;
+        instantMintPool = instant;
+        ratifiedMintPool = ratified;
+        multiSigMintPool = multiSig;
+        emit MintThresholdChanged(instant, ratified, multiSig);
+        emit MintLimitsChanged(instant, ratified, multiSig);
+        emit InstantPoolRefilled();
+        emit RatifyPoolRefilled();
+        emit MultiSigPoolRefilled();
+    }
+}
+
+contract TokenControllerPauseMock is TokenControllerMock {
+    address public pausedImplementation;
+
+    function setPausedImplementation(address _pausedToken) external {
+        pausedImplementation = _pausedToken;
+    }
+
+    /**
+     *@dev pause all pausable actions on TrueUSD, mints/burn/transfer/approve
+     */
+    function pauseToken() external override onlyOwner {
+        OwnedUpgradeabilityProxy(uint160(address(token))).upgradeTo(pausedImplementation);
+    }
+}
+
+
+// Root file: contracts/true-currencies/mocks/TokenFaucet.sol
+
+pragma solidity 0.6.10;
+
+// import {TokenControllerMock} from "contracts/true-currencies/mocks/TokenControllerMock.sol";
+
+contract TokenFaucet is TokenControllerMock {
+    function faucet(uint256 _amount) external {
+        require(_amount <= instantMintThreshold);
+        token.mint(msg.sender, _amount);
+        emit InstantMint(msg.sender, _amount, msg.sender);
+    }
+}

--- a/flatten/TrueAUD.sol
+++ b/flatten/TrueAUD.sol
@@ -1,0 +1,1324 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-currencies/common/GasRefund.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+/**
+ * @title Gas Reclaim Legacy
+ *
+ * Note: this contract does not affect any of the token logic. It merely
+ * exists so the TokenController (owner) can reclaim the sponsored gas
+ *
+ * Previously TrueCurrency has a feature called "gas boost" which allowed
+ * us to sponsor gas by setting non-empty storage slots to 1.
+ * We are depricating this feature, but there is a bunch of gas saved
+ * from years of sponsoring gas. This contract is meant to allow the owner
+ * to take advantage of this leftover gas. Once all the slots are used,
+ * this contract can be removed from TrueCurrency.
+ *
+ * Utilitzes the gas refund mechanism in EVM. Each time an non-empty
+ * storage slot is set to 0, evm will refund 15,000 to the sender.
+ * Also utilized the refund for selfdestruct, see gasRefund39
+ */
+abstract contract GasRefund {
+    /**
+     * @dev Refund 15,000 gas per slot.
+     * @param amount number of slots to free
+     */
+    function gasRefund15(uint256 amount) internal {
+        assembly {
+            // get number of free slots
+            let offset := sload(0xfffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // get location of first slot
+            let location := add(offset, 0xfffff)
+            // loop until end is reached
+            for {
+                let end := sub(location, amount)
+            } gt(location, end) {
+                location := sub(location, 1)
+            } {
+                // set storage location to zero
+                // this refunds 15,000 gas
+                sstore(location, 0)
+            }
+            // store new number of free slots
+            sstore(0xfffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev use smart contract self-destruct to refund gas
+     * will refund 39,000 * amount gas
+     */
+    function gasRefund39(uint256 amount) internal {
+        assembly {
+            // get amount of gas slots
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // first sheep pointer
+            let location := sub(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, offset)
+            // loop from location to end
+            for {
+                let end := add(location, amount)
+            } lt(location, end) {
+                location := add(location, 1)
+            } {
+                // load sheep address
+                let sheep := sload(location)
+                // call selfdestruct on sheep
+                pop(call(gas(), sheep, 0, 0, 0, 0, 0))
+                // clear sheep address
+                sstore(location, 0)
+            }
+            // store new number of sheep
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev Return the remaining sponsored gas slots
+     */
+    function remainingGasRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xfffff)
+        }
+    }
+
+    /**
+     * @dev Return the remaining sheep slots
+     */
+    function remainingSheepRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrencyWithGasRefund.sol
+
+// pragma solidity 0.6.10;
+
+// import {GasRefund} from "contracts/true-currencies/common/GasRefund.sol";
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+abstract contract TrueCurrencyWithGasRefund is GasRefund, TrueCurrency {
+    /**
+     * @dev reclaim gas from legacy gas refund #1
+     * will refund 15,000 * amount gas to sender (minus exection cost)
+     * If gas pool is empty, refund 39,000 * amount gas by calling selfdestruct
+     */
+    function refundGas(uint256 amount) external onlyOwner {
+        if (remainingGasRefundPool() > 0) {
+            gasRefund15(amount);
+        } else {
+            gasRefund39(amount.div(3));
+        }
+    }
+}
+
+
+// Root file: contracts/true-currencies/tokens/TrueAUD.sol
+
+pragma solidity 0.6.10;
+
+// import {TrueCurrencyWithGasRefund} from "contracts/true-currencies/TrueCurrencyWithGasRefund.sol";
+
+/**
+ * title TrueAUD
+ * @dev This is the top-level ERC20 contract, but most of the interesting functionality is
+ * inherited - see the documentation on the corresponding contracts.
+ */
+contract TrueAUD is TrueCurrencyWithGasRefund {
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueAUD";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TAUD";
+    }
+}

--- a/flatten/TrueCAD.sol
+++ b/flatten/TrueCAD.sol
@@ -1,0 +1,1324 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-currencies/common/GasRefund.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+/**
+ * @title Gas Reclaim Legacy
+ *
+ * Note: this contract does not affect any of the token logic. It merely
+ * exists so the TokenController (owner) can reclaim the sponsored gas
+ *
+ * Previously TrueCurrency has a feature called "gas boost" which allowed
+ * us to sponsor gas by setting non-empty storage slots to 1.
+ * We are depricating this feature, but there is a bunch of gas saved
+ * from years of sponsoring gas. This contract is meant to allow the owner
+ * to take advantage of this leftover gas. Once all the slots are used,
+ * this contract can be removed from TrueCurrency.
+ *
+ * Utilitzes the gas refund mechanism in EVM. Each time an non-empty
+ * storage slot is set to 0, evm will refund 15,000 to the sender.
+ * Also utilized the refund for selfdestruct, see gasRefund39
+ */
+abstract contract GasRefund {
+    /**
+     * @dev Refund 15,000 gas per slot.
+     * @param amount number of slots to free
+     */
+    function gasRefund15(uint256 amount) internal {
+        assembly {
+            // get number of free slots
+            let offset := sload(0xfffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // get location of first slot
+            let location := add(offset, 0xfffff)
+            // loop until end is reached
+            for {
+                let end := sub(location, amount)
+            } gt(location, end) {
+                location := sub(location, 1)
+            } {
+                // set storage location to zero
+                // this refunds 15,000 gas
+                sstore(location, 0)
+            }
+            // store new number of free slots
+            sstore(0xfffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev use smart contract self-destruct to refund gas
+     * will refund 39,000 * amount gas
+     */
+    function gasRefund39(uint256 amount) internal {
+        assembly {
+            // get amount of gas slots
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // first sheep pointer
+            let location := sub(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, offset)
+            // loop from location to end
+            for {
+                let end := add(location, amount)
+            } lt(location, end) {
+                location := add(location, 1)
+            } {
+                // load sheep address
+                let sheep := sload(location)
+                // call selfdestruct on sheep
+                pop(call(gas(), sheep, 0, 0, 0, 0, 0))
+                // clear sheep address
+                sstore(location, 0)
+            }
+            // store new number of sheep
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev Return the remaining sponsored gas slots
+     */
+    function remainingGasRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xfffff)
+        }
+    }
+
+    /**
+     * @dev Return the remaining sheep slots
+     */
+    function remainingSheepRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrencyWithGasRefund.sol
+
+// pragma solidity 0.6.10;
+
+// import {GasRefund} from "contracts/true-currencies/common/GasRefund.sol";
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+abstract contract TrueCurrencyWithGasRefund is GasRefund, TrueCurrency {
+    /**
+     * @dev reclaim gas from legacy gas refund #1
+     * will refund 15,000 * amount gas to sender (minus exection cost)
+     * If gas pool is empty, refund 39,000 * amount gas by calling selfdestruct
+     */
+    function refundGas(uint256 amount) external onlyOwner {
+        if (remainingGasRefundPool() > 0) {
+            gasRefund15(amount);
+        } else {
+            gasRefund39(amount.div(3));
+        }
+    }
+}
+
+
+// Root file: contracts/true-currencies/tokens/TrueCAD.sol
+
+pragma solidity 0.6.10;
+
+// import {TrueCurrencyWithGasRefund} from "contracts/true-currencies/TrueCurrencyWithGasRefund.sol";
+
+/**
+ * @title TrueCAD
+ * @dev This is the top-level ERC20 contract, but most of the interesting functionality is
+ * inherited - see the documentation on the corresponding contracts.
+ */
+contract TrueCAD is TrueCurrencyWithGasRefund {
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueCAD";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TCAD";
+    }
+}

--- a/flatten/TrueCurrency.sol
+++ b/flatten/TrueCurrency.sol
@@ -1,0 +1,1158 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Root file: contracts/true-currencies/TrueCurrency.sol
+
+pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}

--- a/flatten/TrueCurrencyWithGasRefund.sol
+++ b/flatten/TrueCurrencyWithGasRefund.sol
@@ -1,0 +1,1291 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-currencies/common/GasRefund.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+/**
+ * @title Gas Reclaim Legacy
+ *
+ * Note: this contract does not affect any of the token logic. It merely
+ * exists so the TokenController (owner) can reclaim the sponsored gas
+ *
+ * Previously TrueCurrency has a feature called "gas boost" which allowed
+ * us to sponsor gas by setting non-empty storage slots to 1.
+ * We are depricating this feature, but there is a bunch of gas saved
+ * from years of sponsoring gas. This contract is meant to allow the owner
+ * to take advantage of this leftover gas. Once all the slots are used,
+ * this contract can be removed from TrueCurrency.
+ *
+ * Utilitzes the gas refund mechanism in EVM. Each time an non-empty
+ * storage slot is set to 0, evm will refund 15,000 to the sender.
+ * Also utilized the refund for selfdestruct, see gasRefund39
+ */
+abstract contract GasRefund {
+    /**
+     * @dev Refund 15,000 gas per slot.
+     * @param amount number of slots to free
+     */
+    function gasRefund15(uint256 amount) internal {
+        assembly {
+            // get number of free slots
+            let offset := sload(0xfffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // get location of first slot
+            let location := add(offset, 0xfffff)
+            // loop until end is reached
+            for {
+                let end := sub(location, amount)
+            } gt(location, end) {
+                location := sub(location, 1)
+            } {
+                // set storage location to zero
+                // this refunds 15,000 gas
+                sstore(location, 0)
+            }
+            // store new number of free slots
+            sstore(0xfffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev use smart contract self-destruct to refund gas
+     * will refund 39,000 * amount gas
+     */
+    function gasRefund39(uint256 amount) internal {
+        assembly {
+            // get amount of gas slots
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // first sheep pointer
+            let location := sub(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, offset)
+            // loop from location to end
+            for {
+                let end := add(location, amount)
+            } lt(location, end) {
+                location := add(location, 1)
+            } {
+                // load sheep address
+                let sheep := sload(location)
+                // call selfdestruct on sheep
+                pop(call(gas(), sheep, 0, 0, 0, 0, 0))
+                // clear sheep address
+                sstore(location, 0)
+            }
+            // store new number of sheep
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev Return the remaining sponsored gas slots
+     */
+    function remainingGasRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xfffff)
+        }
+    }
+
+    /**
+     * @dev Return the remaining sheep slots
+     */
+    function remainingSheepRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Root file: contracts/true-currencies/TrueCurrencyWithGasRefund.sol
+
+pragma solidity 0.6.10;
+
+// import {GasRefund} from "contracts/true-currencies/common/GasRefund.sol";
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+abstract contract TrueCurrencyWithGasRefund is GasRefund, TrueCurrency {
+    /**
+     * @dev reclaim gas from legacy gas refund #1
+     * will refund 15,000 * amount gas to sender (minus exection cost)
+     * If gas pool is empty, refund 39,000 * amount gas by calling selfdestruct
+     */
+    function refundGas(uint256 amount) external onlyOwner {
+        if (remainingGasRefundPool() > 0) {
+            gasRefund15(amount);
+        } else {
+            gasRefund39(amount.div(3));
+        }
+    }
+}

--- a/flatten/TrueCurrencyWithLegacyAutosweep.sol
+++ b/flatten/TrueCurrencyWithLegacyAutosweep.sol
@@ -1,0 +1,1345 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/DelegateERC20.sol
+
+// pragma solidity 0.6.10;
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+/**
+ * @title DelegateERC20
+ * Accept forwarding delegation calls from the old TrueUSD (V1) contract.
+ * This way the all the ERC20 functions in the old contract still works
+ * (except Burn).
+ *
+ * The original contract is at 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E.
+ * Lines 497-574 on-chain call these delegate functions to forward calls
+ * This gives the delegate contract the power to change the state of the TrueUSD
+ * contract. The owner of this contract is the TrueUSD TokenController
+ * at 0x0000000000075efbee23fe2de1bd0b7690883cc9.
+ *
+ * Our audits for TrueCurrency can be found here: github.com/trusttoken/audits
+ */
+abstract contract DelegateERC20 is TrueCurrency {
+    address constant DELEGATE_FROM = 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E;
+
+    // require msg.sender is the delegate smart contract
+    modifier onlyDelegateFrom() {
+        require(msg.sender == DELEGATE_FROM);
+        _;
+    }
+
+    /**
+     * @dev Delegate call to get total supply
+     * @return Total supply
+     */
+    function delegateTotalSupply() public view returns (uint256) {
+        return totalSupply();
+    }
+
+    /**
+     * @dev Delegate call to get balance
+     * @param who Address to get balance for
+     * @return balance of account
+     */
+    function delegateBalanceOf(address who) public view returns (uint256) {
+        return balanceOf(who);
+    }
+
+    /**
+     * @dev Delegate call to transfer
+     * @param to address to transfer to
+     * @param value amount to transfer
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateTransfer(
+        address to,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        _transfer(origSender, to, value);
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to get allowance
+     * @param owner account owner
+     * @param spender account to check allowance for
+     * @return allowance
+     */
+    function delegateAllowance(address owner, address spender) public view returns (uint256) {
+        return allowance(owner, spender);
+    }
+
+    /**
+     * @dev Delegate call to transfer from
+     * @param from account to transfer funds from
+     * @param to account to transfer funds to
+     * @param value value to transfer
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateTransferFrom(
+        address from,
+        address to,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 transferFrom with _msgSender() replaced by origSender
+        _transfer(from, to, value);
+        _approve(from, origSender, _allowances[from][origSender].sub(value, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to approve
+     * @param spender account to approve for
+     * @param value amount to approve
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateApprove(
+        address spender,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        _approve(origSender, spender, value);
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to increase approval
+     * @param spender account to increase approval for
+     * @param addedValue amount of approval to add
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateIncreaseApproval(
+        address spender,
+        uint256 addedValue,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 increaseAllowance() with _msgSender() replaced by origSender
+        _approve(origSender, spender, _allowances[origSender][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to decrease approval
+     * @param spender spender to decrease approval for
+     * @param subtractedValue value to subtract from approval
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateDecreaseApproval(
+        address spender,
+        uint256 subtractedValue,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 decreaseAllowance() with _msgSender() replaced by origSender
+        _approve(origSender, spender, _allowances[origSender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+}
+
+
+// Root file: contracts/true-currencies/TrueCurrencyWithLegacyAutosweep.sol
+
+pragma solidity 0.6.10;
+
+// import {DelegateERC20} from "contracts/true-currencies/DelegateERC20.sol";
+
+/**
+ * @dev Contract that prevents addresses that were previously using autosweep addresses from
+ * making transfers on them.
+ *
+ * In older versions TrueCurrencies had a feature called Autosweep.
+ * Given a single deposit address, it was possible to generate 16^5-1 autosweep addresses.
+ * E.g. having deposit address 0xc257274276a4e539741ca11b590b9447b26a8051, you could generate
+ * - 0xc257274276a4e539741ca11b590b9447b2600000
+ * - 0xc257274276a4e539741ca11b590b9447b2600001
+ * - ...
+ * - 0xc257274276a4e539741ca11b590b9447b26fffff
+ * Every transfer to an autosweep address resulted as a transfer to deposit address.
+ * This feature got deprecated, but there were 4 addresses that still actively using the feature.
+ *
+ * This contract will reject a transfer to these 4*(16^5-1) addresses to prevent accidental token freeze.
+ */
+abstract contract TrueCurrencyWithLegacyAutosweep is DelegateERC20 {
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal override {
+        requireNotAutosweepAddress(recipient, 0x33091DE8341533468D13A80C5A670f4f47cC649f);
+        requireNotAutosweepAddress(recipient, 0x50E2719208914764087e68C32bC5AaC321f5B04d);
+        requireNotAutosweepAddress(recipient, 0x71d69e5481A9B7Be515E20B38a3f62Dab7170D78);
+        requireNotAutosweepAddress(recipient, 0x90fdaA85D52dB6065D466B86f16bF840D514a488);
+
+        super._transfer(sender, recipient, amount);
+    }
+
+    function requireNotAutosweepAddress(address recipient, address depositAddress) internal pure {
+        return
+            require(uint256(recipient) >> 20 != uint256(depositAddress) >> 20 || recipient == depositAddress, "Autosweep is disabled");
+    }
+}

--- a/flatten/TrueFarm.sol
+++ b/flatten/TrueFarm.sol
@@ -1,0 +1,580 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueDistributor.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ITrueDistributor {
+    function trustToken() external view returns (IERC20);
+
+    function farm() external view returns (address);
+
+    function distribute() external;
+
+    function nextDistribution() external view returns (uint256);
+
+    function empty() external;
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueFarm.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ITrueDistributor} from "contracts/truefi/interface/ITrueDistributor.sol";
+
+interface ITrueFarm {
+    function stakingToken() external view returns (IERC20);
+
+    function trustToken() external view returns (IERC20);
+
+    function trueDistributor() external view returns (ITrueDistributor);
+
+    function name() external view returns (string memory);
+
+    function totalStaked() external view returns (uint256);
+
+    function stake(uint256 amount) external;
+
+    function unstake(uint256 amount) external;
+
+    function claim() external;
+
+    function exit(uint256 amount) external;
+}
+
+
+// Root file: contracts/truefi/TrueFarm.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+// import {ITrueDistributor} from "contracts/truefi/interface/ITrueDistributor.sol";
+// import {ITrueFarm} from "contracts/truefi/interface/ITrueFarm.sol";
+
+/**
+ * @title TrueFarm
+ * @notice Deposit liquidity tokens to earn TRU rewards over time
+ * @dev Staking pool where tokens are staked for TRU rewards
+ * A Distributor contract decides how much TRU a farm can earn over time
+ */
+contract TrueFarm is ITrueFarm, Initializable {
+    using SafeMath for uint256;
+    uint256 constant PRECISION = 1e30;
+
+    // ================ WARNING ==================
+    // ===== THIS CONTRACT IS INITIALIZABLE ======
+    // === STORAGE VARIABLES ARE DECLARED BELOW ==
+    // REMOVAL OR REORDER OF VARIABLES WILL RESULT
+    // ========= IN STORAGE CORRUPTION ===========
+
+    IERC20 public override stakingToken;
+    IERC20 public override trustToken;
+    ITrueDistributor public override trueDistributor;
+    string public override name;
+
+    // track stakes
+    uint256 public override totalStaked;
+    mapping(address => uint256) public staked;
+
+    // track overall cumulative rewards
+    uint256 public cumulativeRewardPerToken;
+    // track previous cumulate rewards for accounts
+    mapping(address => uint256) public previousCumulatedRewardPerToken;
+    // track claimable rewards for accounts
+    mapping(address => uint256) public claimableReward;
+
+    // track total rewards
+    uint256 public totalClaimedRewards;
+    uint256 public totalFarmRewards;
+
+    // ======= STORAGE DECLARATION END ============
+
+    /**
+     * @dev Emitted when an account stakes
+     * @param who Account staking
+     * @param amountStaked Amount of tokens staked
+     */
+    event Stake(address indexed who, uint256 amountStaked);
+
+    /**
+     * @dev Emitted when an account unstakes
+     * @param who Account unstaking
+     * @param amountUnstaked Amount of tokens unstaked
+     */
+    event Unstake(address indexed who, uint256 amountUnstaked);
+
+    /**
+     * @dev Emitted when an account claims TRU rewards
+     * @param who Account claiming
+     * @param amountClaimed Amount of TRU claimed
+     */
+    event Claim(address indexed who, uint256 amountClaimed);
+
+    /**
+     * @dev Initalize staking pool with a Distributor contraxct
+     * The distributor contract calculates how much TRU rewards this contract
+     * gets, and stores TRU for distribution.
+     * @param _stakingToken Token to stake
+     * @param _trueDistributor Distributor contract
+     * @param _name Farm name
+     */
+    function initialize(
+        IERC20 _stakingToken,
+        ITrueDistributor _trueDistributor,
+        string memory _name
+    ) public initializer {
+        stakingToken = _stakingToken;
+        trueDistributor = _trueDistributor;
+        trustToken = _trueDistributor.trustToken();
+        name = _name;
+        require(trueDistributor.farm() == address(this), "TrueFarm: Distributor farm is not set");
+    }
+
+    /**
+     * @dev Stake tokens for TRU rewards.
+     * @param amount Amount of tokens to stake
+     */
+    function stake(uint256 amount) external override update {
+        staked[msg.sender] = staked[msg.sender].add(amount);
+        totalStaked = totalStaked.add(amount);
+        require(stakingToken.transferFrom(msg.sender, address(this), amount));
+        emit Stake(msg.sender, amount);
+    }
+
+    /**
+     * @dev Internal unstake function
+     * @param amount Amount of tokens to unstake
+     */
+    function _unstake(uint256 amount) internal {
+        require(amount <= staked[msg.sender], "TrueFarm: Cannot withdraw amount bigger than available balance");
+        staked[msg.sender] = staked[msg.sender].sub(amount);
+        totalStaked = totalStaked.sub(amount);
+        require(stakingToken.transfer(msg.sender, amount));
+        emit Unstake(msg.sender, amount);
+    }
+
+    /**
+     * @dev Internal claim function
+     */
+    function _claim() internal {
+        totalClaimedRewards = totalClaimedRewards.add(claimableReward[msg.sender]);
+        uint256 rewardToClaim = claimableReward[msg.sender];
+        claimableReward[msg.sender] = 0;
+        require(trustToken.transfer(msg.sender, rewardToClaim));
+        emit Claim(msg.sender, rewardToClaim);
+    }
+
+    /**
+     * @dev Remove staked tokens
+     * @param amount Amount of tokens to unstake
+     */
+    function unstake(uint256 amount) external override update {
+        _unstake(amount);
+    }
+
+    /**
+     * @dev Claim TRU rewards
+     */
+    function claim() external override update {
+        _claim();
+    }
+
+    /**
+     * @dev Unstake amount and claim rewards
+     * @param amount Amount of tokens to unstake
+     */
+    function exit(uint256 amount) external override update {
+        _unstake(amount);
+        _claim();
+    }
+
+    /**
+     * @dev View to estimate the claimable reward for an account
+     * @return claimable rewards for account
+     */
+    function claimable(address account) external view returns (uint256) {
+        // estimate pending reward from distributor
+        uint256 pending = trueDistributor.nextDistribution();
+        // calculate total rewards (including pending)
+        uint256 newTotalFarmRewards = trustToken.balanceOf(address(this)).add(pending).add(totalClaimedRewards).mul(PRECISION);
+        // calculate block reward
+        uint256 totalBlockReward = newTotalFarmRewards.sub(totalFarmRewards);
+        // calculate next cumulative reward per token
+        uint256 nextcumulativeRewardPerToken = cumulativeRewardPerToken.add(totalBlockReward.div(totalStaked));
+        // return claimable reward for this account
+        // prettier-ignore
+        return claimableReward[account].add(
+            staked[account].mul(nextcumulativeRewardPerToken.sub(previousCumulatedRewardPerToken[account])).div(PRECISION));
+    }
+
+    /**
+     * @dev Update state and get TRU from distributor
+     */
+    modifier update() {
+        // pull TRU from distributor
+        // only pull if there is distribution and distributor farm is set to this farm
+        if (trueDistributor.nextDistribution() > 0 && trueDistributor.farm() == address(this)) {
+            trueDistributor.distribute();
+        }
+        // calculate total rewards
+        uint256 newTotalFarmRewards = trustToken.balanceOf(address(this)).add(totalClaimedRewards).mul(PRECISION);
+        // calculate block reward
+        uint256 totalBlockReward = newTotalFarmRewards.sub(totalFarmRewards);
+        // update farm rewards
+        totalFarmRewards = newTotalFarmRewards;
+        // if there are stakers
+        if (totalStaked > 0) {
+            cumulativeRewardPerToken = cumulativeRewardPerToken.add(totalBlockReward.div(totalStaked));
+        }
+        // update claimable reward for sender
+        claimableReward[msg.sender] = claimableReward[msg.sender].add(
+            staked[msg.sender].mul(cumulativeRewardPerToken.sub(previousCumulatedRewardPerToken[msg.sender])).div(PRECISION)
+        );
+        // update previous cumulative for sender
+        previousCumulatedRewardPerToken[msg.sender] = cumulativeRewardPerToken;
+        _;
+    }
+}

--- a/flatten/TrueFarm.sol
+++ b/flatten/TrueFarm.sol
@@ -536,6 +536,9 @@ contract TrueFarm is ITrueFarm, Initializable {
      * @return claimable rewards for account
      */
     function claimable(address account) external view returns (uint256) {
+        if (staked[account] == 0) {
+            return claimableReward[account];
+        }
         // estimate pending reward from distributor
         uint256 pending = trueDistributor.nextDistribution();
         // calculate total rewards (including pending)

--- a/flatten/TrueFiPool.sol
+++ b/flatten/TrueFiPool.sol
@@ -1,0 +1,1758 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/ReentrancyGuard.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Contract module that helps prevent reentrant calls to a function.
+ *
+ * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
+ * available, which can be applied to functions to make sure there are no nested
+ * (reentrant) calls to them.
+ *
+ * Note that because there is a single `nonReentrant` guard, functions marked as
+ * `nonReentrant` may not call one another. This can be worked around by making
+ * those functions `private`, and then adding `external` `nonReentrant` entry
+ * points to them.
+ *
+ * TIP: If you would like to learn more about reentrancy and alternative ways
+ * to protect against it, check out our blog post
+ * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
+ */
+contract ReentrancyGuard {
+    // Booleans are more expensive than uint256 or any type that takes up a full
+    // word because each write operation emits an extra SLOAD to first read the
+    // slot's contents, replace the bits taken up by the boolean, and then write
+    // back. This is the compiler's defense against contract upgrades and
+    // pointer aliasing, and it cannot be disabled.
+
+    // The values being non-zero value makes deployment a bit more expensive,
+    // but in exchange the refund on every call to nonReentrant will be lower in
+    // amount. Since refunds are capped to a percentage of the total
+    // transaction's gas, it is best to keep them low in cases like this one, to
+    // increase the likelihood of the full refund coming into effect.
+    uint256 private constant _NOT_ENTERED = 1;
+    uint256 private constant _ENTERED = 2;
+
+    uint256 private _status;
+
+    constructor () internal {
+        _status = _NOT_ENTERED;
+    }
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and make it call a
+     * `private` function that does the actual work.
+     */
+    modifier nonReentrant() {
+        // On the first call to nonReentrant, _notEntered will be true
+        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
+
+        // Any calls to nonReentrant after this point will fail
+        _status = _ENTERED;
+
+        _;
+
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _status = _NOT_ENTERED;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Dependency file: contracts/truefi/common/UpgradeableERC20.sol
+
+// pragma solidity 0.6.10;
+
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20 is Initializable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    mapping(address => uint256) private _balances;
+
+    mapping(address => mapping(address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    function __ERC20_initialize(string memory name, string memory symbol) internal initializer {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public override view returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public override view returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public virtual override view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(
+            _msgSender(),
+            spender,
+            _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero")
+        );
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {}
+}
+
+
+// Dependency file: contracts/truefi/common/UpgradeableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is Initializable, Context {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function initialize() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Dependency file: contracts/truefi/interface/IYToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IYToken is IERC20 {
+    function getPricePerFullShare() external view returns (uint256);
+}
+
+
+// Dependency file: contracts/truefi/interface/ICurve.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IYToken} from "contracts/truefi/interface/IYToken.sol";
+
+interface ICurve {
+    function calc_token_amount(uint256[4] memory amounts, bool deposit) external view returns (uint256);
+
+    function get_virtual_price() external view returns (uint256);
+}
+
+interface ICurveGauge {
+    function balanceOf(address depositor) external view returns (uint256);
+
+    function minter() external returns (ICurveMinter);
+
+    function deposit(uint256 amount) external;
+
+    function withdraw(uint256 amount) external;
+}
+
+interface ICurveMinter {
+    function mint(address gauge) external;
+
+    function token() external view returns (IERC20);
+}
+
+interface ICurvePool {
+    function add_liquidity(uint256[4] memory amounts, uint256 min_mint_amount) external;
+
+    function remove_liquidity_one_coin(
+        uint256 _token_amount,
+        int128 i,
+        uint256 min_amount,
+        bool donate_dust
+    ) external;
+
+    function calc_withdraw_one_coin(uint256 _token_amount, int128 i) external view returns (uint256);
+
+    function token() external view returns (IERC20);
+
+    function curve() external view returns (ICurve);
+
+    function coins(int128 id) external view returns (IYToken);
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueFiPool.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * TruePool is an ERC20 which represents a share of a pool
+ *
+ * This contract can be used to wrap opportunities to be compatible
+ * with TrueFi and allow users to directly opt-in through the TUSD contract
+ *
+ * Each TruePool is also a staking opportunity for TRU
+ */
+interface ITrueFiPool is IERC20 {
+    /// @dev pool token (TUSD)
+    function currencyToken() external view returns (IERC20);
+
+    /// @dev stake token (TRU)
+    function stakeToken() external view returns (IERC20);
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Mint pool tokens based on value to sender
+     */
+    function join(uint256 amount) external;
+
+    /**
+     * @dev exit pool
+     * 1. Transfer pool tokens from sender
+     * 2. Burn pool tokens
+     * 3. Transfer value of pool tokens in TUSD to sender
+     */
+    function exit(uint256 amount) external;
+
+    /**
+     * @dev borrow from pool
+     * 1. Transfer TUSD to sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function borrow(uint256 amount, uint256 amountWithoutFee) external;
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function repay(uint256 amount) external;
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueLender.sol
+
+// pragma solidity 0.6.10;
+
+interface ITrueLender {
+    function value() external view returns (uint256);
+
+    function distribute(
+        address recipient,
+        uint256 numerator,
+        uint256 denominator
+    ) external;
+}
+
+
+// Dependency file: contracts/truefi/interface/IUniswapRouter.sol
+
+// pragma solidity 0.6.10;
+
+interface IUniswapRouter {
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+}
+
+
+// Dependency file: contracts/truefi/Log.sol
+
+/*
+ * ABDK Math 64.64 Smart Contract Library.  Copyright © 2019 by ABDK Consulting.
+ * Author: Mikhail Vladimirov <mikhail.vladimirov@gmail.com>
+ */
+// pragma solidity 0.6.10;
+
+/**
+ * Smart contract library of mathematical functions operating with signed
+ * 64.64-bit fixed point numbers.  Signed 64.64-bit fixed point number is
+ * basically a simple fraction whose numerator is signed 128-bit integer and
+ * denominator is 2^64.  As long as denominator is always the same, there is no
+ * need to store it, thus in Solidity signed 64.64-bit fixed point numbers are
+ * represented by int128 type holding only the numerator.
+ */
+library ABDKMath64x64 {
+    /**
+     * Convert unsigned 256-bit integer number into signed 64.64-bit fixed point
+     * number.  Revert on overflow.
+     *
+     * @param x unsigned 256-bit integer number
+     * @return signed 64.64-bit fixed point number
+     */
+    function fromUInt(uint256 x) internal pure returns (int128) {
+        require(x <= 0x7FFFFFFFFFFFFFFF);
+        return int128(x << 64);
+    }
+
+    /**
+     * Calculate binary logarithm of x.  Revert if x <= 0.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function log_2(int128 x) internal pure returns (int128) {
+        require(x > 0);
+
+        int256 msb = 0;
+        int256 xc = x;
+        if (xc >= 0x10000000000000000) {
+            xc >>= 64;
+            msb += 64;
+        }
+        if (xc >= 0x100000000) {
+            xc >>= 32;
+            msb += 32;
+        }
+        if (xc >= 0x10000) {
+            xc >>= 16;
+            msb += 16;
+        }
+        if (xc >= 0x100) {
+            xc >>= 8;
+            msb += 8;
+        }
+        if (xc >= 0x10) {
+            xc >>= 4;
+            msb += 4;
+        }
+        if (xc >= 0x4) {
+            xc >>= 2;
+            msb += 2;
+        }
+        if (xc >= 0x2) msb += 1; // No need to shift xc anymore
+
+        int256 result = (msb - 64) << 64;
+        uint256 ux = uint256(x) << uint256(127 - msb);
+        for (int256 bit = 0x8000000000000000; bit > 0; bit >>= 1) {
+            ux *= ux;
+            uint256 b = ux >> 255;
+            ux >>= 127 + b;
+            result += bit * int256(b);
+        }
+
+        return int128(result);
+    }
+
+    /**
+     * Calculate natural logarithm of x.  Revert if x <= 0.
+     *
+     * @param x signed 64.64-bit fixed point number
+     * @return signed 64.64-bit fixed point number
+     */
+    function ln(int128 x) internal pure returns (int128) {
+        require(x > 0);
+
+        return int128((uint256(log_2(x)) * 0xB17217F7D1CF79ABC9E3B39803F2F6AF) >> 128);
+    }
+}
+
+
+// Root file: contracts/truefi/TrueFiPool.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {ERC20} from "contracts/truefi/common/UpgradeableERC20.sol";
+// import {Ownable} from "contracts/truefi/common/UpgradeableOwnable.sol";
+// import {ICurveGauge, ICurveMinter, ICurvePool} from "contracts/truefi/interface/ICurve.sol";
+// import {ITrueFiPool} from "contracts/truefi/interface/ITrueFiPool.sol";
+// import {ITrueLender} from "contracts/truefi/interface/ITrueLender.sol";
+// import {IUniswapRouter} from "contracts/truefi/interface/IUniswapRouter.sol";
+// import {ABDKMath64x64} from "contracts/truefi/Log.sol";
+
+/**
+ * @title TrueFi Pool
+ * @dev Lending pool which uses curve.fi to store idle funds
+ * Earn high interest rates on currency deposits through uncollateralized loans
+ *
+ * Funds deposited in this pool are NOT LIQUID!
+ * Exiting the pool will withdraw a basket of LoanTokens backing the pool
+ * After exiting, an account will need to wait for LoanTokens to expire and burn them
+ * It is recommended to perform a zap or swap tokens on Uniswap for liquidity
+ *
+ * Funds are managed through an external function to save gas on deposits
+ */
+contract TrueFiPool is ITrueFiPool, ERC20, ReentrancyGuard, Ownable {
+    using SafeMath for uint256;
+
+    // ================ WARNING ==================
+    // ===== THIS CONTRACT IS INITIALIZABLE ======
+    // === STORAGE VARIABLES ARE DECLARED BELOW ==
+    // REMOVAL OR REORDER OF VARIABLES WILL RESULT
+    // ========= IN STORAGE CORRUPTION ===========
+
+    ICurvePool public _curvePool;
+    ICurveGauge public _curveGauge;
+    IERC20 public _currencyToken;
+    ITrueLender public _lender;
+    ICurveMinter public _minter;
+    IUniswapRouter public _uniRouter;
+
+    // fee for deposits
+    uint256 public joiningFee;
+    // track claimable fees
+    uint256 public claimableFees;
+
+    mapping(address => uint256) latestJoinBlock;
+
+    IERC20 public _stakeToken;
+
+    // ======= STORAGE DECLARATION END ============
+
+    // curve.fi data
+    uint8 constant N_TOKENS = 4;
+    uint8 constant TUSD_INDEX = 3;
+
+    /**
+     * @dev Emitted when stake token address
+     * @param token New stake token address
+     */
+    event StakeTokenChanged(IERC20 token);
+
+    /**
+     * @dev Emitted when fee is changed
+     * @param newFee New fee
+     */
+    event JoiningFeeChanged(uint256 newFee);
+
+    /**
+     * @dev Emitted when someone joins the pool
+     * @param staker Account staking
+     * @param deposited Amount deposited
+     * @param minted Amount of pool tokens minted
+     */
+    event Joined(address indexed staker, uint256 deposited, uint256 minted);
+
+    /**
+     * @dev Emitted when someone exits the pool
+     * @param staker Account exiting
+     * @param amount Amount unstaking
+     */
+    event Exited(address indexed staker, uint256 amount);
+
+    /**
+     * @dev Emitted when funds are flushed into curve.fi
+     * @param currencyAmount Amount of tokens deposited
+     */
+    event Flushed(uint256 currencyAmount);
+
+    /**
+     * @dev Emitted when funds are pulled from curve.fi
+     * @param yAmount Amount of pool tokens
+     */
+    event Pulled(uint256 yAmount);
+
+    /**
+     * @dev Emitted when funds are borrowed from pool
+     * @param borrower Borrower address
+     * @param amount Amount of funds borrowed from pool
+     * @param fee Fees collected from this transaction
+     */
+    event Borrow(address borrower, uint256 amount, uint256 fee);
+
+    /**
+     * @dev Emitted when borrower repays the pool
+     * @param payer Address of borrower
+     * @param amount Amount repaid
+     */
+    event Repaid(address indexed payer, uint256 amount);
+
+    /**
+     * @dev Emitted when fees are collected
+     * @param beneficiary Account to receive fees
+     * @param amount Amount of fees collected
+     */
+    event Collected(address indexed beneficiary, uint256 amount);
+
+    /**
+     * @dev Initialize pool
+     * @param __curvePool curve pool address
+     * @param __curveGauge curve gauge address
+     * @param __currencyToken curve pool underlying token
+     * @param __lender TrueLender address
+     * @param __uniRouter Uniswap router
+     */
+    function initialize(
+        ICurvePool __curvePool,
+        ICurveGauge __curveGauge,
+        IERC20 __currencyToken,
+        ITrueLender __lender,
+        IUniswapRouter __uniRouter,
+        IERC20 __stakeToken
+    ) public initializer {
+        ERC20.__ERC20_initialize("TrueFi LP", "TFI-LP");
+        Ownable.initialize();
+
+        _curvePool = __curvePool;
+        _curveGauge = __curveGauge;
+        _currencyToken = __currencyToken;
+        _lender = __lender;
+        _minter = _curveGauge.minter();
+        _uniRouter = __uniRouter;
+        _stakeToken = __stakeToken;
+
+        joiningFee = 25;
+
+        _currencyToken.approve(address(_curvePool), uint256(-1));
+        _curvePool.token().approve(address(_curvePool), uint256(-1));
+    }
+
+    /**
+     * @dev only lender can perform borrowing or repaying
+     */
+    modifier onlyLender() {
+        require(msg.sender == address(_lender), "TrueFiPool: Only lender can borrow or repay");
+        _;
+    }
+
+    /**
+     * @dev get currency token address
+     * @return currency token address
+     */
+    function currencyToken() public override view returns (IERC20) {
+        return _currencyToken;
+    }
+
+    /**
+     * @dev get stake token address
+     * @return stake token address
+     */
+    function stakeToken() public override view returns (IERC20) {
+        return _stakeToken;
+    }
+
+    /**
+     * @dev set stake token address
+     * @param token stake token address
+     */
+    function setStakeToken(IERC20 token) public onlyOwner {
+        _stakeToken = token;
+        emit StakeTokenChanged(token);
+    }
+
+    /**
+     * @dev Get total balance of stake tokens
+     */
+    function stakeTokenBalance() public view returns (uint256) {
+        return _stakeToken.balanceOf(address(this));
+    }
+
+    /**
+     * @dev Get total balance of curve.fi pool tokens
+     */
+    function yTokenBalance() public view returns (uint256) {
+        return _curvePool.token().balanceOf(address(this)).add(_curveGauge.balanceOf(address(this)));
+    }
+
+    /**
+     * @dev Virtual value of yCRV tokens in the pool
+     */
+    function yTokenValue() public view returns (uint256) {
+        return yTokenBalance().mul(_curvePool.curve().get_virtual_price()).div(1 ether);
+    }
+
+    /**
+     * @dev Virtual value of liquid assets in the pool
+     */
+    function liquidValue() public view returns (uint256) {
+        return currencyBalance().add(yTokenValue());
+    }
+
+    /**
+     * @dev Calculate pool value in TUSD
+     * "virtual price" of entire pool - LoanTokens, TUSD, curve y pool tokens
+     * @return pool value in TUSD
+     */
+    function poolValue() public view returns (uint256) {
+        return liquidValue().add(_lender.value());
+    }
+
+    /**
+     * @dev ensure enough curve.fi pool tokens are available
+     * Check if current available amount of TUSD is enough and
+     * withdraw remainder from gauge
+     * @param neededAmount amount required
+     */
+    function ensureEnoughTokensAreAvailable(uint256 neededAmount) internal {
+        uint256 currentlyAvailableAmount = _curvePool.token().balanceOf(address(this));
+        if (currentlyAvailableAmount < neededAmount) {
+            _curveGauge.withdraw(neededAmount.sub(currentlyAvailableAmount));
+        }
+    }
+
+    /**
+     * @dev set pool join fee
+     * @param fee new fee
+     */
+    function setJoiningFee(uint256 fee) external onlyOwner {
+        require(fee <= 10000, "TrueFiPool: Fee cannot exceed transaction value");
+        joiningFee = fee;
+        emit JoiningFeeChanged(fee);
+    }
+
+    /**
+     * @dev sets all token allowances used to 0
+     */
+    function resetApprovals() external onlyOwner {
+        _currencyToken.approve(address(_curvePool), 0);
+        _curvePool.token().approve(address(_curvePool), 0);
+        _curvePool.token().approve(address(_curveGauge), 0);
+    }
+
+    /**
+     * @dev Join the pool by depositing currency tokens
+     * @param amount amount of currency token to deposit
+     */
+    function join(uint256 amount) external override {
+        uint256 fee = amount.mul(joiningFee).div(10000);
+        uint256 amountToDeposit = amount.sub(fee);
+        uint256 amountToMint = amountToDeposit;
+
+        // first staker mints same amount deposited
+        if (totalSupply() > 0) {
+            amountToMint = totalSupply().mul(amountToDeposit).div(poolValue());
+        }
+        // mint pool tokens
+        _mint(msg.sender, amountToMint);
+        claimableFees = claimableFees.add(fee);
+
+        latestJoinBlock[tx.origin] = block.number;
+        require(_currencyToken.transferFrom(msg.sender, address(this), amount));
+
+        emit Joined(msg.sender, amount, amountToMint);
+    }
+
+    // prettier-ignore
+    /**
+     * @dev Exit pool
+     * This function will withdraw a basket of currencies backing the pool value
+     * @param amount amount of pool tokens to redeem for underlying tokens
+     */
+    function exit(uint256 amount) external override nonReentrant {
+        require(block.number != latestJoinBlock[tx.origin], "TrueFiPool: Cannot join and exit in same block");
+        require(amount <= balanceOf(msg.sender), "TrueFiPool: insufficient funds");
+
+        uint256 _totalSupply = totalSupply();
+
+        // get share of currency tokens kept in the pool
+        uint256 currencyAmountToTransfer = amount.mul(
+            currencyBalance()).div(_totalSupply);
+
+        // calculate amount of curve.fi pool tokens
+        uint256 curveLiquidityAmountToTransfer = amount.mul(
+            yTokenBalance()).div(_totalSupply);
+
+        // calculate amount of stake tokens
+        uint256 stakeTokenAmountToTransfer = amount.mul(
+            stakeTokenBalance()).div(_totalSupply);
+
+        // burn tokens sent
+        _burn(msg.sender, amount);
+
+        // withdraw basket of loan tokens
+        _lender.distribute(msg.sender, amount, _totalSupply);
+
+        // if currency remaining, transfer
+        if (currencyAmountToTransfer > 0) {
+            require(_currencyToken.transfer(msg.sender, currencyAmountToTransfer));
+        }
+        // if curve tokens remaining, transfer
+        if (curveLiquidityAmountToTransfer > 0) {
+            ensureEnoughTokensAreAvailable(curveLiquidityAmountToTransfer);
+            require(_curvePool.token().transfer(msg.sender, curveLiquidityAmountToTransfer));
+        }
+
+        // if stake token remaining, transfer
+        if (stakeTokenAmountToTransfer > 0) {
+            require(_stakeToken.transfer(msg.sender, stakeTokenAmountToTransfer));
+        }
+
+        emit Exited(msg.sender, amount);
+    }
+
+    /**
+     * @dev Exit pool only with liquid tokens
+     * This function will withdraw TUSD but with a small penalty
+     * @param amount amount of pool tokens to redeem for underlying tokens
+     */
+    function liquidExit(uint256 amount) external nonReentrant {
+        require(block.number != latestJoinBlock[tx.origin], "TrueFiPool: Cannot join and exit in same block");
+        require(amount <= balanceOf(msg.sender), "TrueFiPool: Insufficient funds");
+
+        uint256 amountToWithdraw = poolValue().mul(amount).div(totalSupply());
+        amountToWithdraw = amountToWithdraw.mul(liquidExitPenalty(amountToWithdraw)).div(10000);
+        require(amountToWithdraw <= liquidValue(), "TrueFiPool: Not enough liquidity in pool");
+
+        // burn tokens sent
+        _burn(msg.sender, amount);
+
+        if (amountToWithdraw > currencyBalance()) {
+            removeLiquidityFromCurve(amountToWithdraw.sub(currencyBalance()));
+            require(amountToWithdraw <= currencyBalance(), "TrueFiPool: Not enough funds were withdrawn from Curve");
+        }
+
+        require(_currencyToken.transfer(msg.sender, amountToWithdraw));
+
+        emit Exited(msg.sender, amountToWithdraw);
+    }
+
+    /**
+     * @dev Penalty (in % * 100) applied if liquid exit is performed with this amount
+     * returns 10000 if no penalty
+     */
+    function liquidExitPenalty(uint256 amount) public view returns (uint256) {
+        uint256 lv = liquidValue();
+        uint256 pv = poolValue();
+        if (amount == pv) {
+            return 10000;
+        }
+        uint256 liquidRatioBefore = lv.mul(10000).div(pv);
+        uint256 liquidRatioAfter = lv.sub(amount).mul(10000).div(pv.sub(amount));
+        return uint256(10000).sub(averageExitPenalty(liquidRatioAfter, liquidRatioBefore));
+    }
+
+    /**
+     * @dev Calculates integral of 5/(x+50)dx times 10000
+     */
+    function integrateAtPoint(uint256 x) public pure returns (uint256) {
+        return uint256(ABDKMath64x64.ln(ABDKMath64x64.fromUInt(x.add(50)))).mul(50000).div(2**64);
+    }
+
+    /**
+     * @dev Calculates average penalty on interval [from; to]
+     */
+    function averageExitPenalty(uint256 from, uint256 to) public pure returns (uint256) {
+        require(from <= to, "TrueFiPool: To precedes from");
+        if (from == 10000) {
+            // When all liquid, dont penalize
+            return 0;
+        }
+        if (from == to) {
+            return uint256(50000).div(from.add(50));
+        }
+        return integrateAtPoint(to).sub(integrateAtPoint(from)).div(to.sub(from));
+    }
+
+    /**
+     * @dev Deposit idle funds into curve.fi pool and stake in gauge
+     * Called by owner to help manage funds in pool and save on gas for deposits
+     * @param currencyAmount Amount of funds to deposit into curve
+     * @param minMintAmount Minimum amount to mint
+     */
+    function flush(uint256 currencyAmount, uint256 minMintAmount) external onlyOwner {
+        require(currencyAmount <= currencyBalance(), "TrueFiPool: Insufficient currency balance");
+
+        uint256[N_TOKENS] memory amounts = [0, 0, 0, currencyAmount];
+
+        // add TUSD to curve
+        _currencyToken.approve(address(_curvePool), currencyAmount);
+        _curvePool.add_liquidity(amounts, minMintAmount);
+
+        // stake yCurve tokens in gauge
+        uint256 yBalance = _curvePool.token().balanceOf(address(this));
+        _curvePool.token().approve(address(_curveGauge), yBalance);
+        _curveGauge.deposit(yBalance);
+
+        emit Flushed(currencyAmount);
+    }
+
+    /**
+     * @dev Remove liquidity from curve
+     * @param yAmount amount of curve pool tokens
+     * @param minCurrencyAmount minimum amount of tokens to withdraw
+     */
+    function pull(uint256 yAmount, uint256 minCurrencyAmount) external onlyOwner {
+        require(yAmount <= yTokenBalance(), "TrueFiPool: Insufficient Curve liquidity balance");
+
+        // unstake in gauge
+        ensureEnoughTokensAreAvailable(yAmount);
+
+        // remove TUSD from curve
+        _curvePool.token().approve(address(_curvePool), yAmount);
+        _curvePool.remove_liquidity_one_coin(yAmount, TUSD_INDEX, minCurrencyAmount, false);
+
+        emit Pulled(yAmount);
+    }
+
+    // prettier-ignore
+    /**
+     * @dev Remove liquidity from curve and transfer to borrower
+     * @param expectedAmount expected amount to borrow
+     */
+    function borrow(uint256 expectedAmount, uint256 amountWithoutFee) external override nonReentrant onlyLender {
+        require(expectedAmount >= amountWithoutFee, "TrueFiPool: Fee cannot be negative");
+
+        // if there is not enough TUSD, withdraw from curve
+        if (expectedAmount > currencyBalance()) {
+            removeLiquidityFromCurve(expectedAmount.sub(currencyBalance()));
+            require(expectedAmount <= currencyBalance(), "TrueFiPool: Not enough funds in pool to cover borrow");
+        }
+
+        // calculate fees and transfer remainder
+        uint256 fee = expectedAmount.sub(amountWithoutFee);
+        claimableFees = claimableFees.add(fee);
+        require(_currencyToken.transfer(msg.sender, amountWithoutFee));
+
+        emit Borrow(msg.sender, expectedAmount, fee);
+    }
+
+    function removeLiquidityFromCurve(uint256 amountToWithdraw) internal {
+        // get rough estimate of how much yCRV we should sell
+        uint256 roughCurveTokenAmount = calcTokenAmount(amountToWithdraw).mul(1005).div(1000);
+        require(roughCurveTokenAmount <= yTokenBalance(), "TrueFiPool: Not enough Curve liquidity tokens in pool to cover borrow");
+        // pull tokens from gauge
+        ensureEnoughTokensAreAvailable(roughCurveTokenAmount);
+        // remove TUSD from curve
+        _curvePool.token().approve(address(_curvePool), roughCurveTokenAmount);
+        uint256 minAmount = roughCurveTokenAmount.mul(_curvePool.curve().get_virtual_price()).mul(999).div(1000).div(1 ether);
+        _curvePool.remove_liquidity_one_coin(roughCurveTokenAmount, TUSD_INDEX, minAmount, false);
+    }
+
+    /**
+     * @dev repay debt by transferring tokens to the contract
+     * @param currencyAmount amount to repay
+     */
+    function repay(uint256 currencyAmount) external override onlyLender {
+        require(_currencyToken.transferFrom(msg.sender, address(this), currencyAmount));
+        emit Repaid(msg.sender, currencyAmount);
+    }
+
+    /**
+     * @dev Collect CRV tokens minted by staking at gauge
+     */
+    function collectCrv() external onlyOwner {
+        _minter.mint(address(_curveGauge));
+    }
+
+    /**
+     * @dev Sell collected CRV on Uniswap
+     * - Selling CRV is managed by the contract owner
+     * - Calculations can be made off-chain and called based on market conditions
+     * - Need to pass path of exact pairs to go through while executing exchange
+     * For example, CRV -> WETH -> TUSD
+     *
+     * @param amountIn see https://uniswap.org/docs/v2/smart-contracts/router02/#swapexacttokensfortokens
+     * @param amountOutMin see https://uniswap.org/docs/v2/smart-contracts/router02/#swapexacttokensfortokens
+     * @param path see https://uniswap.org/docs/v2/smart-contracts/router02/#swapexacttokensfortokens
+     */
+    function sellCrv(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path
+    ) public onlyOwner {
+        _minter.token().approve(address(_uniRouter), amountIn);
+        _uniRouter.swapExactTokensForTokens(amountIn, amountOutMin, path, address(this), block.timestamp + 1 hours);
+    }
+
+    /**
+     * @dev Claim fees from the pool
+     * @param beneficiary account to send funds to
+     */
+    function collectFees(address beneficiary) external onlyOwner {
+        uint256 amount = claimableFees;
+        claimableFees = 0;
+
+        if (amount > 0) {
+            require(_currencyToken.transfer(beneficiary, amount));
+        }
+
+        emit Collected(beneficiary, amount);
+    }
+
+    /**
+     * @notice Expected amount of minted Curve.fi yDAI/yUSDC/yUSDT/yTUSD tokens.
+     * Can be used to control slippage
+     * Called in flush() function
+     * @param currencyAmount amount to calculate for
+     */
+    function calcTokenAmount(uint256 currencyAmount) public view returns (uint256) {
+        // prettier-ignore
+        uint256 yTokenAmount = currencyAmount.mul(1e18).div(
+            _curvePool.coins(TUSD_INDEX).getPricePerFullShare());
+        uint256[N_TOKENS] memory yAmounts = [0, 0, 0, yTokenAmount];
+        return _curvePool.curve().calc_token_amount(yAmounts, true);
+    }
+
+    /**
+     * @dev Converts the value of a single yCRV into an underlying asset
+     * @param yAmount amount of curve pool tokens to calculate for
+     * @return Value of one y pool token
+     */
+    function calcWithdrawOneCoin(uint256 yAmount) public view returns (uint256) {
+        return _curvePool.calc_withdraw_one_coin(yAmount, TUSD_INDEX);
+    }
+
+    /**
+     * @dev Currency token balance
+     * @return Currency token balance
+     */
+    function currencyBalance() internal view returns (uint256) {
+        return _currencyToken.balanceOf(address(this)).sub(claimableFees);
+    }
+}

--- a/flatten/TrueGBP.sol
+++ b/flatten/TrueGBP.sol
@@ -1,0 +1,1324 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-currencies/common/GasRefund.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+/**
+ * @title Gas Reclaim Legacy
+ *
+ * Note: this contract does not affect any of the token logic. It merely
+ * exists so the TokenController (owner) can reclaim the sponsored gas
+ *
+ * Previously TrueCurrency has a feature called "gas boost" which allowed
+ * us to sponsor gas by setting non-empty storage slots to 1.
+ * We are depricating this feature, but there is a bunch of gas saved
+ * from years of sponsoring gas. This contract is meant to allow the owner
+ * to take advantage of this leftover gas. Once all the slots are used,
+ * this contract can be removed from TrueCurrency.
+ *
+ * Utilitzes the gas refund mechanism in EVM. Each time an non-empty
+ * storage slot is set to 0, evm will refund 15,000 to the sender.
+ * Also utilized the refund for selfdestruct, see gasRefund39
+ */
+abstract contract GasRefund {
+    /**
+     * @dev Refund 15,000 gas per slot.
+     * @param amount number of slots to free
+     */
+    function gasRefund15(uint256 amount) internal {
+        assembly {
+            // get number of free slots
+            let offset := sload(0xfffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // get location of first slot
+            let location := add(offset, 0xfffff)
+            // loop until end is reached
+            for {
+                let end := sub(location, amount)
+            } gt(location, end) {
+                location := sub(location, 1)
+            } {
+                // set storage location to zero
+                // this refunds 15,000 gas
+                sstore(location, 0)
+            }
+            // store new number of free slots
+            sstore(0xfffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev use smart contract self-destruct to refund gas
+     * will refund 39,000 * amount gas
+     */
+    function gasRefund39(uint256 amount) internal {
+        assembly {
+            // get amount of gas slots
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // first sheep pointer
+            let location := sub(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, offset)
+            // loop from location to end
+            for {
+                let end := add(location, amount)
+            } lt(location, end) {
+                location := add(location, 1)
+            } {
+                // load sheep address
+                let sheep := sload(location)
+                // call selfdestruct on sheep
+                pop(call(gas(), sheep, 0, 0, 0, 0, 0))
+                // clear sheep address
+                sstore(location, 0)
+            }
+            // store new number of sheep
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev Return the remaining sponsored gas slots
+     */
+    function remainingGasRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xfffff)
+        }
+    }
+
+    /**
+     * @dev Return the remaining sheep slots
+     */
+    function remainingSheepRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrencyWithGasRefund.sol
+
+// pragma solidity 0.6.10;
+
+// import {GasRefund} from "contracts/true-currencies/common/GasRefund.sol";
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+abstract contract TrueCurrencyWithGasRefund is GasRefund, TrueCurrency {
+    /**
+     * @dev reclaim gas from legacy gas refund #1
+     * will refund 15,000 * amount gas to sender (minus exection cost)
+     * If gas pool is empty, refund 39,000 * amount gas by calling selfdestruct
+     */
+    function refundGas(uint256 amount) external onlyOwner {
+        if (remainingGasRefundPool() > 0) {
+            gasRefund15(amount);
+        } else {
+            gasRefund39(amount.div(3));
+        }
+    }
+}
+
+
+// Root file: contracts/true-currencies/tokens/TrueGBP.sol
+
+pragma solidity 0.6.10;
+
+// import {TrueCurrencyWithGasRefund} from "contracts/true-currencies/TrueCurrencyWithGasRefund.sol";
+
+/**
+ * @title TrueGBP
+ * @dev This is the top-level ERC20 contract, but most of the interesting functionality is
+ * inherited - see the documentation on the corresponding contracts.
+ */
+contract TrueGBP is TrueCurrencyWithGasRefund {
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueGBP";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TGBP";
+    }
+}

--- a/flatten/TrueGold.sol
+++ b/flatten/TrueGold.sol
@@ -1,0 +1,1033 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-gold/common/ProxyStorage.sol
+
+// SPDX-License-Identifier: UNLICENSED
+// pragma solidity 0.6.10;
+
+contract ProxyStorage {
+    // Initializable.sol
+    bool _initialized;
+    bool _initializing;
+
+    // Ownable.sol
+    address _owner;
+
+    // ERC20.sol
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    uint256 _totalSupply;
+
+    // TrueMintableBurnable.sol
+    uint256 _minBurnAmount;
+    uint256 _maxBurnAmount;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 20         "trueGold.proxy.owner"                                        Proxy Owner
+     ** 28         "trueGold.pending.proxy.owner"                                Pending Proxy Owner
+     ** 29         "trueGold.proxy.implementation"                               Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   _balances
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       _allowances
+     **/
+}
+
+
+// Dependency file: contracts/true-gold/common/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable is ProxyStorage {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    // bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    // bool private _initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(_initializing || isConstructor() || !_initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+}
+
+
+// Dependency file: contracts/true-gold/interface/IOwnable.sol
+
+// pragma solidity 0.6.10;
+
+interface IOwnable {
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/true-gold/common/Ownable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/interface/IOwnable.sol";
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+// import "contracts/true-gold/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is ProxyStorage, Initializable, IOwnable {
+    // address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function __Ownable_init_unchained() internal initializer {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == msg.sender, "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual override onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/true-gold/Reclaimable.sol
+
+// pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import "contracts/true-gold/common/Ownable.sol";
+// import "contracts/true-gold/common/ProxyStorage.sol";
+// import "contracts/true-gold/interface/IOwnable.sol";
+
+contract Reclaimable is Ownable {
+    function reclaimEther(address payable to) public onlyOwner {
+        to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address to) public onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(to, balance);
+    }
+
+    function reclaimContract(IOwnable ownable) public onlyOwner {
+        ownable.transferOwnership(_owner);
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/ERC20.sol
+
+// pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+// import "@openzeppelin/contracts/utils/Address.sol";
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20MinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ProxyStorage, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    // mapping (address => uint256) private _balances;
+    // mapping (address => mapping (address => uint256)) private _allowances;
+    // uint256 private _totalSupply;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8);
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public override view returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public override view returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(msg.sender, recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public virtual override view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(msg.sender, spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/ERC20Burnable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ERC20.sol";
+
+/**
+ * @dev Extension of {ERC20} that allows token holders to destroy both their own
+ * tokens and those that they have an allowance for, in a way that can be
+ * recognized off-chain (via event analysis).
+ */
+abstract contract ERC20Burnable is ERC20 {
+    /**
+     * @dev Destroys `amount` tokens from the caller.
+     *
+     * See {ERC20-_burn}.
+     */
+    function burn(uint256 amount) public virtual {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, deducting from the caller's
+     * allowance.
+     *
+     * See {ERC20-_burn} and {ERC20-allowance}.
+     *
+     * Requirements:
+     *
+     * - the caller must have allowance for ``accounts``'s tokens of at least
+     * `amount`.
+     */
+    function burnFrom(address account, uint256 amount) public virtual {
+        uint256 decreasedAllowance = allowance(account, msg.sender).sub(amount, "ERC20Burnable: burn amount exceeds allowance");
+
+        _approve(account, msg.sender, decreasedAllowance);
+        _burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-gold/TrueMintableBurnable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ERC20Burnable.sol";
+// import "contracts/true-gold/common/Initializable.sol";
+// import "contracts/true-gold/common/Ownable.sol";
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+abstract contract TrueMintableBurnable is ProxyStorage, Initializable, Ownable, ERC20Burnable {
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    event Mint(address indexed to, uint256 value);
+    event Burn(address indexed burner, uint256 value);
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    // solhint-disable-next-line func-name-mixedcase
+    function __TrueMintableBurnable_init_unchained(uint256 minBurnAmount, uint256 maxBurnAmount) internal initializer {
+        setBurnBounds(minBurnAmount, maxBurnAmount);
+    }
+
+    function burnMin() public view returns (uint256) {
+        return _minBurnAmount;
+    }
+
+    function burnMax() public view returns (uint256) {
+        return _maxBurnAmount;
+    }
+
+    // Change the minimum and maximum amount that can be burned at once. Burning may be disabled by setting both to 0
+    // (this will not be done under normal operation, but we can't add checks to disallow it without losing a lot of
+    // flexibility since burning could also be as good as disabled by setting the minimum extremely high, and we don't
+    // want to lock in any particular cap for the minimum)
+    function setBurnBounds(uint256 minAmount, uint256 maxAmount) public virtual onlyOwner {
+        require(minAmount <= maxAmount, "TrueMintableBurnable: min is greater then max");
+        _minBurnAmount = minAmount;
+        _maxBurnAmount = maxAmount;
+        emit SetBurnBounds(minAmount, maxAmount);
+    }
+
+    function mint(address account, uint256 amount) public virtual onlyOwner {
+        require(uint256(account) > REDEMPTION_ADDRESS_COUNT, "TrueMintableBurnable: mint to a redemption or zero address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        require(super.transfer(recipient, amount));
+        if (uint256(recipient) <= REDEMPTION_ADDRESS_COUNT) {
+            _burn(recipient, amount);
+        }
+        return true;
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        require(super.transferFrom(sender, recipient, amount));
+        if (uint256(recipient) <= REDEMPTION_ADDRESS_COUNT) {
+            _burn(recipient, amount);
+        }
+        return true;
+    }
+
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= _minBurnAmount, "TrueMintableBurnable: burn amount below min bound");
+        require(amount <= _maxBurnAmount, "TrueMintableBurnable: burn amount exceeds max bound");
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Root file: contracts/true-gold/TrueGold.sol
+
+pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/Initializable.sol";
+// import "contracts/true-gold/common/Ownable.sol";
+
+// import "contracts/true-gold/Reclaimable.sol";
+// import "contracts/true-gold/TrueMintableBurnable.sol";
+
+contract TrueGold is Initializable, Ownable, TrueMintableBurnable, Reclaimable {
+    using SafeMath for uint256;
+
+    uint8 private constant DECIMALS = 6;
+    uint256 private constant BURN_AMOUNT_MULTIPLIER = 12_500_000;
+
+    function initialize(uint256 minBurnAmount, uint256 maxBurnAmount) public initializer {
+        __Ownable_init_unchained();
+        __TrueMintableBurnable_init_unchained(minBurnAmount, maxBurnAmount);
+    }
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueGold";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TGLD";
+    }
+
+    function setBurnBounds(uint256 minAmount, uint256 maxAmount) public override onlyOwner {
+        require(minAmount.mod(BURN_AMOUNT_MULTIPLIER) == 0, "TrueGold: min amount is not a multiple of 12,500,000");
+        require(maxAmount.mod(BURN_AMOUNT_MULTIPLIER) == 0, "TrueGold: max amount is not a multiple of 12,500,000");
+        super.setBurnBounds(minAmount, maxAmount);
+    }
+
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount.mod(BURN_AMOUNT_MULTIPLIER) == 0, "TrueGold: burn amount is not a multiple of 12,500,000");
+        super._burn(account, amount);
+    }
+}

--- a/flatten/TrueGoldController.sol
+++ b/flatten/TrueGoldController.sol
@@ -1,0 +1,1992 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: contracts/true-gold/interface/IOwnable.sol
+
+// pragma solidity 0.6.10;
+
+interface IOwnable {
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/proxy/OwnedUpgradeabilityProxy.sol
+
+// solhint-disable const-name-snakecase
+// pragma solidity 0.6.10;
+
+/**
+ * @title OwnedUpgradeabilityProxy
+ * @dev This contract combines an upgradeability proxy with basic authorization control functionalities
+ */
+contract OwnedUpgradeabilityProxy {
+    /**
+     * @dev Event to show ownership has been transferred
+     * @param previousOwner representing the address of the previous owner
+     * @param newOwner representing the address of the new owner
+     */
+    event ProxyOwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Event to show ownership transfer is pending
+     * @param currentOwner representing the address of the current owner
+     * @param pendingOwner representing the address of the pending owner
+     */
+    event NewPendingOwner(address currentOwner, address pendingOwner);
+
+    // Storage position of the owner and pendingOwner of the contract
+    bytes32 private constant proxyOwnerPosition = 0x6279e8199720cf3557ecd8b58d667c8edc486bd1cf3ad59ea9ebdfcae0d0dfac; //keccak256("trueUSD.proxy.owner");
+    bytes32 private constant pendingProxyOwnerPosition = 0x8ddbac328deee8d986ec3a7b933a196f96986cb4ee030d86cc56431c728b83f4; //keccak256("trueUSD.pending.proxy.owner");
+
+    /**
+     * @dev the constructor sets the original owner of the contract to the sender account.
+     */
+    constructor() public {
+        _setUpgradeabilityOwner(msg.sender);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyProxyOwner() {
+        require(msg.sender == proxyOwner(), "only Proxy Owner");
+        _;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the pending owner.
+     */
+    modifier onlyPendingProxyOwner() {
+        require(msg.sender == pendingProxyOwner(), "only pending Proxy Owner");
+        _;
+    }
+
+    /**
+     * @dev Tells the address of the owner
+     * @return owner the address of the owner
+     */
+    function proxyOwner() public view returns (address owner) {
+        bytes32 position = proxyOwnerPosition;
+        assembly {
+            owner := sload(position)
+        }
+    }
+
+    /**
+     * @dev Tells the address of the owner
+     * @return pendingOwner the address of the pending owner
+     */
+    function pendingProxyOwner() public view returns (address pendingOwner) {
+        bytes32 position = pendingProxyOwnerPosition;
+        assembly {
+            pendingOwner := sload(position)
+        }
+    }
+
+    /**
+     * @dev Sets the address of the owner
+     */
+    function _setUpgradeabilityOwner(address newProxyOwner) internal {
+        bytes32 position = proxyOwnerPosition;
+        assembly {
+            sstore(position, newProxyOwner)
+        }
+    }
+
+    /**
+     * @dev Sets the address of the owner
+     */
+    function _setPendingUpgradeabilityOwner(address newPendingProxyOwner) internal {
+        bytes32 position = pendingProxyOwnerPosition;
+        assembly {
+            sstore(position, newPendingProxyOwner)
+        }
+    }
+
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     *changes the pending owner to newOwner. But doesn't actually transfer
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferProxyOwnership(address newOwner) external onlyProxyOwner {
+        require(newOwner != address(0));
+        _setPendingUpgradeabilityOwner(newOwner);
+        emit NewPendingOwner(proxyOwner(), newOwner);
+    }
+
+    /**
+     * @dev Allows the pendingOwner to claim ownership of the proxy
+     */
+    function claimProxyOwnership() external onlyPendingProxyOwner {
+        emit ProxyOwnershipTransferred(proxyOwner(), pendingProxyOwner());
+        _setUpgradeabilityOwner(pendingProxyOwner());
+        _setPendingUpgradeabilityOwner(address(0));
+    }
+
+    /**
+     * @dev Allows the proxy owner to upgrade the current version of the proxy.
+     * @param implementation representing the address of the new implementation to be set.
+     */
+    function upgradeTo(address implementation) public virtual onlyProxyOwner {
+        address currentImplementation;
+        bytes32 position = implementationPosition;
+        assembly {
+            currentImplementation := sload(position)
+        }
+        require(currentImplementation != implementation);
+        assembly {
+            sstore(position, implementation)
+        }
+        emit Upgraded(implementation);
+    }
+
+    /**
+     * @dev This event will be emitted every time the implementation gets upgraded
+     * @param implementation representing the address of the upgraded implementation
+     */
+    event Upgraded(address indexed implementation);
+
+    // Storage position of the address of the current implementation
+    bytes32 private constant implementationPosition = 0x6e41e0fbe643dfdb6043698bf865aada82dc46b953f754a3468eaa272a362dc7; //keccak256("trueUSD.proxy.implementation");
+
+    function implementation() public view returns (address impl) {
+        bytes32 position = implementationPosition;
+        assembly {
+            impl := sload(position)
+        }
+    }
+
+    /**
+     * @dev Fallback functions allowing to perform a delegatecall to the given implementation.
+     * This function will return whatever the implementation call returns
+     */
+    fallback() external payable {
+        proxyCall();
+    }
+
+    receive() external payable {
+        proxyCall();
+    }
+
+    function proxyCall() internal {
+        bytes32 position = implementationPosition;
+
+        assembly {
+            let ptr := mload(0x40)
+            calldatacopy(ptr, returndatasize(), calldatasize())
+            let result := delegatecall(gas(), sload(position), ptr, calldatasize(), returndatasize(), returndatasize())
+            returndatacopy(ptr, 0, returndatasize())
+
+            switch result
+                case 0 {
+                    revert(ptr, returndatasize())
+                }
+                default {
+                    return(ptr, returndatasize())
+                }
+        }
+    }
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: contracts/registry/Registry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+contract Registry {
+    struct AttributeData {
+        uint256 value;
+        bytes32 notes;
+        address adminAddr;
+        uint256 timestamp;
+    }
+
+    // never remove any storage variables
+    address public owner;
+    address public pendingOwner;
+    bool initialized;
+
+    // Stores arbitrary attributes for users. An example use case is an IERC20
+    // token that requires its users to go through a KYC/AML check - in this case
+    // a validator can set an account's "hasPassedKYC/AML" attribute to 1 to indicate
+    // that account can use the token. This mapping stores that value (1, in the
+    // example) as well as which validator last set the value and at what time,
+    // so that e.g. the check can be renewed at appropriate intervals.
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
+    // The logic governing who is allowed to set what attributes is abstracted as
+    // this accessManager, so that it may be replaced by the owner as needed
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    mapping(bytes32 => RegistryClone[]) subscribers;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetManager(address indexed oldManager, address indexed newManager);
+    event StartSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+    event StopSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+
+    // Allows a write if either a) the writer is that Registry's owner, or
+    // b) the writer is writing to attribute foo and that writer already has
+    // the canWriteTo-foo attribute set (in that same Registry)
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
+        return (_admin == owner || hasAttribute(_admin, keccak256(abi.encodePacked(WRITE_PERMISSION ^ _attribute))));
+    }
+
+    // Writes are allowed only if the accessManager approves
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
+
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    function subscribe(bytes32 _attribute, RegistryClone _syncer) external onlyOwner {
+        subscribers[_attribute].push(_syncer);
+        emit StartSubscription(_attribute, _syncer);
+    }
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external onlyOwner {
+        uint256 length = subscribers[_attribute].length;
+        require(_index < length);
+        emit StopSubscription(_attribute, subscribers[_attribute][_index]);
+        subscribers[_attribute][_index] = subscribers[_attribute][length - 1];
+        subscribers[_attribute].pop();
+    }
+
+    function subscriberCount(bytes32 _attribute) public view returns (uint256) {
+        return subscribers[_attribute].length;
+    }
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, "", msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, "", msg.sender);
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    // Returns true if the uint256 value stored for this attribute is non-zero
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
+        return attributes[_who][_attribute].value != 0;
+    }
+
+    // Returns the exact value of the attribute, as well as its metadata
+    function getAttribute(address _who, bytes32 _attribute)
+        public
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        )
+    {
+        AttributeData memory data = attributes[_who][_attribute];
+        return (data.value, data.notes, data.adminAddr, data.timestamp);
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].value;
+    }
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) public view returns (address) {
+        return attributes[_who][_attribute].adminAddr;
+    }
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].timestamp;
+    }
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external {
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > _startIndex) {
+            RegistryClone target = targets[index];
+            for (uint256 i = _addresses.length; i-- > 0; ) {
+                address who = _addresses[i];
+                target.syncAttributeValue(who, _attribute, attributes[who][_attribute].value);
+            }
+        }
+    }
+
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+contract ProxyStorage {
+    // Initializable.sol
+    bool _initialized;
+    bool _initializing;
+
+    // Ownable.sol
+    address _owner;
+
+    // ERC20.sol
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    uint256 _totalSupply;
+
+    // TrueMintableBurnable.sol
+    uint256 _minBurnAmount;
+    uint256 _maxBurnAmount;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 20         "trueGold.proxy.owner"                                        Proxy Owner
+     ** 28         "trueGold.pending.proxy.owner"                                Pending Proxy Owner
+     ** 29         "trueGold.proxy.implementation"                               Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   _balances
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       _allowances
+     **/
+}
+
+
+// Dependency file: contracts/true-gold/common/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable is ProxyStorage {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    // bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    // bool private _initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(_initializing || isConstructor() || !_initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/Ownable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/interface/IOwnable.sol";
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+// import "contracts/true-gold/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is ProxyStorage, Initializable, IOwnable {
+    // address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function __Ownable_init_unchained() internal initializer {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == msg.sender, "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual override onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Dependency file: contracts/true-gold/Reclaimable.sol
+
+// pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import "contracts/true-gold/common/Ownable.sol";
+// import "contracts/true-gold/common/ProxyStorage.sol";
+// import "contracts/true-gold/interface/IOwnable.sol";
+
+contract Reclaimable is Ownable {
+    function reclaimEther(address payable to) public onlyOwner {
+        to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address to) public onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(to, balance);
+    }
+
+    function reclaimContract(IOwnable ownable) public onlyOwner {
+        ownable.transferOwnership(_owner);
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/ERC20.sol
+
+// pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+// import "@openzeppelin/contracts/utils/Address.sol";
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20MinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ProxyStorage, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    // mapping (address => uint256) private _balances;
+    // mapping (address => mapping (address => uint256)) private _allowances;
+    // uint256 private _totalSupply;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8);
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public override view returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public override view returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(msg.sender, recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public virtual override view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(msg.sender, spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/ERC20Burnable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ERC20.sol";
+
+/**
+ * @dev Extension of {ERC20} that allows token holders to destroy both their own
+ * tokens and those that they have an allowance for, in a way that can be
+ * recognized off-chain (via event analysis).
+ */
+abstract contract ERC20Burnable is ERC20 {
+    /**
+     * @dev Destroys `amount` tokens from the caller.
+     *
+     * See {ERC20-_burn}.
+     */
+    function burn(uint256 amount) public virtual {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, deducting from the caller's
+     * allowance.
+     *
+     * See {ERC20-_burn} and {ERC20-allowance}.
+     *
+     * Requirements:
+     *
+     * - the caller must have allowance for ``accounts``'s tokens of at least
+     * `amount`.
+     */
+    function burnFrom(address account, uint256 amount) public virtual {
+        uint256 decreasedAllowance = allowance(account, msg.sender).sub(amount, "ERC20Burnable: burn amount exceeds allowance");
+
+        _approve(account, msg.sender, decreasedAllowance);
+        _burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-gold/TrueMintableBurnable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ERC20Burnable.sol";
+// import "contracts/true-gold/common/Initializable.sol";
+// import "contracts/true-gold/common/Ownable.sol";
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+abstract contract TrueMintableBurnable is ProxyStorage, Initializable, Ownable, ERC20Burnable {
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    event Mint(address indexed to, uint256 value);
+    event Burn(address indexed burner, uint256 value);
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    // solhint-disable-next-line func-name-mixedcase
+    function __TrueMintableBurnable_init_unchained(uint256 minBurnAmount, uint256 maxBurnAmount) internal initializer {
+        setBurnBounds(minBurnAmount, maxBurnAmount);
+    }
+
+    function burnMin() public view returns (uint256) {
+        return _minBurnAmount;
+    }
+
+    function burnMax() public view returns (uint256) {
+        return _maxBurnAmount;
+    }
+
+    // Change the minimum and maximum amount that can be burned at once. Burning may be disabled by setting both to 0
+    // (this will not be done under normal operation, but we can't add checks to disallow it without losing a lot of
+    // flexibility since burning could also be as good as disabled by setting the minimum extremely high, and we don't
+    // want to lock in any particular cap for the minimum)
+    function setBurnBounds(uint256 minAmount, uint256 maxAmount) public virtual onlyOwner {
+        require(minAmount <= maxAmount, "TrueMintableBurnable: min is greater then max");
+        _minBurnAmount = minAmount;
+        _maxBurnAmount = maxAmount;
+        emit SetBurnBounds(minAmount, maxAmount);
+    }
+
+    function mint(address account, uint256 amount) public virtual onlyOwner {
+        require(uint256(account) > REDEMPTION_ADDRESS_COUNT, "TrueMintableBurnable: mint to a redemption or zero address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        require(super.transfer(recipient, amount));
+        if (uint256(recipient) <= REDEMPTION_ADDRESS_COUNT) {
+            _burn(recipient, amount);
+        }
+        return true;
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        require(super.transferFrom(sender, recipient, amount));
+        if (uint256(recipient) <= REDEMPTION_ADDRESS_COUNT) {
+            _burn(recipient, amount);
+        }
+        return true;
+    }
+
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= _minBurnAmount, "TrueMintableBurnable: burn amount below min bound");
+        require(amount <= _maxBurnAmount, "TrueMintableBurnable: burn amount exceeds max bound");
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-gold/TrueGold.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/Initializable.sol";
+// import "contracts/true-gold/common/Ownable.sol";
+
+// import "contracts/true-gold/Reclaimable.sol";
+// import "contracts/true-gold/TrueMintableBurnable.sol";
+
+contract TrueGold is Initializable, Ownable, TrueMintableBurnable, Reclaimable {
+    using SafeMath for uint256;
+
+    uint8 private constant DECIMALS = 6;
+    uint256 private constant BURN_AMOUNT_MULTIPLIER = 12_500_000;
+
+    function initialize(uint256 minBurnAmount, uint256 maxBurnAmount) public initializer {
+        __Ownable_init_unchained();
+        __TrueMintableBurnable_init_unchained(minBurnAmount, maxBurnAmount);
+    }
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueGold";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TGLD";
+    }
+
+    function setBurnBounds(uint256 minAmount, uint256 maxAmount) public override onlyOwner {
+        require(minAmount.mod(BURN_AMOUNT_MULTIPLIER) == 0, "TrueGold: min amount is not a multiple of 12,500,000");
+        require(maxAmount.mod(BURN_AMOUNT_MULTIPLIER) == 0, "TrueGold: max amount is not a multiple of 12,500,000");
+        super.setBurnBounds(minAmount, maxAmount);
+    }
+
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount.mod(BURN_AMOUNT_MULTIPLIER) == 0, "TrueGold: burn amount is not a multiple of 12,500,000");
+        super._burn(account, amount);
+    }
+}
+
+
+// Root file: contracts/true-gold/TrueGoldController.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {IOwnable} from "contracts/true-gold/interface/IOwnable.sol";
+
+// import {OwnedUpgradeabilityProxy} from "contracts/proxy/OwnedUpgradeabilityProxy.sol";
+// import {Registry} from "contracts/registry/Registry.sol";
+
+// import "contracts/true-gold/TrueGold.sol";
+
+/** @title TrueGoldController
+@dev This contract has been copied from {true-currencies} repository and adjusted for TrueGold needs.
+https://github.com/trusttoken/true-currencies/blob/eb01ca47111e66c9fa8bf59d78617ad28e232e06/contracts/truecurrencies/admin/TokenController.sol
+
+This contract allows us to split ownership of the TrueGold contract
+into two addresses. One, called the "owner" address, has unfettered control of the TrueGold contract -
+it can mint new tokens, transfer ownership of the contract, etc. However to make
+extra sure that TrueGold is never compromised, this owner key will not be used in
+day-to-day operations, allowing it to be stored at a heightened level of security.
+Instead, the owner appoints an various "admin" address.
+There are 3 different types of admin addresses;  MintKey, MintRatifier, and MintPauser.
+MintKey can request and revoke mints one at a time.
+MintPausers can pause individual mints or pause all mints.
+MintRatifiers can approve and finalize mints with enough approval.
+
+There are three levels of mints: instant mint, ratified mint, and multiSig mint. Each have a different threshold
+and deduct from a different pool.
+Instant mint has the lowest threshold and finalizes instantly without any ratifiers. Deduct from instant mint pool,
+which can be refilled by one ratifier.
+Ratify mint has the second lowest threshold and finalizes with one ratifier approval. Deduct from ratify mint pool,
+which can be refilled by three ratifiers.
+MultiSig mint has the highest threshold and finalizes with three ratifier approvals. Deduct from multiSig mint pool,
+which can only be refilled by the owner.
+*/
+
+contract TrueGoldController {
+    using SafeMath for uint256;
+
+    struct MintOperation {
+        address to;
+        uint256 value;
+        uint256 requestedBlock;
+        uint256 numberOfApproval;
+        bool paused;
+        mapping(address => bool) approved;
+    }
+
+    address payable public owner;
+    address payable public pendingOwner;
+
+    bool public initialized;
+
+    uint256 public instantMintThreshold;
+    uint256 public ratifiedMintThreshold;
+    uint256 public multiSigMintThreshold;
+
+    uint256 public instantMintLimit;
+    uint256 public ratifiedMintLimit;
+    uint256 public multiSigMintLimit;
+
+    uint256 public instantMintPool;
+    uint256 public ratifiedMintPool;
+    uint256 public multiSigMintPool;
+    address[2] public ratifiedPoolRefillApprovals;
+
+    uint8 public constant RATIFY_MINT_SIGS = 1; //number of approvals needed to finalize a Ratified Mint
+    uint8 public constant MULTISIG_MINT_SIGS = 3; //number of approvals needed to finalize a MultiSig Mint
+
+    bool public mintPaused;
+    uint256 public mintReqInvalidBeforeThisBlock; //all mint request before this block are invalid
+    address public mintKey;
+    MintOperation[] public mintOperations; //list of a mint requests
+
+    TrueGold public token;
+    Registry public registry;
+    address public fastPause;
+
+    bytes32 public constant IS_MINT_PAUSER = "isTGLDMintPauser";
+    bytes32 public constant IS_MINT_RATIFIER = "isTGLDMintRatifier";
+
+    // paused version of TrueGold in Production
+    // pausing the contract upgrades the proxy to this implementation
+    address public constant PAUSED_IMPLEMENTATION = 0x3c8984DCE8f68FCDEEEafD9E0eca3598562eD291; // TODO replace with deployed PausedTrueGold address
+
+    modifier onlyFastPauseOrOwner() {
+        require(msg.sender == fastPause || msg.sender == owner, "must be pauser or owner");
+        _;
+    }
+
+    modifier onlyMintKeyOrOwner() {
+        require(msg.sender == mintKey || msg.sender == owner, "must be mintKey or owner");
+        _;
+    }
+
+    modifier onlyMintPauserOrOwner() {
+        require(registry.hasAttribute(msg.sender, IS_MINT_PAUSER) || msg.sender == owner, "must be pauser or owner");
+        _;
+    }
+
+    modifier onlyMintRatifierOrOwner() {
+        require(registry.hasAttribute(msg.sender, IS_MINT_RATIFIER) || msg.sender == owner, "must be ratifier or owner");
+        _;
+    }
+
+    //mint operations by the mintkey cannot be processed on when mints are paused
+    modifier mintNotPaused() {
+        if (msg.sender != owner) {
+            require(!mintPaused, "minting is paused");
+        }
+        _;
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event NewOwnerPending(address indexed currentOwner, address indexed pendingOwner);
+    event SetRegistry(address indexed registry);
+    event TransferChild(address indexed child, address indexed newOwner);
+    event ReclaimContract(address indexed other);
+    event SetToken(TrueGold newContract);
+
+    event RequestMint(address indexed to, uint256 indexed value, uint256 opIndex, address mintKey);
+    event FinalizeMint(address indexed to, uint256 indexed value, uint256 opIndex, address mintKey);
+    event InstantMint(address indexed to, uint256 indexed value, address indexed mintKey);
+
+    event TransferMintKey(address indexed previousMintKey, address indexed newMintKey);
+    event MintRatified(uint256 indexed opIndex, address indexed ratifier);
+    event RevokeMint(uint256 opIndex);
+    event AllMintsPaused(bool status);
+    event MintPaused(uint256 opIndex, bool status);
+    event FastPauseSet(address _newFastPause);
+
+    event MintThresholdChanged(uint256 instant, uint256 ratified, uint256 multiSig);
+    event MintLimitsChanged(uint256 instant, uint256 ratified, uint256 multiSig);
+    event InstantPoolRefilled();
+    event RatifyPoolRefilled();
+    event MultiSigPoolRefilled();
+
+    /*
+    ========================================
+    Ownership functions
+    ========================================
+    */
+
+    function initialize() external {
+        require(!initialized, "already initialized");
+        owner = msg.sender;
+        initialized = true;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only Pending Owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address payable newOwner) external onlyOwner {
+        pendingOwner = newOwner;
+        emit NewOwnerPending(address(owner), address(pendingOwner));
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() external onlyPendingOwner {
+        emit OwnershipTransferred(address(owner), address(pendingOwner));
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+
+    /*
+    ========================================
+    proxy functions
+    ========================================
+    */
+
+    function transferTokenProxyOwnership(address _newOwner) external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).transferProxyOwnership(_newOwner);
+    }
+
+    function claimTokenProxyOwnership() external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).claimProxyOwnership();
+    }
+
+    function upgradeTokenProxyImplTo(address _implementation) external onlyOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(_implementation);
+    }
+
+    /*
+    ========================================
+    Minting functions
+    ========================================
+    */
+
+    /**
+     * @dev set the threshold for a mint to be considered an instant mint, ratify mint and multiSig mint
+     Instant mint requires no approval, ratify mint requires 1 approval and multiSig mint requires 3 approvals
+     */
+    function setMintThresholds(
+        uint256 _instant,
+        uint256 _ratified,
+        uint256 _multiSig
+    ) external onlyOwner {
+        require(_instant <= _ratified && _ratified <= _multiSig);
+        instantMintThreshold = _instant;
+        ratifiedMintThreshold = _ratified;
+        multiSigMintThreshold = _multiSig;
+        emit MintThresholdChanged(_instant, _ratified, _multiSig);
+    }
+
+    /**
+     * @dev set the limit of each mint pool. For example can only instant mint up to the instant mint pool limit
+     before needing to refill
+     */
+    function setMintLimits(
+        uint256 _instant,
+        uint256 _ratified,
+        uint256 _multiSig
+    ) external onlyOwner {
+        require(_instant <= _ratified && _ratified <= _multiSig);
+        instantMintLimit = _instant;
+        if (instantMintPool > instantMintLimit) {
+            instantMintPool = instantMintLimit;
+        }
+        ratifiedMintLimit = _ratified;
+        if (ratifiedMintPool > ratifiedMintLimit) {
+            ratifiedMintPool = ratifiedMintLimit;
+        }
+        multiSigMintLimit = _multiSig;
+        if (multiSigMintPool > multiSigMintLimit) {
+            multiSigMintPool = multiSigMintLimit;
+        }
+        emit MintLimitsChanged(_instant, _ratified, _multiSig);
+    }
+
+    /**
+     * @dev Ratifier can refill instant mint pool
+     */
+    function refillInstantMintPool() external onlyMintRatifierOrOwner {
+        ratifiedMintPool = ratifiedMintPool.sub(instantMintLimit.sub(instantMintPool));
+        instantMintPool = instantMintLimit;
+        emit InstantPoolRefilled();
+    }
+
+    /**
+     * @dev Owner or 3 ratifiers can refill Ratified Mint Pool
+     */
+    function refillRatifiedMintPool() external onlyMintRatifierOrOwner {
+        if (msg.sender != owner) {
+            address[2] memory refillApprovals = ratifiedPoolRefillApprovals;
+            require(msg.sender != refillApprovals[0] && msg.sender != refillApprovals[1]);
+            if (refillApprovals[0] == address(0)) {
+                ratifiedPoolRefillApprovals[0] = msg.sender;
+                return;
+            }
+            if (refillApprovals[1] == address(0)) {
+                ratifiedPoolRefillApprovals[1] = msg.sender;
+                return;
+            }
+        }
+        delete ratifiedPoolRefillApprovals; // clears the whole array
+        multiSigMintPool = multiSigMintPool.sub(ratifiedMintLimit.sub(ratifiedMintPool));
+        ratifiedMintPool = ratifiedMintLimit;
+        emit RatifyPoolRefilled();
+    }
+
+    /**
+     * @dev Owner can refill MultiSig Mint Pool
+     */
+    function refillMultiSigMintPool() external onlyOwner {
+        multiSigMintPool = multiSigMintLimit;
+        emit MultiSigPoolRefilled();
+    }
+
+    /**
+     * @dev mintKey initiates a request to mint _value for account _to
+     * @param _to the address to mint to
+     * @param _value the amount requested
+     */
+    function requestMint(address _to, uint256 _value) external mintNotPaused onlyMintKeyOrOwner {
+        MintOperation memory op = MintOperation(_to, _value, block.number, 0, false);
+        emit RequestMint(_to, _value, mintOperations.length, msg.sender);
+        mintOperations.push(op);
+    }
+
+    /**
+     * @dev Instant mint without ratification if the amount is less than instantMintThreshold and instantMintPool
+     * @param _to the address to mint to
+     * @param _value the amount minted
+     */
+    function instantMint(address _to, uint256 _value) external mintNotPaused onlyMintKeyOrOwner {
+        require(_value <= instantMintThreshold, "over the instant mint threshold");
+        require(_value <= instantMintPool, "instant mint pool is dry");
+        instantMintPool = instantMintPool.sub(_value);
+        emit InstantMint(_to, _value, msg.sender);
+        token.mint(_to, _value);
+    }
+
+    /**
+     * @dev ratifier ratifies a request mint. If the number of ratifiers that signed off is greater than
+     the number of approvals required, the request is finalized
+     * @param _index the index of the requestMint to ratify
+     * @param _to the address to mint to
+     * @param _value the amount requested
+     */
+    function ratifyMint(
+        uint256 _index,
+        address _to,
+        uint256 _value
+    ) external mintNotPaused onlyMintRatifierOrOwner {
+        MintOperation memory op = mintOperations[_index];
+        require(op.to == _to, "to address does not match");
+        require(op.value == _value, "amount does not match");
+        require(!mintOperations[_index].approved[msg.sender], "already approved");
+        mintOperations[_index].approved[msg.sender] = true;
+        mintOperations[_index].numberOfApproval = mintOperations[_index].numberOfApproval.add(1);
+        emit MintRatified(_index, msg.sender);
+        if (hasEnoughApproval(mintOperations[_index].numberOfApproval, _value)) {
+            finalizeMint(_index);
+        }
+    }
+
+    /**
+     * @dev finalize a mint request, mint the amount requested to the specified address
+     @param _index of the request (visible in the RequestMint event accompanying the original request)
+     */
+    function finalizeMint(uint256 _index) public mintNotPaused {
+        MintOperation memory op = mintOperations[_index];
+        address to = op.to;
+        uint256 value = op.value;
+        if (msg.sender != owner) {
+            require(canFinalize(_index));
+            _subtractFromMintPool(value);
+        }
+        delete mintOperations[_index];
+        token.mint(to, value);
+        emit FinalizeMint(to, value, _index, msg.sender);
+    }
+
+    /**
+     * assumption: only invoked when canFinalize
+     */
+    function _subtractFromMintPool(uint256 _value) internal {
+        if (_value <= ratifiedMintPool && _value <= ratifiedMintThreshold) {
+            ratifiedMintPool = ratifiedMintPool.sub(_value);
+        } else {
+            multiSigMintPool = multiSigMintPool.sub(_value);
+        }
+    }
+
+    /**
+     * @dev compute if the number of approvals is enough for a given mint amount
+     */
+    function hasEnoughApproval(uint256 _numberOfApproval, uint256 _value) public view returns (bool) {
+        if (_value <= ratifiedMintPool && _value <= ratifiedMintThreshold) {
+            if (_numberOfApproval >= RATIFY_MINT_SIGS) {
+                return true;
+            }
+        }
+        if (_value <= multiSigMintPool && _value <= multiSigMintThreshold) {
+            if (_numberOfApproval >= MULTISIG_MINT_SIGS) {
+                return true;
+            }
+        }
+        if (msg.sender == owner) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @dev compute if a mint request meets all the requirements to be finalized
+     utility function for a front end
+     */
+    function canFinalize(uint256 _index) public view returns (bool) {
+        MintOperation memory op = mintOperations[_index];
+        require(op.requestedBlock > mintReqInvalidBeforeThisBlock, "this mint is invalid"); //also checks if request still exists
+        require(!op.paused, "this mint is paused");
+        require(hasEnoughApproval(op.numberOfApproval, op.value), "not enough approvals");
+        return true;
+    }
+
+    /**
+     *@dev revoke a mint request, Delete the mintOperation
+     *@param _index of the request (visible in the RequestMint event accompanying the original request)
+     */
+    function revokeMint(uint256 _index) external onlyMintKeyOrOwner {
+        delete mintOperations[_index];
+        emit RevokeMint(_index);
+    }
+
+    function mintOperationCount() public view returns (uint256) {
+        return mintOperations.length;
+    }
+
+    /*
+    ========================================
+    Key management
+    ========================================
+    */
+
+    /**
+     *@dev Replace the current mintkey with new mintkey
+     *@param _newMintKey address of the new mintKey
+     */
+    function transferMintKey(address _newMintKey) external onlyOwner {
+        require(_newMintKey != address(0), "new mint key cannot be 0x0");
+        emit TransferMintKey(mintKey, _newMintKey);
+        mintKey = _newMintKey;
+    }
+
+    /*
+    ========================================
+    Mint Pausing
+    ========================================
+    */
+
+    /**
+     *@dev invalidates all mint request initiated before the current block
+     */
+    function invalidateAllPendingMints() external onlyOwner {
+        mintReqInvalidBeforeThisBlock = block.number;
+    }
+
+    /**
+     *@dev pause any further mint request and mint finalizations
+     */
+    function pauseMints() external onlyMintPauserOrOwner {
+        mintPaused = true;
+        emit AllMintsPaused(true);
+    }
+
+    /**
+     *@dev unpause any further mint request and mint finalizations
+     */
+    function unpauseMints() external onlyOwner {
+        mintPaused = false;
+        emit AllMintsPaused(false);
+    }
+
+    /**
+     *@dev pause a specific mint request
+     *@param  _opIndex the index of the mint request the caller wants to pause
+     */
+    function pauseMint(uint256 _opIndex) external onlyMintPauserOrOwner {
+        mintOperations[_opIndex].paused = true;
+        emit MintPaused(_opIndex, true);
+    }
+
+    /**
+     *@dev unpause a specific mint request
+     *@param  _opIndex the index of the mint request the caller wants to unpause
+     */
+    function unpauseMint(uint256 _opIndex) external onlyOwner {
+        mintOperations[_opIndex].paused = false;
+        emit MintPaused(_opIndex, false);
+    }
+
+    /*
+    ========================================
+    set and claim contracts, administrative
+    ========================================
+    */
+
+    /**
+    *@dev Update this contract's token pointer to newContract (e.g. if the
+    contract is upgraded)
+    */
+    function setToken(TrueGold _newContract) external onlyOwner {
+        token = _newContract;
+        emit SetToken(_newContract);
+    }
+
+    /**
+     *@dev Update this contract's registry pointer to _registry
+     */
+    function setRegistry(Registry _registry) external onlyOwner {
+        registry = _registry;
+        emit SetRegistry(address(registry));
+    }
+
+    /**
+    *@dev Transfer ownership of _child to _newOwner.
+    Can be used e.g. to upgrade this TrueGoldController contract.
+    *@param _child contract that TrueGoldController currently Owns
+    *@param _newOwner new owner/pending owner of _child
+    */
+    function transferChild(IOwnable _child, address _newOwner) external onlyOwner {
+        _child.transferOwnership(_newOwner);
+        emit TransferChild(address(_child), _newOwner);
+    }
+
+    /**
+     *@dev Transfer ownership of a contract from token to this TrueGoldController.
+     *@param _other address of the contract to claim ownership of
+     */
+    function requestReclaimContract(IOwnable _other) public onlyOwner {
+        token.reclaimContract(_other);
+        emit ReclaimContract(address(_other));
+    }
+
+    /**
+     *@dev send all ether in token address to the owner of TrueGoldController
+     */
+    function requestReclaimEther() external onlyOwner {
+        token.reclaimEther(owner);
+    }
+
+    /**
+    *@dev transfer all tokens of a particular type in token address to the
+    owner of TrueGoldController
+    *@param _token token address of the token to transfer
+    */
+    function requestReclaimToken(IERC20 _token) external onlyOwner {
+        token.reclaimToken(_token, owner);
+    }
+
+    /**
+     *@dev set new contract to which specified address can send eth to to quickly pause token
+     *@param _newFastPause address of the new contract
+     */
+    function setFastPause(address _newFastPause) external onlyOwner {
+        fastPause = _newFastPause;
+        emit FastPauseSet(address(_newFastPause));
+    }
+
+    /**
+     *@dev pause all pausable actions on TrueGold, mints/burn/transfer/approve
+     */
+    function pauseToken() external virtual onlyFastPauseOrOwner {
+        OwnedUpgradeabilityProxy(address(uint160(address(token)))).upgradeTo(PAUSED_IMPLEMENTATION);
+    }
+
+    /**
+    *@dev Change the minimum and maximum amounts that TrueGold users can
+    burn to newMin and newMax
+    *@param _min minimum amount user can burn at a time
+    *@param _max maximum amount user can burn at a time
+    */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        token.setBurnBounds(_min, _max);
+    }
+
+    /**
+     *@dev Owner can send ether balance in contract address
+     *@param _to address to which the funds will be send to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     *@dev Owner can send erc20 token balance in contract address
+     *@param _token address of the token to send
+     *@param _to address to which the funds will be send to
+     */
+    function reclaimToken(IERC20 _token, address _to) external onlyOwner {
+        uint256 balance = _token.balanceOf(address(this));
+        _token.transfer(_to, balance);
+    }
+}

--- a/flatten/TrueHKD.sol
+++ b/flatten/TrueHKD.sol
@@ -1,0 +1,1324 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: contracts/true-currencies/common/GasRefund.sol
+
+// SPDX-License-Identifier: MIT
+// pragma solidity 0.6.10;
+
+/**
+ * @title Gas Reclaim Legacy
+ *
+ * Note: this contract does not affect any of the token logic. It merely
+ * exists so the TokenController (owner) can reclaim the sponsored gas
+ *
+ * Previously TrueCurrency has a feature called "gas boost" which allowed
+ * us to sponsor gas by setting non-empty storage slots to 1.
+ * We are depricating this feature, but there is a bunch of gas saved
+ * from years of sponsoring gas. This contract is meant to allow the owner
+ * to take advantage of this leftover gas. Once all the slots are used,
+ * this contract can be removed from TrueCurrency.
+ *
+ * Utilitzes the gas refund mechanism in EVM. Each time an non-empty
+ * storage slot is set to 0, evm will refund 15,000 to the sender.
+ * Also utilized the refund for selfdestruct, see gasRefund39
+ */
+abstract contract GasRefund {
+    /**
+     * @dev Refund 15,000 gas per slot.
+     * @param amount number of slots to free
+     */
+    function gasRefund15(uint256 amount) internal {
+        assembly {
+            // get number of free slots
+            let offset := sload(0xfffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // get location of first slot
+            let location := add(offset, 0xfffff)
+            // loop until end is reached
+            for {
+                let end := sub(location, amount)
+            } gt(location, end) {
+                location := sub(location, 1)
+            } {
+                // set storage location to zero
+                // this refunds 15,000 gas
+                sstore(location, 0)
+            }
+            // store new number of free slots
+            sstore(0xfffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev use smart contract self-destruct to refund gas
+     * will refund 39,000 * amount gas
+     */
+    function gasRefund39(uint256 amount) internal {
+        assembly {
+            // get amount of gas slots
+            let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            // make sure there are enough slots
+            if lt(offset, amount) {
+                amount := offset
+            }
+            if eq(amount, 0) {
+                stop()
+            }
+            // first sheep pointer
+            let location := sub(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, offset)
+            // loop from location to end
+            for {
+                let end := add(location, amount)
+            } lt(location, end) {
+                location := add(location, 1)
+            } {
+                // load sheep address
+                let sheep := sload(location)
+                // call selfdestruct on sheep
+                pop(call(gas(), sheep, 0, 0, 0, 0, 0))
+                // clear sheep address
+                sstore(location, 0)
+            }
+            // store new number of sheep
+            sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, sub(offset, amount))
+        }
+    }
+
+    /**
+     * @dev Return the remaining sponsored gas slots
+     */
+    function remainingGasRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xfffff)
+        }
+    }
+
+    /**
+     * @dev Return the remaining sheep slots
+     */
+    function remainingSheepRefundPool() public view returns (uint256 length) {
+        assembly {
+            length := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrencyWithGasRefund.sol
+
+// pragma solidity 0.6.10;
+
+// import {GasRefund} from "contracts/true-currencies/common/GasRefund.sol";
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+abstract contract TrueCurrencyWithGasRefund is GasRefund, TrueCurrency {
+    /**
+     * @dev reclaim gas from legacy gas refund #1
+     * will refund 15,000 * amount gas to sender (minus exection cost)
+     * If gas pool is empty, refund 39,000 * amount gas by calling selfdestruct
+     */
+    function refundGas(uint256 amount) external onlyOwner {
+        if (remainingGasRefundPool() > 0) {
+            gasRefund15(amount);
+        } else {
+            gasRefund39(amount.div(3));
+        }
+    }
+}
+
+
+// Root file: contracts/true-currencies/tokens/TrueHKD.sol
+
+pragma solidity 0.6.10;
+
+// import {TrueCurrencyWithGasRefund} from "contracts/true-currencies/TrueCurrencyWithGasRefund.sol";
+
+/**
+ * @title TrueHKD
+ * @dev This is the top-level ERC20 contract, but most of the interesting functionality is
+ * inherited - see the documentation on the corresponding contracts.
+ */
+contract TrueHKD is TrueCurrencyWithGasRefund {
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueHKD";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "THKD";
+    }
+}

--- a/flatten/TrueLender.sol
+++ b/flatten/TrueLender.sol
@@ -1,0 +1,1044 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Dependency file: contracts/truefi/common/UpgradeableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is Initializable, Context {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function initialize() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Dependency file: contracts/truefi/interface/ILoanToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ILoanToken is IERC20 {
+    enum Status {Awaiting, Funded, Withdrawn, Settled, Defaulted}
+
+    function borrower() external view returns (address);
+
+    function amount() external view returns (uint256);
+
+    function term() external view returns (uint256);
+
+    function apy() external view returns (uint256);
+
+    function start() external view returns (uint256);
+
+    function lender() external view returns (address);
+
+    function debt() external view returns (uint256);
+
+    function profit() external view returns (uint256);
+
+    function status() external view returns (Status);
+
+    function borrowerFee() external view returns (uint256);
+
+    function receivedAmount() external view returns (uint256);
+
+    function isLoanToken() external pure returns (bool);
+
+    function getParameters()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function fund() external;
+
+    function withdraw(address _beneficiary) external;
+
+    function close() external;
+
+    function redeem(uint256 _amount) external;
+
+    function repay(address _sender, uint256 _amount) external;
+
+    function reclaim() external;
+
+    function allowTransfer(address account, bool _status) external;
+
+    function repaid() external view returns (uint256);
+
+    function balance() external view returns (uint256);
+
+    function value(uint256 _balance) external view returns (uint256);
+
+    function currencyToken() external view returns (IERC20);
+
+    function version() external pure returns (uint8);
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueFiPool.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * TruePool is an ERC20 which represents a share of a pool
+ *
+ * This contract can be used to wrap opportunities to be compatible
+ * with TrueFi and allow users to directly opt-in through the TUSD contract
+ *
+ * Each TruePool is also a staking opportunity for TRU
+ */
+interface ITrueFiPool is IERC20 {
+    /// @dev pool token (TUSD)
+    function currencyToken() external view returns (IERC20);
+
+    /// @dev stake token (TRU)
+    function stakeToken() external view returns (IERC20);
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Mint pool tokens based on value to sender
+     */
+    function join(uint256 amount) external;
+
+    /**
+     * @dev exit pool
+     * 1. Transfer pool tokens from sender
+     * 2. Burn pool tokens
+     * 3. Transfer value of pool tokens in TUSD to sender
+     */
+    function exit(uint256 amount) external;
+
+    /**
+     * @dev borrow from pool
+     * 1. Transfer TUSD to sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function borrow(uint256 amount, uint256 amountWithoutFee) external;
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function repay(uint256 amount) external;
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueLender.sol
+
+// pragma solidity 0.6.10;
+
+interface ITrueLender {
+    function value() external view returns (uint256);
+
+    function distribute(
+        address recipient,
+        uint256 numerator,
+        uint256 denominator
+    ) external;
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueRatingAgency.sol
+
+// pragma solidity 0.6.10;
+
+interface ITrueRatingAgency {
+    function getResults(address id)
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function submit(address id) external;
+
+    function retract(address id) external;
+
+    function yes(address id, uint256 stake) external;
+
+    function no(address id, uint256 stake) external;
+
+    function withdraw(address id, uint256 stake) external;
+
+    function claim(address id, address voter) external;
+}
+
+
+// Root file: contracts/truefi/TrueLender.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {Ownable} from "contracts/truefi/common/UpgradeableOwnable.sol";
+// import {ILoanToken} from "contracts/truefi/interface/ILoanToken.sol";
+// import {ITrueFiPool} from "contracts/truefi/interface/ITrueFiPool.sol";
+// import {ITrueLender} from "contracts/truefi/interface/ITrueLender.sol";
+// import {ITrueRatingAgency} from "contracts/truefi/interface/ITrueRatingAgency.sol";
+
+/**
+ * @title TrueLender v1.0
+ * @dev TrueFi Lending Strategy
+ * This contract implements the lending strategy for the TrueFi pool
+ * The strategy takes into account several parameters and consumes
+ * information from the prediction market in order to approve loans
+ *
+ * This strategy is conservative to avoid defaults.
+ * See: https://github.com/trusttoken/truefi-spec
+ *
+ * 1. Only approve loans which have the following inherent properties:
+ * - minAPY <= loanAPY <= maxAPY
+ * - minSize <= loanSize <= maxSize
+ * - minTerm <= loanTerm <= maxTerm
+ *
+ * 2. Only approve loans which have been rated in the prediction market under the conditions:
+ * - timeInMarket >= votingPeriod
+ * - stakedTRU > (participationFactor * loanSize)
+ * - 1 < ( interest * P(loan_repaid) - (loanSize * riskAversion * P(loan_defaults))
+ *
+ * Once a loan meets these requirements, fund() can be called to transfer
+ * funds from the pool to the LoanToken contract
+ */
+contract TrueLender is ITrueLender, Ownable {
+    using SafeMath for uint256;
+
+    // ================ WARNING ==================
+    // ===== THIS CONTRACT IS INITIALIZABLE ======
+    // === STORAGE VARIABLES ARE DECLARED BELOW ==
+    // REMOVAL OR REORDER OF VARIABLES WILL RESULT
+    // ========= IN STORAGE CORRUPTION ===========
+
+    mapping(address => bool) public allowedBorrowers;
+    ILoanToken[] _loans;
+
+    ITrueFiPool public pool;
+    IERC20 public currencyToken;
+    ITrueRatingAgency public ratingAgency;
+
+    uint256 private constant TOKEN_PRECISION_DIFFERENCE = 10**10;
+
+    // ===== Pool parameters =====
+
+    // bound on APY
+    uint256 public minApy;
+    uint256 public maxApy;
+
+    // How many votes in predction market
+    uint256 public participationFactor;
+
+    // How much worse is it to lose $1 TUSD than it is to gain $1 TUSD
+    uint256 public riskAversion;
+
+    // bound on min & max loan sizes
+    uint256 public minSize;
+    uint256 public maxSize;
+
+    // bound on min & max loan terms
+    uint256 public minTerm;
+    uint256 public maxTerm;
+
+    // minimum prediction market voting period
+    uint256 public votingPeriod;
+
+    // maximum amount of loans lender can handle at once
+    uint256 public maxLoans;
+
+    // ======= STORAGE DECLARATION END ============
+
+    /**
+     * @dev Emitted when a borrower's whitelist status changes
+     * @param who Address for which whitelist status has changed
+     * @param status New whitelist status
+     */
+    event Allowed(address indexed who, bool status);
+
+    /**
+     * @dev Emitted when APY bounds have changed
+     * @param minApy New minimum APY
+     * @param maxApy New maximum APY
+     */
+    event ApyLimitsChanged(uint256 minApy, uint256 maxApy);
+
+    /**
+     * @dev Emitted when participation factor changed
+     * @param participationFactor New participation factor
+     */
+    event ParticipationFactorChanged(uint256 participationFactor);
+
+    /**
+     * @dev Emitted when risk aversion changed
+     * @param riskAversion New risk aversion factor
+     */
+    event RiskAversionChanged(uint256 riskAversion);
+
+    /**
+     * @dev Emitted when the minimum voting period is changed
+     * @param votingPeriod New voting period
+     */
+    event VotingPeriodChanged(uint256 votingPeriod);
+
+    /**
+     * @dev Emitted when the loan size bounds are changed
+     * @param minSize New minimum loan size
+     * @param maxSize New maximum loan size
+     */
+    event SizeLimitsChanged(uint256 minSize, uint256 maxSize);
+
+    /**
+     * @dev Emitted when loan term bounds are changed
+     * @param minTerm New minimum loan term
+     * @param maxTerm New minimum loan term
+     */
+    event TermLimitsChanged(uint256 minTerm, uint256 maxTerm);
+
+    /**
+     * @dev Emitted when loans limit is change
+     * @param maxLoans new maximum amount of loans
+     */
+    event LoansLimitChanged(uint256 maxLoans);
+
+    /**
+     * @dev Emitted when a loan is funded
+     * @param loanToken LoanToken contract which was funded
+     * @param amount Amount funded
+     */
+    event Funded(address indexed loanToken, uint256 amount);
+
+    /**
+     * @dev Emitted when funds are reclaimed from the LoanToken contract
+     * @param loanToken LoanToken from which funds were reclaimed
+     * @param amount Amount repaid
+     */
+    event Reclaimed(address indexed loanToken, uint256 amount);
+
+    /**
+     * @dev Modifier for only lending pool
+     */
+    modifier onlyPool() {
+        require(msg.sender == address(pool), "TrueLender: Sender is not a pool");
+        _;
+    }
+
+    /**
+     * @dev Initalize the contract with parameters
+     * @param _pool Lending pool address
+     * @param _ratingAgency Prediction market address
+     */
+    function initialize(ITrueFiPool _pool, ITrueRatingAgency _ratingAgency) public initializer {
+        Ownable.initialize();
+
+        pool = _pool;
+        currencyToken = _pool.currencyToken();
+        currencyToken.approve(address(_pool), uint256(-1));
+        ratingAgency = _ratingAgency;
+
+        minApy = 1000;
+        maxApy = 3000;
+        participationFactor = 10000;
+        riskAversion = 15000;
+        minSize = 1000000 ether;
+        maxSize = 10000000 ether;
+        minTerm = 182 days;
+        maxTerm = 3650 days;
+        votingPeriod = 7 days;
+
+        maxLoans = 100;
+    }
+
+    /**
+     * @dev Set new bounds on loan size. Only owner can change parameters.
+     * @param min New minimum loan size
+     * @param max New maximum loan size
+     */
+    function setSizeLimits(uint256 min, uint256 max) external onlyOwner {
+        require(min > 0, "TrueLender: Minimal loan size cannot be 0");
+        require(max >= min, "TrueLender: Maximal loan size is smaller than minimal");
+        minSize = min;
+        maxSize = max;
+        emit SizeLimitsChanged(min, max);
+    }
+
+    /**
+     * @dev Set new bounds on loan term length. Only owner can change parameters.
+     * @param min New minimum loan term
+     * @param max New maximum loan term
+     */
+    function setTermLimits(uint256 min, uint256 max) external onlyOwner {
+        require(max >= min, "TrueLender: Maximal loan term is smaller than minimal");
+        minTerm = min;
+        maxTerm = max;
+        emit TermLimitsChanged(min, max);
+    }
+
+    /**
+     * @dev Set new bounds on loan APY. Only owner can change parameters.
+     * @param newMinApy New minimum loan APY
+     * @param newMaxApy New maximum loan APY
+     */
+    function setApyLimits(uint256 newMinApy, uint256 newMaxApy) external onlyOwner {
+        require(newMaxApy >= newMinApy, "TrueLender: Maximal APY is smaller than minimal");
+        minApy = newMinApy;
+        maxApy = newMaxApy;
+        emit ApyLimitsChanged(newMinApy, newMaxApy);
+    }
+
+    /**
+     * @dev Set new minimum voting period in credit rating market.
+     * Only owner can change parameters
+     * @param newVotingPeriod new minimum voting period
+     */
+    function setVotingPeriod(uint256 newVotingPeriod) external onlyOwner {
+        votingPeriod = newVotingPeriod;
+        emit VotingPeriodChanged(newVotingPeriod);
+    }
+
+    /**
+     * @dev Set new participation factor. Only owner can change parameters.
+     * @param newParticipationFactor New participation factor.
+     */
+    function setParticipationFactor(uint256 newParticipationFactor) external onlyOwner {
+        participationFactor = newParticipationFactor;
+        emit ParticipationFactorChanged(newParticipationFactor);
+    }
+
+    /**
+     * @dev Set new risk aversion factor. Only owner can change parameters.
+     * @param newRiskAversion New risk aversion factor
+     */
+    function setRiskAversion(uint256 newRiskAversion) external onlyOwner {
+        riskAversion = newRiskAversion;
+        emit RiskAversionChanged(newRiskAversion);
+    }
+
+    /**
+     * @dev Set new loans limit. Only owner can change parameters.
+     * @param newLoansLimit New loans limit
+     */
+    function setLoansLimit(uint256 newLoansLimit) external onlyOwner {
+        maxLoans = newLoansLimit;
+        emit LoansLimitChanged(maxLoans);
+    }
+
+    /**
+     * @dev Get currently funded loans
+     * @return result Array of loans currently funded
+     */
+    function loans() public view returns (ILoanToken[] memory result) {
+        result = _loans;
+    }
+
+    /**
+     * @dev Fund a loan which meets the strategy requirements
+     * @param loanToken LoanToken to fund
+     */
+    function fund(ILoanToken loanToken) external {
+        require(loanToken.borrower() == msg.sender, "TrueLender: Sender is not borrower");
+        require(loanToken.isLoanToken(), "TrueLender: Only LoanTokens can be funded");
+        require(loanToken.currencyToken() == currencyToken, "TrueLender: Only the same currency LoanTokens can be funded");
+        require(_loans.length < maxLoans, "TrueLender: Loans number has reached the limit");
+
+        (uint256 amount, uint256 apy, uint256 term) = loanToken.getParameters();
+        uint256 receivedAmount = loanToken.receivedAmount();
+        (uint256 start, uint256 no, uint256 yes) = ratingAgency.getResults(address(loanToken));
+
+        require(loanSizeWithinBounds(amount), "TrueLender: Loan size is out of bounds");
+        require(loanTermWithinBounds(term), "TrueLender: Loan term is out of bounds");
+        require(loanIsAttractiveEnough(apy), "TrueLender: APY is out of bounds");
+        require(votingLastedLongEnough(start), "TrueLender: Voting time is below minimum");
+        require(votesThresholdReached(amount, yes), "TrueLender: Not enough votes given for the loan");
+        require(loanIsCredible(apy, term, yes, no), "TrueLender: Loan risk is too high");
+
+        _loans.push(loanToken);
+        pool.borrow(amount, receivedAmount);
+        currencyToken.approve(address(loanToken), receivedAmount);
+        loanToken.fund();
+        emit Funded(address(loanToken), receivedAmount);
+    }
+
+    /**
+     * @dev Temporary fix for old LoanTokens with incorrect value calculation
+     */
+    function loanValue(ILoanToken loan) public view returns (uint256) {
+        uint256 _balance = loan.balanceOf(address(this));
+        if (_balance == 0) {
+            return 0;
+        }
+
+        uint256 passed = block.timestamp.sub(loan.start());
+        if (passed > loan.term()) {
+            passed = loan.term();
+        }
+
+        uint256 helper = loan.amount().mul(loan.apy()).mul(passed).mul(_balance);
+        // assume month is 30 days
+        uint256 interest = helper.div(365 days).div(10000).div(loan.debt());
+
+        return loan.amount().mul(_balance).div(loan.debt()).add(interest);
+    }
+
+    /**
+     * @dev Loop through loan tokens and calculate theoretical value of all loans
+     * There should never be too many loans in the pool to run out of gas
+     * @return Theoretical value of all the loans funded by this strategy
+     */
+    function value() external override view returns (uint256) {
+        uint256 totalValue;
+        for (uint256 index = 0; index < _loans.length; index++) {
+            totalValue = totalValue.add(loanValue(_loans[index]));
+        }
+        return totalValue;
+    }
+
+    /**
+     * @dev For settled loans, redeem LoanTokens for underlying funds
+     * @param loanToken Loan to reclaim capital from
+     */
+    function reclaim(ILoanToken loanToken) external onlyOwner {
+        require(loanToken.isLoanToken(), "TrueLender: Only LoanTokens can be used to reclaimed");
+        require(
+            loanToken.status() == ILoanToken.Status.Settled || loanToken.status() == ILoanToken.Status.Defaulted,
+            "TrueLender: LoanToken is not closed yet"
+        );
+
+        // call redeem function on LoanToken
+        uint256 balanceBefore = currencyToken.balanceOf(address(this));
+        loanToken.redeem(loanToken.balanceOf(address(this)));
+        uint256 balanceAfter = currencyToken.balanceOf(address(this));
+
+        // gets reclaimed amount and pays back to pool
+        uint256 fundsReclaimed = balanceAfter.sub(balanceBefore);
+        pool.repay(fundsReclaimed);
+
+        // remove loan from loan array
+        for (uint256 index = 0; index < _loans.length; index++) {
+            if (_loans[index] == loanToken) {
+                _loans[index] = _loans[_loans.length - 1];
+                _loans.pop();
+                break;
+            }
+        }
+
+        emit Reclaimed(address(loanToken), fundsReclaimed);
+    }
+
+    /**
+     * @dev Withdraw a basket of tokens held by the pool
+     * When exiting the pool, the pool contract calls this function
+     * to withdraw a fraction of all the loans held by the pool
+     * Loop through recipient's share of LoanTokens and calculate versus total per loan.
+     * There should never be too many loans in the pool to run out of gas
+     *
+     * @param recipient Recipient of basket
+     * @param numerator Numerator of fraction to withdraw
+     * @param denominator Denominator of fraction to withdraw
+     */
+    function distribute(
+        address recipient,
+        uint256 numerator,
+        uint256 denominator
+    ) external override onlyPool {
+        for (uint256 index = 0; index < _loans.length; index++) {
+            _loans[index].transfer(recipient, numerator.mul(_loans[index].balanceOf(address(this))).div(denominator));
+        }
+    }
+
+    /**
+     * @dev Check if a loan is within APY bounds
+     * @param apy APY of loan
+     * @return Whether a loan is within APY bounds
+     */
+    function loanIsAttractiveEnough(uint256 apy) public view returns (bool) {
+        return apy >= minApy && apy <= maxApy;
+    }
+
+    /**
+     * @dev Check if a loan has been in the credit market long enough
+     * @param start Timestamp at which rating began
+     * @return Whether a loan has been rated for long enough
+     */
+    function votingLastedLongEnough(uint256 start) public view returns (bool) {
+        return start.add(votingPeriod) <= block.timestamp;
+    }
+
+    /**
+     * @dev Check if a loan is within size bounds
+     * @param amount Size of loan
+     * @return Whether a loan is within size bounds
+     */
+    function loanSizeWithinBounds(uint256 amount) public view returns (bool) {
+        return amount >= minSize && amount <= maxSize;
+    }
+
+    /**
+     * @dev Check if loan term is within term bounds
+     * @param term Term of loan
+     * @return Whether loan term is within term bounds
+     */
+    function loanTermWithinBounds(uint256 term) public view returns (bool) {
+        return term >= minTerm && term <= maxTerm;
+    }
+
+    /**
+     * @dev Check if a loan is within APY bounds
+     * Minimum absolute value of yes votes, rather than ratio of yes to no
+     * @param amount Size of loan
+     * @param yesVotes Number of yes votes
+     * @return Whether a loan has reached the required voting threshold
+     */
+    function votesThresholdReached(uint256 amount, uint256 yesVotes) public view returns (bool) {
+        return amount.mul(participationFactor) <= yesVotes.mul(10000).mul(TOKEN_PRECISION_DIFFERENCE);
+    }
+
+    /**
+     * @dev Use APY and term of loan to check expected value of a loan
+     * Expected value = profit - (default_loss * (no / yes))
+     * e.g. riskAversion = 10,000 => expected value of 1
+     * @param apy APY of loan
+     * @param term Term length of loan
+     * @param yesVotes Number of YES votes in credit market
+     * @param noVotes Number of NO votes in credit market
+     */
+    function loanIsCredible(
+        uint256 apy,
+        uint256 term,
+        uint256 yesVotes,
+        uint256 noVotes
+    ) public view returns (bool) {
+        return apy.mul(term).mul(yesVotes).div(365 days) >= noVotes.mul(riskAversion);
+    }
+}

--- a/flatten/TrueMintableBurnable.sol
+++ b/flatten/TrueMintableBurnable.sol
@@ -1,0 +1,961 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+contract ProxyStorage {
+    // Initializable.sol
+    bool _initialized;
+    bool _initializing;
+
+    // Ownable.sol
+    address _owner;
+
+    // ERC20.sol
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    uint256 _totalSupply;
+
+    // TrueMintableBurnable.sol
+    uint256 _minBurnAmount;
+    uint256 _maxBurnAmount;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 20         "trueGold.proxy.owner"                                        Proxy Owner
+     ** 28         "trueGold.pending.proxy.owner"                                Pending Proxy Owner
+     ** 29         "trueGold.proxy.implementation"                               Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   _balances
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       _allowances
+     **/
+}
+
+
+// Dependency file: contracts/true-gold/common/ERC20.sol
+
+// pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+// import "@openzeppelin/contracts/utils/Address.sol";
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20MinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ProxyStorage, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    // mapping (address => uint256) private _balances;
+    // mapping (address => mapping (address => uint256)) private _allowances;
+    // uint256 private _totalSupply;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8);
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public override view returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public override view returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(msg.sender, recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public virtual override view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(msg.sender, spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/ERC20Burnable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ERC20.sol";
+
+/**
+ * @dev Extension of {ERC20} that allows token holders to destroy both their own
+ * tokens and those that they have an allowance for, in a way that can be
+ * recognized off-chain (via event analysis).
+ */
+abstract contract ERC20Burnable is ERC20 {
+    /**
+     * @dev Destroys `amount` tokens from the caller.
+     *
+     * See {ERC20-_burn}.
+     */
+    function burn(uint256 amount) public virtual {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, deducting from the caller's
+     * allowance.
+     *
+     * See {ERC20-_burn} and {ERC20-allowance}.
+     *
+     * Requirements:
+     *
+     * - the caller must have allowance for ``accounts``'s tokens of at least
+     * `amount`.
+     */
+    function burnFrom(address account, uint256 amount) public virtual {
+        uint256 decreasedAllowance = allowance(account, msg.sender).sub(amount, "ERC20Burnable: burn amount exceeds allowance");
+
+        _approve(account, msg.sender, decreasedAllowance);
+        _burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-gold/common/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable is ProxyStorage {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    // bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    // bool private _initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(_initializing || isConstructor() || !_initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+}
+
+
+// Dependency file: contracts/true-gold/interface/IOwnable.sol
+
+// pragma solidity 0.6.10;
+
+interface IOwnable {
+    function transferOwnership(address newOwner) external;
+}
+
+
+// Dependency file: contracts/true-gold/common/Ownable.sol
+
+// pragma solidity 0.6.10;
+
+// import "contracts/true-gold/interface/IOwnable.sol";
+
+// import "contracts/true-gold/common/ProxyStorage.sol";
+// import "contracts/true-gold/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is ProxyStorage, Initializable, IOwnable {
+    // address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function __Ownable_init_unchained() internal initializer {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == msg.sender, "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual override onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Root file: contracts/true-gold/TrueMintableBurnable.sol
+
+pragma solidity 0.6.10;
+
+// import "contracts/true-gold/common/ERC20Burnable.sol";
+// import "contracts/true-gold/common/Initializable.sol";
+// import "contracts/true-gold/common/Ownable.sol";
+// import "contracts/true-gold/common/ProxyStorage.sol";
+
+abstract contract TrueMintableBurnable is ProxyStorage, Initializable, Ownable, ERC20Burnable {
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    event Mint(address indexed to, uint256 value);
+    event Burn(address indexed burner, uint256 value);
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    // solhint-disable-next-line func-name-mixedcase
+    function __TrueMintableBurnable_init_unchained(uint256 minBurnAmount, uint256 maxBurnAmount) internal initializer {
+        setBurnBounds(minBurnAmount, maxBurnAmount);
+    }
+
+    function burnMin() public view returns (uint256) {
+        return _minBurnAmount;
+    }
+
+    function burnMax() public view returns (uint256) {
+        return _maxBurnAmount;
+    }
+
+    // Change the minimum and maximum amount that can be burned at once. Burning may be disabled by setting both to 0
+    // (this will not be done under normal operation, but we can't add checks to disallow it without losing a lot of
+    // flexibility since burning could also be as good as disabled by setting the minimum extremely high, and we don't
+    // want to lock in any particular cap for the minimum)
+    function setBurnBounds(uint256 minAmount, uint256 maxAmount) public virtual onlyOwner {
+        require(minAmount <= maxAmount, "TrueMintableBurnable: min is greater then max");
+        _minBurnAmount = minAmount;
+        _maxBurnAmount = maxAmount;
+        emit SetBurnBounds(minAmount, maxAmount);
+    }
+
+    function mint(address account, uint256 amount) public virtual onlyOwner {
+        require(uint256(account) > REDEMPTION_ADDRESS_COUNT, "TrueMintableBurnable: mint to a redemption or zero address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        require(super.transfer(recipient, amount));
+        if (uint256(recipient) <= REDEMPTION_ADDRESS_COUNT) {
+            _burn(recipient, amount);
+        }
+        return true;
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        require(super.transferFrom(sender, recipient, amount));
+        if (uint256(recipient) <= REDEMPTION_ADDRESS_COUNT) {
+            _burn(recipient, amount);
+        }
+        return true;
+    }
+
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= _minBurnAmount, "TrueMintableBurnable: burn amount below min bound");
+        require(amount <= _maxBurnAmount, "TrueMintableBurnable: burn amount exceeds max bound");
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}

--- a/flatten/TrueRatingAgency.sol
+++ b/flatten/TrueRatingAgency.sol
@@ -1,0 +1,1166 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: contracts/trusttoken/interface/IBurnableERC20.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IBurnableERC20 is IERC20 {
+    function burn(uint256 amount) external;
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Dependency file: contracts/truefi/common/UpgradeableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is Initializable, Context {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function initialize() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// Dependency file: contracts/truefi/interface/IArbitraryDistributor.sol
+
+// pragma solidity 0.6.10;
+
+interface IArbitraryDistributor {
+    function amount() external returns (uint256);
+
+    function remaining() external returns (uint256);
+
+    function beneficiary() external returns (address);
+
+    function distribute(uint256 _amount) external;
+
+    function empty() external;
+}
+
+
+// Dependency file: contracts/truefi/interface/ILoanFactory.sol
+
+// pragma solidity 0.6.10;
+
+interface ILoanFactory {
+    function createLoanToken(
+        uint256 _amount,
+        uint256 _term,
+        uint256 _apy
+    ) external;
+
+    function isLoanToken(address) external view returns (bool);
+}
+
+
+// Dependency file: contracts/truefi/interface/ILoanToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ILoanToken is IERC20 {
+    enum Status {Awaiting, Funded, Withdrawn, Settled, Defaulted}
+
+    function borrower() external view returns (address);
+
+    function amount() external view returns (uint256);
+
+    function term() external view returns (uint256);
+
+    function apy() external view returns (uint256);
+
+    function start() external view returns (uint256);
+
+    function lender() external view returns (address);
+
+    function debt() external view returns (uint256);
+
+    function profit() external view returns (uint256);
+
+    function status() external view returns (Status);
+
+    function borrowerFee() external view returns (uint256);
+
+    function receivedAmount() external view returns (uint256);
+
+    function isLoanToken() external pure returns (bool);
+
+    function getParameters()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function fund() external;
+
+    function withdraw(address _beneficiary) external;
+
+    function close() external;
+
+    function redeem(uint256 _amount) external;
+
+    function repay(address _sender, uint256 _amount) external;
+
+    function reclaim() external;
+
+    function allowTransfer(address account, bool _status) external;
+
+    function repaid() external view returns (uint256);
+
+    function balance() external view returns (uint256);
+
+    function value(uint256 _balance) external view returns (uint256);
+
+    function currencyToken() external view returns (IERC20);
+
+    function version() external pure returns (uint8);
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueFiPool.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * TruePool is an ERC20 which represents a share of a pool
+ *
+ * This contract can be used to wrap opportunities to be compatible
+ * with TrueFi and allow users to directly opt-in through the TUSD contract
+ *
+ * Each TruePool is also a staking opportunity for TRU
+ */
+interface ITrueFiPool is IERC20 {
+    /// @dev pool token (TUSD)
+    function currencyToken() external view returns (IERC20);
+
+    /// @dev stake token (TRU)
+    function stakeToken() external view returns (IERC20);
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Mint pool tokens based on value to sender
+     */
+    function join(uint256 amount) external;
+
+    /**
+     * @dev exit pool
+     * 1. Transfer pool tokens from sender
+     * 2. Burn pool tokens
+     * 3. Transfer value of pool tokens in TUSD to sender
+     */
+    function exit(uint256 amount) external;
+
+    /**
+     * @dev borrow from pool
+     * 1. Transfer TUSD to sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function borrow(uint256 amount, uint256 amountWithoutFee) external;
+
+    /**
+     * @dev join pool
+     * 1. Transfer TUSD from sender
+     * 2. Only lending pool should be allowed to call this
+     */
+    function repay(uint256 amount) external;
+}
+
+
+// Dependency file: contracts/truefi/interface/ITrueRatingAgency.sol
+
+// pragma solidity 0.6.10;
+
+interface ITrueRatingAgency {
+    function getResults(address id)
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function submit(address id) external;
+
+    function retract(address id) external;
+
+    function yes(address id, uint256 stake) external;
+
+    function no(address id, uint256 stake) external;
+
+    function withdraw(address id, uint256 stake) external;
+
+    function claim(address id, address voter) external;
+}
+
+
+// Root file: contracts/truefi/TrueRatingAgency.sol
+
+pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {IBurnableERC20} from "contracts/trusttoken/interface/IBurnableERC20.sol";
+
+// import {Ownable} from "contracts/truefi/common/UpgradeableOwnable.sol";
+// import {IArbitraryDistributor} from "contracts/truefi/interface/IArbitraryDistributor.sol";
+// import {ILoanFactory} from "contracts/truefi/interface/ILoanFactory.sol";
+// import {ILoanToken} from "contracts/truefi/interface/ILoanToken.sol";
+// import {ITrueFiPool} from "contracts/truefi/interface/ITrueFiPool.sol";
+// import {ITrueRatingAgency} from "contracts/truefi/interface/ITrueRatingAgency.sol";
+
+/**
+ * @title TrueRatingAgency
+ * @dev Credit prediction market for LoanTokens
+ *
+ * TrueFi uses use a prediction market to signal how risky a loan is.
+ * The Credit Prediction Market estimates the likelihood of a loan defaulting.
+ * Any TRU holder can vote YES or NO and stake TRU as collateral on their vote.
+ * If a loan is funded, TRU is locked into the market until expiry.
+ * Locking TRU into the prediction market allows voters to earn and claim
+ * incentive TRU throughout the course of the loan. After the loan's term,
+ * if the voter is correct, they earn a TRU reward plus a portion of the
+ * losing side's vote. A portion of the losing side's TRU is burned.
+ *
+ * Voting Lifecycle:
+ * - Borrowers can apply for loans at any time by deploying a LoanToken
+ * - LoanTokens are registered with the prediction market contract
+ * - Once registered, TRU holders can vote at any time
+ * - If a loan is funded, TRU is locked for the term of the loan
+ * - At the end of the term, payouts are determined based on the loan outcome
+ *
+ * States:
+ * Void:        Rated loan is invalid
+ * Pending:     Waiting to be funded
+ * Retracted:   Rating has been cancelled
+ * Running:     Rated loan has been funded
+ * Settled:     Rated loan has been paid back in full
+ * Defaulted:   Rated loan has not been paid back in full
+ */
+contract TrueRatingAgency is ITrueRatingAgency, Ownable {
+    using SafeMath for uint256;
+
+    enum LoanStatus {Void, Pending, Retracted, Running, Settled, Defaulted}
+
+    struct Loan {
+        address creator;
+        uint256 timestamp;
+        mapping(bool => uint256) prediction;
+        mapping(address => mapping(bool => uint256)) votes;
+        mapping(address => uint256) claimed;
+        uint256 reward;
+    }
+
+    uint256 private constant TOKEN_PRECISION_DIFFERENCE = 10**10;
+
+    // ================ WARNING ==================
+    // ===== THIS CONTRACT IS INITIALIZABLE ======
+    // === STORAGE VARIABLES ARE DECLARED BELOW ==
+    // REMOVAL OR REORDER OF VARIABLES WILL RESULT
+    // ========= IN STORAGE CORRUPTION ===========
+
+    mapping(address => bool) public allowedSubmitters;
+    mapping(address => Loan) public loans;
+
+    IBurnableERC20 public trustToken;
+    IArbitraryDistributor public distributor;
+    ILoanFactory public factory;
+
+    /**
+     * @dev % multiplied by 100. e.g. 10.5% = 1050
+     */
+    uint256 public lossFactor;
+    uint256 public burnFactor;
+
+    // reward multiplier for voters
+    uint256 public rewardMultiplier;
+
+    // ======= STORAGE DECLARATION END ============
+
+    event Allowed(address indexed who, bool status);
+    event LossFactorChanged(uint256 lossFactor);
+    event BurnFactorChanged(uint256 burnFactor);
+    event LoanSubmitted(address id);
+    event LoanRetracted(address id);
+    event Voted(address loanToken, address voter, bool choice, uint256 stake);
+    event Withdrawn(address loanToken, address voter, uint256 stake, uint256 received, uint256 burned);
+    event RewardMultiplierChanged(uint256 newRewardMultiplier);
+    event Claimed(address loanToken, address voter, uint256 claimedReward);
+
+    /**
+     * @dev Only whitelisted borrowers can submit for credit ratings
+     */
+    modifier onlyAllowedSubmitters() {
+        require(allowedSubmitters[msg.sender], "TrueRatingAgency: Sender is not allowed to submit");
+        _;
+    }
+
+    /**
+     * @dev Only loan submitter can perform certain actions
+     */
+    modifier onlyCreator(address id) {
+        require(loans[id].creator == msg.sender, "TrueRatingAgency: Not sender's loan");
+        _;
+    }
+
+    /**
+     * @dev Cannot submit the same loan multiple times
+     */
+    modifier onlyNotExistingLoans(address id) {
+        require(status(id) == LoanStatus.Void, "TrueRatingAgency: Loan was already created");
+        _;
+    }
+
+    /**
+     * @dev Only loans in Pending state
+     */
+    modifier onlyPendingLoans(address id) {
+        require(status(id) == LoanStatus.Pending, "TrueRatingAgency: Loan is not currently pending");
+        _;
+    }
+
+    /**
+     * @dev Only loans in Running state
+     */
+    modifier onlyNotRunningLoans(address id) {
+        require(status(id) != LoanStatus.Running, "TrueRatingAgency: Loan is currently running");
+        _;
+    }
+
+    /**
+     * @dev Only loans that have been funded
+     */
+    modifier onlyFundedLoans(address id) {
+        require(status(id) >= LoanStatus.Running, "TrueRatingAgency: Loan was not funded");
+        _;
+    }
+
+    /**
+     * @dev Initalize Rating Agenct
+     * Distributor contract decides how much TRU is rewarded to stakers
+     * @param _trustToken TRU contract
+     * @param _distributor Distributor contract
+     * @param _factory Factory contract for deploying tokens
+     */
+    function initialize(
+        IBurnableERC20 _trustToken,
+        IArbitraryDistributor _distributor,
+        ILoanFactory _factory
+    ) public initializer {
+        require(address(this) == _distributor.beneficiary(), "TrueRatingAgency: Invalid distributor beneficiary");
+        Ownable.initialize();
+
+        trustToken = _trustToken;
+        distributor = _distributor;
+        factory = _factory;
+
+        lossFactor = 2500;
+        burnFactor = 2500;
+    }
+
+    /**
+     * @dev Set loss factor.
+     * Loss factor decides what percentage of TRU is lost for incorrect votes
+     * @param newLossFactor New loss factor
+     */
+    function setLossFactor(uint256 newLossFactor) external onlyOwner {
+        require(newLossFactor <= 10000, "TrueRatingAgency: Loss factor cannot be greater than 100%");
+        lossFactor = newLossFactor;
+        emit LossFactorChanged(newLossFactor);
+    }
+
+    /**
+     * @dev Set burn factor.
+     * Burn factor decides what percentage of lost TRU is burned
+     */
+    function setBurnFactor(uint256 newBurnFactor) external onlyOwner {
+        require(newBurnFactor <= 10000, "TrueRatingAgency: Burn factor cannot be greater than 100%");
+        burnFactor = newBurnFactor;
+        emit BurnFactorChanged(newBurnFactor);
+    }
+
+    /**
+     * @dev Set reward multiplier.
+     * Reward multiplier increases reward for TRU stakers
+     */
+    function setRewardMultiplier(uint256 newRewardMultiplier) external onlyOwner {
+        rewardMultiplier = newRewardMultiplier;
+        emit RewardMultiplierChanged(newRewardMultiplier);
+    }
+
+    /**
+     * @dev Get number of NO votes for a specific account and loan
+     * @param id Loan ID
+     * @param voter Voter account
+     */
+    function getNoVote(address id, address voter) public view returns (uint256) {
+        return loans[id].votes[voter][false];
+    }
+
+    /**
+     * @dev Get number of YES votes for a specific account and loan
+     * @param id Loan ID
+     * @param voter Voter account
+     */
+    function getYesVote(address id, address voter) public view returns (uint256) {
+        return loans[id].votes[voter][true];
+    }
+
+    /**
+     * @dev Get total NO votes for a specific loan
+     * @param id Loan ID
+     */
+    function getTotalNoVotes(address id) public view returns (uint256) {
+        return loans[id].prediction[false];
+    }
+
+    /**
+     * @dev Get total YES votes for a specific loan
+     * @param id Loan ID
+     */
+    function getTotalYesVotes(address id) public view returns (uint256) {
+        return loans[id].prediction[true];
+    }
+
+    /**
+     * @dev Get timestamp at which voting started for a specific loan
+     * @param id Loan ID
+     */
+    function getVotingStart(address id) public view returns (uint256) {
+        return loans[id].timestamp;
+    }
+
+    /**
+     * @dev Get current results for a specific loan
+     * @param id Loan ID
+     * @return (start_time, total_no, total_yes)
+     */
+    function getResults(address id)
+        external
+        override
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        )
+    {
+        return (getVotingStart(id), getTotalNoVotes(id), getTotalYesVotes(id));
+    }
+
+    /**
+     * @dev Whitelist borrowers to submit loans for rating
+     * @param who Account to whitelist
+     * @param status Flag to whitelist accounts
+     */
+    function allow(address who, bool status) external onlyOwner {
+        allowedSubmitters[who] = status;
+        emit Allowed(who, status);
+    }
+
+    /**
+     * @dev Submit a loan for rating
+     * Cannot submit the same loan twice
+     * @param id Loan ID
+     */
+    function submit(address id) external override onlyAllowedSubmitters onlyNotExistingLoans(id) {
+        require(ILoanToken(id).borrower() == msg.sender, "TrueRatingAgency: Sender is not borrower");
+        require(factory.isLoanToken(id), "TrueRatingAgency: Only LoanTokens created via LoanFactory are supported");
+        loans[id] = Loan({creator: msg.sender, timestamp: block.timestamp, reward: 0});
+        emit LoanSubmitted(id);
+    }
+
+    /**
+     * @dev Remove Loan from rating agency
+     * Can only be retracted by loan creator
+     * @param id Loan ID
+     */
+    function retract(address id) external override onlyPendingLoans(id) onlyCreator(id) {
+        loans[id].creator = address(0);
+        loans[id].prediction[true] = 0;
+        loans[id].prediction[false] = 0;
+
+        emit LoanRetracted(id);
+    }
+
+    /**
+     * @dev Vote on a loan by staking TRU
+     * @param id Loan ID
+     * @param stake Amount of TRU to stake
+     * @param choice Voter choice. false = NO, true = YES
+     */
+    function vote(
+        address id,
+        uint256 stake,
+        bool choice
+    ) internal {
+        require(loans[id].votes[msg.sender][!choice] == 0, "TrueRatingAgency: Cannot vote both yes and no");
+
+        loans[id].prediction[choice] = loans[id].prediction[choice].add(stake);
+        loans[id].votes[msg.sender][choice] = loans[id].votes[msg.sender][choice].add(stake);
+
+        require(trustToken.transferFrom(msg.sender, address(this), stake));
+        emit Voted(id, msg.sender, choice, stake);
+    }
+
+    /**
+     * @dev Vote YES on a loan by staking TRU
+     * @param id Loan ID
+     * @param stake Amount of TRU to stake
+     */
+    function yes(address id, uint256 stake) external override onlyPendingLoans(id) {
+        vote(id, stake, true);
+    }
+
+    /**
+     * @dev Vote NO on a loan by staking TRU
+     * @param id Loan ID
+     * @param stake Amount of TRU to stake
+     */
+    function no(address id, uint256 stake) external override onlyPendingLoans(id) {
+        vote(id, stake, false);
+    }
+
+    // prettier-ignore
+    /**
+     * @dev Withdraw stake on a loan and remove votes.
+     * Unstaking only allowed for loans that are not Running
+     * @param id Loan ID
+     * @param stake Amount of TRU to unstake
+     */
+    function withdraw(address id, uint256 stake) external override onlyNotRunningLoans(id) {
+        bool choice = loans[id].votes[msg.sender][true] > 0;
+        LoanStatus loanStatus = status(id);
+
+        require(loans[id].votes[msg.sender][choice] >= stake,
+            "TrueRatingAgency: Cannot withdraw more than was staked");
+
+        uint256 amountToTransfer = stake;
+        uint256 burned = 0;
+        if (loanStatus > LoanStatus.Running) {
+            // claim TRU reward
+            claim(id, msg.sender);
+            // check if prediction correct
+            bool correct = wasPredictionCorrect(id, choice);
+            if (correct) {
+                // if correct, take some from incorrect side's stake
+                // amount taken from incorrect side but not burned
+                amountToTransfer = amountToTransfer.add(
+                    bounty(id, !choice).mul(stake).div(loans[id].prediction[choice]));
+            } else {
+                // if incorrect, calculate loss & burn stake
+                // stake - (stake * lossFactor)
+                uint256 lostAmount = amountToTransfer.mul(lossFactor).div(10000);
+                amountToTransfer = amountToTransfer.sub(lostAmount);
+                burned = lostAmount.mul(burnFactor).div(10000);
+                trustToken.burn(burned);
+            }
+        }
+
+        // if loan still pending, update total votes
+        if (loanStatus == LoanStatus.Pending) {
+            loans[id].prediction[choice] = loans[id].prediction[choice].sub(stake);
+        }
+
+        // update account votes
+        loans[id].votes[msg.sender][choice] = loans[id].votes[msg.sender][choice].sub(stake);
+
+        // transfer tokens to sender and emit event
+        require(trustToken.transfer(msg.sender, amountToTransfer));
+        emit Withdrawn(id, msg.sender, stake, amountToTransfer, burned);
+    }
+
+    /**
+     * @dev Total amount of funds given to correct voters
+     * @param id Loan ID
+     * @param incorrectChoice Vote which was incorrect
+     * @return TRU amount given to correct voters
+     */
+    function bounty(address id, bool incorrectChoice) public view returns (uint256) {
+        // reward = (incorrect_tokens_staked) * (loss_factor) * (1 - burn_factor)
+        // prettier-ignore
+        return loans[id].prediction[incorrectChoice].mul(
+            lossFactor).mul(uint256(10000).sub(burnFactor)).div(10000**2);
+    }
+
+    /**
+     * @dev Internal view to convert values to 8 decimals precision
+     * @param input Value to convert to TRU precision
+     * @return output TRU amount
+     */
+    function toTrustToken(uint256 input) internal pure returns (uint256 output) {
+        output = input.div(TOKEN_PRECISION_DIFFERENCE);
+    }
+
+    /**
+     * @dev Update total TRU reward for a Loan
+     * Reward is divided proportionally based on # TRU staked
+     * chi = (TRU remaining in distributor) / (Total TRU allocated for distribution)
+     * interest = (loan APY * term * principal)
+     * R = Total Reward = (interest * chi * rewardFactor)
+     * @param id Loan ID
+     */
+    modifier calculateTotalReward(address id) {
+        if (loans[id].reward == 0) {
+            uint256 interest = ILoanToken(id).profit();
+
+            // calculate reward
+            // prettier-ignore
+            uint256 reward = toTrustToken(
+                interest
+                    .mul(distributor.remaining())
+                    .mul(rewardMultiplier)
+                    .div(distributor.amount())
+            );
+
+            loans[id].reward = reward;
+            if (loans[id].reward > 0) {
+                distributor.distribute(reward);
+            }
+        }
+        _;
+    }
+
+    /**
+     * @dev Claim TRU rewards for voters
+     * - Only can claim TRU rewards for funded loans
+     * - Voters can claim a portion of their total rewards over time
+     * - Claimed automatically when a user withdraws stake
+     *
+     * chi = (TRU remaining in distributor) / (Total TRU allocated for distribution)
+     * interest = (loan APY * term * principal)
+     * R = Total Reward = (interest * chi)
+     * R is distributed to voters based on their proportion of votes/total_votes
+     *
+     * Claimable reward = R x (current time / total time)
+     *      * (account TRU staked / total TRU staked) - (amount claimed)
+     *
+     * @param id Loan ID
+     * @param voter Voter account
+     */
+    function claim(address id, address voter) public override onlyFundedLoans(id) calculateTotalReward(id) {
+        uint256 claimableRewards = claimable(id, voter);
+
+        if (claimableRewards > 0) {
+            // track amount of claimed tokens
+            loans[id].claimed[voter] = loans[id].claimed[voter].add(claimableRewards);
+            // transfer tokens
+            require(trustToken.transfer(voter, claimableRewards));
+            emit Claimed(id, voter, claimableRewards);
+        }
+    }
+
+    function claimed(address id, address voter) external view returns (uint256) {
+        return loans[id].claimed[voter];
+    }
+
+    function claimable(address id, address voter) public view returns (uint256) {
+        if (status(id) < LoanStatus.Running) {
+            return 0;
+        }
+
+        uint256 totalTime = ILoanToken(id).term();
+        uint256 passedTime = block.timestamp.sub(ILoanToken(id).start());
+
+        // check time of loan
+        if (passedTime > totalTime) {
+            passedTime = totalTime;
+        }
+        // calculate how many tokens user can claim
+        // claimable = stakedByVoter / totalStaked
+        uint256 stakedByVoter = loans[id].votes[voter][false].add(loans[id].votes[voter][true]);
+        uint256 totalStaked = loans[id].prediction[false].add(loans[id].prediction[true]);
+
+        // calculate claimable rewards at current time
+        uint256 helper = loans[id].reward.mul(passedTime).mul(stakedByVoter);
+        uint256 totalClaimable = helper.div(totalTime).div(totalStaked);
+        if (totalClaimable < loans[id].claimed[voter]) {
+            // This happens only in one case: voter withdrew part of stake after loan has ended and claimed all possible rewards
+            return 0;
+        }
+        return totalClaimable.sub(loans[id].claimed[voter]);
+    }
+
+    /**
+     * @dev Check if a prediction was correct for a specific loan and vote
+     * @param id Loan ID
+     * @param choice Outcome prediction
+     */
+    function wasPredictionCorrect(address id, bool choice) internal view returns (bool) {
+        if (status(id) == LoanStatus.Settled && choice) {
+            return true;
+        }
+        if (status(id) == LoanStatus.Defaulted && !choice) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @dev Get status for a specific loan
+     * We rely on correct implementation of LoanToken
+     * @param id Loan ID
+     * @return Status of loan
+     */
+    function status(address id) public view returns (LoanStatus) {
+        Loan storage loan = loans[id];
+        // Void loan doesn't exist because timestamp is zero
+        if (loan.creator == address(0) && loan.timestamp == 0) {
+            return LoanStatus.Void;
+        }
+        // Retracted loan was cancelled by borrower
+        if (loan.creator == address(0) && loan.timestamp != 0) {
+            return LoanStatus.Retracted;
+        }
+        // get internal status
+        ILoanToken.Status loanInternalStatus = ILoanToken(id).status();
+
+        // Running is Funded || Withdrawn
+        if (loanInternalStatus == ILoanToken.Status.Funded || loanInternalStatus == ILoanToken.Status.Withdrawn) {
+            return LoanStatus.Running;
+        }
+        // Settled has been paid back in full and past term
+        if (loanInternalStatus == ILoanToken.Status.Settled) {
+            return LoanStatus.Settled;
+        }
+        // Defaulted has not been paid back in full and past term
+        if (loanInternalStatus == ILoanToken.Status.Defaulted) {
+            return LoanStatus.Defaulted;
+        }
+        // otherwise return Pending
+        return LoanStatus.Pending;
+    }
+}

--- a/flatten/TrueUSD.sol
+++ b/flatten/TrueUSD.sol
@@ -1,0 +1,1378 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// solhint-disable max-states-count, var-name-mixedcase
+
+/**
+ * Defines the storage layout of the token implementation contract. Any
+ * newly declared state variables in future upgrades should be appended
+ * to the bottom. Never remove state variables from this list, however variables
+ * can be renamed. Please add _Deprecated to deprecated variables.
+ */
+contract ProxyStorage {
+    address public owner;
+    address public pendingOwner;
+
+    bool initialized;
+
+    address balances_Deprecated;
+    address allowances_Deprecated;
+
+    uint256 _totalSupply;
+
+    bool private paused_Deprecated = false;
+    address private globalPause_Deprecated;
+
+    uint256 public burnMin = 0;
+    uint256 public burnMax = 0;
+
+    address registry_Deprecated;
+
+    string name_Deprecated;
+    string symbol_Deprecated;
+
+    uint256[] gasRefundPool_Deprecated;
+    uint256 private redemptionAddressCount_Deprecated;
+    uint256 minimumGasPriceForFutureRefunds_Deprecated;
+
+    mapping(address => uint256) _balances;
+    mapping(address => mapping(address => uint256)) _allowances;
+    mapping(bytes32 => mapping(address => uint256)) attributes_Deprecated;
+
+    // reward token storage
+    mapping(address => address) finOps_Deprecated;
+    mapping(address => mapping(address => uint256)) finOpBalances_Deprecated;
+    mapping(address => uint256) finOpSupply_Deprecated;
+
+    // true reward allocation
+    // proportion: 1000 = 100%
+    struct RewardAllocation {
+        uint256 proportion;
+        address finOp;
+    }
+    mapping(address => RewardAllocation[]) _rewardDistribution_Deprecated;
+    uint256 maxRewardProportion_Deprecated = 1000;
+
+    mapping(address => bool) isBlacklisted;
+    mapping(address => bool) public canBurn;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 32         uint256(11)                                                   gasRefundPool_Deprecated
+     ** 64         uint256(address),uint256(14)                                  balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(15))      allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(16))               attributes
+     **/
+}
+
+
+// Dependency file: contracts/true-currencies/common/ClaimableOwnable.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/true-currencies/common/ProxyStorage.sol";
+
+/**
+ * @title ClamableOwnable
+ * @dev The ClamableOwnable contract is a copy of Claimable Contract by Zeppelin.
+ * and provides basic authorization control functions. Inherits storage layout of
+ * ProxyStorage.
+ */
+contract ClaimableOwnable is ProxyStorage {
+    /**
+     * @dev emitted when ownership is transferred
+     * @param previousOwner previous owner of this contract
+     * @param newOwner new owner of this contract
+     */
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner, "only pending owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables _balances, _allowances, _totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ClaimableOwnable} from "contracts/true-currencies/common/ClaimableOwnable.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ClaimableOwnable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/true-currencies/common/ReclaimerToken.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {ERC20} from "contracts/true-currencies/common/ERC20.sol";
+
+/**
+ * @title ReclaimerToken
+ * @dev ERC20 token which allows owner to reclaim ERC20 tokens
+ * or ether sent to this contract
+ */
+abstract contract ReclaimerToken is ERC20 {
+    /**
+     * @dev send all eth balance in the contract to another address
+     * @param _to address to send eth balance to
+     */
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    /**
+     * @dev send all token balance of an arbitrary erc20 token
+     * in the contract to another address
+     * @param token token to reclaim
+     * @param _to address to send eth balance to
+     */
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/common/BurnableTokenWithBounds.sol
+
+// pragma solidity 0.6.10;
+
+// import {ReclaimerToken} from "contracts/true-currencies/common/ReclaimerToken.sol";
+
+/**
+ * @title BurnableTokenWithBounds
+ * @dev Burning functions as redeeming money from the system.
+ * The platform will keep track of who burns coins,
+ * and will send them back the equivalent amount of money (rounded down to the nearest cent).
+ */
+abstract contract BurnableTokenWithBounds is ReclaimerToken {
+    /**
+     * @dev Emitted when `value` tokens are burnt from one account (`burner`)
+     * @param burner address which burned tokens
+     * @param value amount of tokens burned
+     */
+    event Burn(address indexed burner, uint256 value);
+
+    /**
+     * @dev Emitted when new burn bounds were set
+     * @param newMin new minimum burn amount
+     * @param newMax new maximum burn amount
+     * @notice `newMin` should never be greater than `newMax`
+     */
+    event SetBurnBounds(uint256 newMin, uint256 newMax);
+
+    /**
+     * @dev Destroys `amount` tokens from `msg.sender`, reducing the
+     * total supply.
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     * Emits a {Burn} event with `burner` set to `msg.sender`
+     *
+     * Requirements
+     *
+     * - `msg.sender` must have at least `amount` tokens.
+     *
+     */
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    /**
+     * @dev Change the minimum and maximum amount that can be burned at once.
+     * Burning may be disabled by setting both to 0 (this will not be done
+     * under normal operation, but we can't add checks to disallow it without
+     * losing a lot of flexibility since burning could also be as good as disabled
+     * by setting the minimum extremely high, and we don't want to lock
+     * in any particular cap for the minimum)
+     * @param _min minimum amount that can be burned at once
+     * @param _max maximum amount that can be burned at once
+     */
+    function setBurnBounds(uint256 _min, uint256 _max) external onlyOwner {
+        require(_min <= _max, "BurnableTokenWithBounds: min > max");
+        burnMin = _min;
+        burnMax = _max;
+        emit SetBurnBounds(_min, _max);
+    }
+
+    /**
+     * @dev Checks if amount is within allowed burn bounds and
+     * destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     * @param account account to burn tokens for
+     * @param amount amount of tokens to burn
+     *
+     * Emits a {Burn} event
+     */
+    function _burn(address account, uint256 amount) internal virtual override {
+        require(amount >= burnMin, "BurnableTokenWithBounds: below min burn bound");
+        require(amount <= burnMax, "BurnableTokenWithBounds: exceeds max burn bound");
+
+        super._burn(account, amount);
+        emit Burn(account, amount);
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrency.sol
+
+// pragma solidity 0.6.10;
+
+// import {BurnableTokenWithBounds} from "contracts/true-currencies/common/BurnableTokenWithBounds.sol";
+
+/**
+ * @title TrueCurrency
+ * @dev TrueCurrency is an ERC20 with blacklist & redemption addresses
+ *
+ * TrueCurrency is a compliant stablecoin with blacklist and redemption
+ * addresses. Only the owner can blacklist accounts. Redemption addresses
+ * are assigned automatically to the first 0x100000 addresses. Sending
+ * tokens to the redemption address will trigger a burn operation. Only
+ * the owner can mint or blacklist accounts.
+ *
+ * This contract is owned by the TokenController, which manages token
+ * minting & admin functionality. See TokenController.sol
+ *
+ * See also: BurnableTokenWithBounds.sol
+ *
+ * ~~~~ Features ~~~~
+ *
+ * Redemption Addresses
+ * - The first 0x100000 addresses are redemption addresses
+ * - Tokens sent to redemption addresses are burned
+ * - Redemptions are tracked off-chain
+ * - Cannot mint tokens to redemption addresses
+ *
+ * Blacklist
+ * - Owner can blacklist accounts in accordance with local regulatory bodies
+ * - Only a court order will merit a blacklist; blacklisting is extremely rare
+ *
+ * Burn Bounds & CanBurn
+ * - Owner can set min & max burn amounts
+ * - Only accounts flagged in canBurn are allowed to burn tokens
+ * - canBurn prevents tokens from being sent to the incorrect address
+ *
+ * Reclaimer Token
+ * - ERC20 Tokens and Ether sent to this contract can be reclaimed by the owner
+ */
+abstract contract TrueCurrency is BurnableTokenWithBounds {
+    uint256 constant CENT = 10**16;
+    uint256 constant REDEMPTION_ADDRESS_COUNT = 0x100000;
+
+    /**
+     * @dev Emitted when account blacklist status changes
+     */
+    event Blacklisted(address indexed account, bool isBlacklisted);
+
+    /**
+     * @dev Emitted when `value` tokens are minted for `to`
+     * @param to address to mint tokens for
+     * @param value amount of tokens to be minted
+     */
+    event Mint(address indexed to, uint256 value);
+
+    /**
+     * @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     * @param account address to mint tokens for
+     * @param amount amount of tokens to be minted
+     *
+     * Emits a {Mint} event
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` cannot be blacklisted.
+     * - `account` cannot be a redemption address.
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        require(!isBlacklisted[account], "TrueCurrency: account is blacklisted");
+        require(!isRedemptionAddress(account), "TrueCurrency: account is a redemption address");
+        _mint(account, amount);
+        emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Set blacklisted status for the account.
+     * @param account address to set blacklist flag for
+     * @param _isBlacklisted blacklist flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setBlacklisted(address account, bool _isBlacklisted) external onlyOwner {
+        require(uint256(account) >= REDEMPTION_ADDRESS_COUNT, "TrueCurrency: blacklisting of redemption address is not allowed");
+        isBlacklisted[account] = _isBlacklisted;
+        emit Blacklisted(account, _isBlacklisted);
+    }
+
+    /**
+     * @dev Set canBurn status for the account.
+     * @param account address to set canBurn flag for
+     * @param _canBurn canBurn flag value
+     *
+     * Requirements:
+     *
+     * - `msg.sender` should be owner.
+     */
+    function setCanBurn(address account, bool _canBurn) external onlyOwner {
+        canBurn[account] = _canBurn;
+    }
+
+    /**
+     * @dev Check if neither account is blacklisted before performing transfer
+     * If transfer recipient is a redemption address, burns tokens
+     * @notice Transfer to redemption address will burn tokens with a 1 cent precision
+     * @param sender address of sender
+     * @param recipient address of recipient
+     * @param amount amount of tokens to transfer
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual override {
+        require(!isBlacklisted[sender], "TrueCurrency: sender is blacklisted");
+        require(!isBlacklisted[recipient], "TrueCurrency: recipient is blacklisted");
+
+        if (isRedemptionAddress(recipient)) {
+            super._transfer(sender, recipient, amount.sub(amount.mod(CENT)));
+            _burn(recipient, amount.sub(amount.mod(CENT)));
+        } else {
+            super._transfer(sender, recipient, amount);
+        }
+    }
+
+    /**
+     * @dev Requere neither accounts to be blacklisted before approval
+     * @param owner address of owner giving approval
+     * @param spender address of spender to approve for
+     * @param amount amount of tokens to approve
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override {
+        require(!isBlacklisted[owner], "TrueCurrency: tokens owner is blacklisted");
+        require(!isBlacklisted[spender] || amount == 0, "TrueCurrency: tokens spender is blacklisted");
+
+        super._approve(owner, spender, amount);
+    }
+
+    /**
+     * @dev Check if tokens can be burned at address before burning
+     * @param account account to burn tokens from
+     * @param amount amount of tokens to burn
+     */
+    function _burn(address account, uint256 amount) internal override {
+        require(canBurn[account], "TrueCurrency: cannot burn from this address");
+        super._burn(account, amount);
+    }
+
+    /**
+     * @dev First 0x100000-1 addresses (0x0000000000000000000000000000000000000001 to 0x00000000000000000000000000000000000fffff)
+     * are the redemption addresses.
+     * @param account address to check is a redemption address
+     *
+     * All transfers to redemption address will trigger token burn.
+     *
+     * @notice For transfer to succeed, canBurn must be true for redemption address
+     *
+     * @return is `account` a redemption address
+     */
+    function isRedemptionAddress(address account) internal pure returns (bool) {
+        return uint256(account) < REDEMPTION_ADDRESS_COUNT && uint256(account) != 0;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/DelegateERC20.sol
+
+// pragma solidity 0.6.10;
+
+// import {TrueCurrency} from "contracts/true-currencies/TrueCurrency.sol";
+
+/**
+ * @title DelegateERC20
+ * Accept forwarding delegation calls from the old TrueUSD (V1) contract.
+ * This way the all the ERC20 functions in the old contract still works
+ * (except Burn).
+ *
+ * The original contract is at 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E.
+ * Lines 497-574 on-chain call these delegate functions to forward calls
+ * This gives the delegate contract the power to change the state of the TrueUSD
+ * contract. The owner of this contract is the TrueUSD TokenController
+ * at 0x0000000000075efbee23fe2de1bd0b7690883cc9.
+ *
+ * Our audits for TrueCurrency can be found here: github.com/trusttoken/audits
+ */
+abstract contract DelegateERC20 is TrueCurrency {
+    address constant DELEGATE_FROM = 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E;
+
+    // require msg.sender is the delegate smart contract
+    modifier onlyDelegateFrom() {
+        require(msg.sender == DELEGATE_FROM);
+        _;
+    }
+
+    /**
+     * @dev Delegate call to get total supply
+     * @return Total supply
+     */
+    function delegateTotalSupply() public view returns (uint256) {
+        return totalSupply();
+    }
+
+    /**
+     * @dev Delegate call to get balance
+     * @param who Address to get balance for
+     * @return balance of account
+     */
+    function delegateBalanceOf(address who) public view returns (uint256) {
+        return balanceOf(who);
+    }
+
+    /**
+     * @dev Delegate call to transfer
+     * @param to address to transfer to
+     * @param value amount to transfer
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateTransfer(
+        address to,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        _transfer(origSender, to, value);
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to get allowance
+     * @param owner account owner
+     * @param spender account to check allowance for
+     * @return allowance
+     */
+    function delegateAllowance(address owner, address spender) public view returns (uint256) {
+        return allowance(owner, spender);
+    }
+
+    /**
+     * @dev Delegate call to transfer from
+     * @param from account to transfer funds from
+     * @param to account to transfer funds to
+     * @param value value to transfer
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateTransferFrom(
+        address from,
+        address to,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 transferFrom with _msgSender() replaced by origSender
+        _transfer(from, to, value);
+        _approve(from, origSender, _allowances[from][origSender].sub(value, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to approve
+     * @param spender account to approve for
+     * @param value amount to approve
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateApprove(
+        address spender,
+        uint256 value,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        _approve(origSender, spender, value);
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to increase approval
+     * @param spender account to increase approval for
+     * @param addedValue amount of approval to add
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateIncreaseApproval(
+        address spender,
+        uint256 addedValue,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 increaseAllowance() with _msgSender() replaced by origSender
+        _approve(origSender, spender, _allowances[origSender][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Delegate call to decrease approval
+     * @param spender spender to decrease approval for
+     * @param subtractedValue value to subtract from approval
+     * @param origSender original msg.sender on delegate contract
+     * @return success
+     */
+    function delegateDecreaseApproval(
+        address spender,
+        uint256 subtractedValue,
+        address origSender
+    ) public onlyDelegateFrom returns (bool) {
+        // ERC20 decreaseAllowance() with _msgSender() replaced by origSender
+        _approve(origSender, spender, _allowances[origSender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+}
+
+
+// Dependency file: contracts/true-currencies/TrueCurrencyWithLegacyAutosweep.sol
+
+// pragma solidity 0.6.10;
+
+// import {DelegateERC20} from "contracts/true-currencies/DelegateERC20.sol";
+
+/**
+ * @dev Contract that prevents addresses that were previously using autosweep addresses from
+ * making transfers on them.
+ *
+ * In older versions TrueCurrencies had a feature called Autosweep.
+ * Given a single deposit address, it was possible to generate 16^5-1 autosweep addresses.
+ * E.g. having deposit address 0xc257274276a4e539741ca11b590b9447b26a8051, you could generate
+ * - 0xc257274276a4e539741ca11b590b9447b2600000
+ * - 0xc257274276a4e539741ca11b590b9447b2600001
+ * - ...
+ * - 0xc257274276a4e539741ca11b590b9447b26fffff
+ * Every transfer to an autosweep address resulted as a transfer to deposit address.
+ * This feature got deprecated, but there were 4 addresses that still actively using the feature.
+ *
+ * This contract will reject a transfer to these 4*(16^5-1) addresses to prevent accidental token freeze.
+ */
+abstract contract TrueCurrencyWithLegacyAutosweep is DelegateERC20 {
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal override {
+        requireNotAutosweepAddress(recipient, 0x33091DE8341533468D13A80C5A670f4f47cC649f);
+        requireNotAutosweepAddress(recipient, 0x50E2719208914764087e68C32bC5AaC321f5B04d);
+        requireNotAutosweepAddress(recipient, 0x71d69e5481A9B7Be515E20B38a3f62Dab7170D78);
+        requireNotAutosweepAddress(recipient, 0x90fdaA85D52dB6065D466B86f16bF840D514a488);
+
+        super._transfer(sender, recipient, amount);
+    }
+
+    function requireNotAutosweepAddress(address recipient, address depositAddress) internal pure {
+        return
+            require(uint256(recipient) >> 20 != uint256(depositAddress) >> 20 || recipient == depositAddress, "Autosweep is disabled");
+    }
+}
+
+
+// Root file: contracts/true-currencies/tokens/TrueUSD.sol
+
+pragma solidity 0.6.10;
+
+// import {TrueCurrencyWithLegacyAutosweep} from "contracts/true-currencies/TrueCurrencyWithLegacyAutosweep.sol";
+
+/**
+ * @title TrueUSD
+ * @dev This is the top-level ERC20 contract, but most of the interesting functionality is
+ * inherited - see the documentation on the corresponding contracts.
+ */
+contract TrueUSD is TrueCurrencyWithLegacyAutosweep {
+    uint8 constant DECIMALS = 18;
+    uint8 constant ROUNDING = 2;
+
+    function decimals() public override pure returns (uint8) {
+        return DECIMALS;
+    }
+
+    function rounding() public pure returns (uint8) {
+        return ROUNDING;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueUSD";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TUSD";
+    }
+}

--- a/flatten/TrustToken.sol
+++ b/flatten/TrustToken.sol
@@ -1,0 +1,1537 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: contracts/registry/Registry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+contract Registry {
+    struct AttributeData {
+        uint256 value;
+        bytes32 notes;
+        address adminAddr;
+        uint256 timestamp;
+    }
+
+    // never remove any storage variables
+    address public owner;
+    address public pendingOwner;
+    bool initialized;
+
+    // Stores arbitrary attributes for users. An example use case is an IERC20
+    // token that requires its users to go through a KYC/AML check - in this case
+    // a validator can set an account's "hasPassedKYC/AML" attribute to 1 to indicate
+    // that account can use the token. This mapping stores that value (1, in the
+    // example) as well as which validator last set the value and at what time,
+    // so that e.g. the check can be renewed at appropriate intervals.
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
+    // The logic governing who is allowed to set what attributes is abstracted as
+    // this accessManager, so that it may be replaced by the owner as needed
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    mapping(bytes32 => RegistryClone[]) subscribers;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetManager(address indexed oldManager, address indexed newManager);
+    event StartSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+    event StopSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+
+    // Allows a write if either a) the writer is that Registry's owner, or
+    // b) the writer is writing to attribute foo and that writer already has
+    // the canWriteTo-foo attribute set (in that same Registry)
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
+        return (_admin == owner || hasAttribute(_admin, keccak256(abi.encodePacked(WRITE_PERMISSION ^ _attribute))));
+    }
+
+    // Writes are allowed only if the accessManager approves
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
+
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    function subscribe(bytes32 _attribute, RegistryClone _syncer) external onlyOwner {
+        subscribers[_attribute].push(_syncer);
+        emit StartSubscription(_attribute, _syncer);
+    }
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external onlyOwner {
+        uint256 length = subscribers[_attribute].length;
+        require(_index < length);
+        emit StopSubscription(_attribute, subscribers[_attribute][_index]);
+        subscribers[_attribute][_index] = subscribers[_attribute][length - 1];
+        subscribers[_attribute].pop();
+    }
+
+    function subscriberCount(bytes32 _attribute) public view returns (uint256) {
+        return subscribers[_attribute].length;
+    }
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, "", msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, "", msg.sender);
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    // Returns true if the uint256 value stored for this attribute is non-zero
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
+        return attributes[_who][_attribute].value != 0;
+    }
+
+    // Returns the exact value of the attribute, as well as its metadata
+    function getAttribute(address _who, bytes32 _attribute)
+        public
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        )
+    {
+        AttributeData memory data = attributes[_who][_attribute];
+        return (data.value, data.notes, data.adminAddr, data.timestamp);
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].value;
+    }
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) public view returns (address) {
+        return attributes[_who][_attribute].adminAddr;
+    }
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].timestamp;
+    }
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external {
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > _startIndex) {
+            RegistryClone target = targets[index];
+            for (uint256 i = _addresses.length; i-- > 0; ) {
+                address who = _addresses[i];
+                target.syncAttributeValue(who, _attribute, attributes[who][_attribute].value);
+            }
+        }
+    }
+
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/trusttoken/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// import {Registry} from "contracts/registry/Registry.sol";
+
+/**
+ * All storage must be declared here
+ * New storage must be appended to the end
+ * Never remove items from this list
+ */
+contract ProxyStorage {
+    bool initalized;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    mapping(uint144 => uint256) attributes; // see RegistrySubscriber
+
+    address owner_;
+    address pendingOwner_;
+
+    mapping(address => address) public delegates; // A record of votes checkpoints for each account, by index
+    struct Checkpoint {
+        // A checkpoint for marking number of votes from a given block
+        uint32 fromBlock;
+        uint96 votes;
+    }
+    mapping(address => mapping(uint32 => Checkpoint)) public checkpoints; // A record of votes checkpoints for each account, by index
+    mapping(address => uint32) public numCheckpoints; // The number of checkpoints for each account
+    mapping(address => uint256) public nonces;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(3))                attributes
+     **/
+}
+
+
+// Dependency file: contracts/trusttoken/common/ClaimableContract.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/trusttoken/common/ProxyStorage.sol";
+
+/**
+ * @title ClaimableContract
+ * @dev The ClaimableContract contract is a copy of Claimable Contract by Zeppelin.
+ and provides basic authorization control functions. Inherits storage layout of
+ ProxyStorage.
+ */
+contract ClaimableContract is ProxyStorage {
+    function owner() public view returns (address) {
+        return owner_;
+    }
+
+    function pendingOwner() public view returns (address) {
+        return pendingOwner_;
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner_ = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner_, "only owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner_);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner_ = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        address _pendingOwner = pendingOwner_;
+        emit OwnershipTransferred(owner_, _pendingOwner);
+        owner_ = _pendingOwner;
+        pendingOwner_ = address(0);
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/trusttoken/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables balances, allowances, totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ * - Remove inheritance from IERC20 because of ProxyStorage name conflicts
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ProxyStorage} from "contracts/trusttoken/common/ProxyStorage.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ProxyStorage, Context {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), allowance[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        balanceOf[sender] = balanceOf[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        balanceOf[recipient] = balanceOf[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        totalSupply = totalSupply.add(amount);
+        balanceOf[account] = balanceOf[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        balanceOf[account] = balanceOf[account].sub(amount, "ERC20: burn amount exceeds balance");
+        totalSupply = totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        allowance[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/governance/interface/IVoteToken.sol
+
+
+// pragma solidity ^0.6.10;
+
+interface IVoteToken {
+    function delegate(address delegatee) external;
+    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s) external;
+    function getCurrentVotes(address account) external view returns (uint96);
+    function getPriorVotes(address account, uint blockNumber) external view returns (uint96);
+}
+
+// Dependency file: contracts/governance/VoteToken.sol
+
+// AND COPIED FROM https://github.com/compound-finance/compound-protocol/blob/master/contracts/Governance/GovernorAlpha.sol
+// Copyright 2020 Compound Labs, Inc.
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Ctrl+f for OLD to see all the modifications.
+
+// OLD: // pragma solidity ^0.5.16;
+// pragma solidity 0.6.10;
+
+// import {ClaimableContract} from "contracts/trusttoken/common/ClaimableContract.sol";
+// import {ERC20} from "contracts/trusttoken/common/ERC20.sol";
+// import {IVoteToken} from "contracts/governance/interface/IVoteToken.sol";
+
+abstract contract VoteToken is ERC20, IVoteToken {
+    bytes32 public constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+    bytes32 public constant DELEGATION_TYPEHASH = keccak256("Delegation(address delegatee,uint256 nonce,uint256 expiry)");
+    
+    event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
+    event DelegateVotesChanged(address indexed delegate, uint previousBalance, uint newBalance);
+
+    function delegate(address delegatee) public override {
+        return _delegate(msg.sender, delegatee);
+    }
+
+    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s) public override {
+        //OLD: bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name)), getChainId(), address(this)));
+        bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH,keccak256(bytes(name())),getChainId(),address(this)));
+        bytes32 structHash = keccak256(abi.encode(DELEGATION_TYPEHASH, delegatee, nonce, expiry));
+        bytes32 digest = keccak256(abi.encodePacked("", domainSeparator, structHash));
+        address signatory = ecrecover(digest, v, r, s);
+        require(signatory != address(0), "TrustToken::delegateBySig: invalid signature");
+        require(nonce == nonces[signatory]++, "TrustToken::delegateBySig: invalid nonce");
+        require(now <= expiry, "TrustToken::delegateBySig: signature expired");
+        return _delegate(signatory, delegatee);
+    }
+
+    function getCurrentVotes(address account) external view override returns (uint96) {
+        uint32 nCheckpoints = numCheckpoints[account];
+        return nCheckpoints > 0 ? checkpoints[account][nCheckpoints - 1].votes : 0;
+    }
+
+    function getPriorVotes(address account, uint blockNumber) public view override returns (uint96) {
+        require(blockNumber < block.number, "TrustToken::getPriorVotes: not yet determined");
+
+        uint32 nCheckpoints = numCheckpoints[account];
+        if (nCheckpoints == 0) {
+            return 0;
+        }
+
+        // First check most recent balance
+        if (checkpoints[account][nCheckpoints - 1].fromBlock <= blockNumber) {
+            return checkpoints[account][nCheckpoints - 1].votes;
+        }
+
+        // Next check implicit zero balance
+        if (checkpoints[account][0].fromBlock > blockNumber) {
+            return 0;
+        }
+
+        uint32 lower = 0;
+        uint32 upper = nCheckpoints - 1;
+        while (upper > lower) {
+            uint32 center = upper - (upper - lower) / 2; // ceil, avoiding overflow
+            Checkpoint memory cp = checkpoints[account][center];
+            if (cp.fromBlock == blockNumber) {
+                return cp.votes;
+            } else if (cp.fromBlock < blockNumber) {
+                lower = center;
+            } else {
+                upper = center - 1;
+            }
+        }
+        return checkpoints[account][lower].votes;
+    }
+
+    function _delegate(address delegator, address delegatee) internal {
+        address currentDelegate = delegates[delegator];
+        // OLD: uint96 delegatorBalance = balanceOf(delegator);
+        uint96 delegatorBalance = uint96(_balanceOf(delegator));
+        delegates[delegator] = delegatee;
+
+        emit DelegateChanged(delegator, currentDelegate, delegatee);
+
+        _moveDelegates(currentDelegate, delegatee, delegatorBalance);
+    }
+
+    function _balanceOf(address account) internal virtual returns(uint256) {
+        return balanceOf[account];
+    }
+
+    function _transfer( address _from, address _to, uint256 _value) internal override virtual {
+        super._transfer(_from, _to, _value);
+        _moveDelegates(delegates[_from], delegates[_to], uint96(_value));
+    }
+
+    function _moveDelegates(address srcRep, address dstRep, uint96 amount) internal {
+        if (srcRep != dstRep && amount > 0) {
+            if (srcRep != address(0)) {
+                uint32 srcRepNum = numCheckpoints[srcRep];
+                uint96 srcRepOld = srcRepNum > 0 ? checkpoints[srcRep][srcRepNum - 1].votes : 0;
+                uint96 srcRepNew = sub96(srcRepOld, amount, "TrustToken::_moveVotes: vote amount underflows");
+                _writeCheckpoint(srcRep, srcRepNum, srcRepOld, srcRepNew);
+            }
+
+            if (dstRep != address(0)) {
+                uint32 dstRepNum = numCheckpoints[dstRep];
+                uint96 dstRepOld = dstRepNum > 0 ? checkpoints[dstRep][dstRepNum - 1].votes : 0;
+                uint96 dstRepNew = add96(dstRepOld, amount, "TrustToken::_moveVotes: vote amount overflows");
+                _writeCheckpoint(dstRep, dstRepNum, dstRepOld, dstRepNew);
+            }
+        }
+    }
+
+    function _writeCheckpoint(address delegatee, uint32 nCheckpoints, uint96 oldVotes, uint96 newVotes) internal {
+        uint32 blockNumber = safe32(block.number, "TrustToken::_writeCheckpoint: block number exceeds 32 bits");
+
+        if (nCheckpoints > 0 && checkpoints[delegatee][nCheckpoints - 1].fromBlock == blockNumber) {
+            checkpoints[delegatee][nCheckpoints - 1].votes = newVotes;
+        } else {
+            checkpoints[delegatee][nCheckpoints] = Checkpoint(blockNumber, newVotes);
+            numCheckpoints[delegatee] = nCheckpoints + 1;
+        }
+
+        emit DelegateVotesChanged(delegatee, oldVotes, newVotes);
+    }
+
+    function safe32(uint n, string memory errorMessage) internal pure returns (uint32) {
+        require(n < 2**32, errorMessage);
+        return uint32(n);
+    }
+
+    function safe96(uint n, string memory errorMessage) internal pure returns (uint96) {
+        require(n < 2**96, errorMessage);
+        return uint96(n);
+    }
+
+    function add96(uint96 a, uint96 b, string memory errorMessage) internal pure returns (uint96) {
+        uint96 c = a + b;
+        require(c >= a, errorMessage);
+        return c;
+    }
+
+    function sub96(uint96 a, uint96 b, string memory errorMessage) internal pure returns (uint96) {
+        require(b <= a, errorMessage);
+        return a - b;
+    }
+
+    function getChainId() internal pure returns (uint) {
+        uint256 chainId;
+        assembly { chainId := chainid() }
+        return chainId;
+    }
+}
+
+
+
+
+// Dependency file: contracts/trusttoken/TimeLockedToken.sol
+
+// pragma solidity 0.6.10;
+
+// import "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {VoteToken} from "contracts/governance/VoteToken.sol";
+// import {ClaimableContract} from "contracts/trusttoken/common/ClaimableContract.sol";
+
+/**
+ * @title TimeLockedToken
+ * @notice Time Locked ERC20 Token
+ * @author Harold Hyatt
+ * @dev Contract which gives the ability to time-lock tokens
+ *
+ * The registerLockup() function allows an account to transfer
+ * its tokens to another account, locking them according to the
+ * distribution epoch periods
+ *
+ * By overriding the balanceOf(), transfer(), and transferFrom()
+ * functions in ERC20, an account can show its full, post-distribution
+ * balance but only transfer or spend up to an allowed amount
+ *
+ * Every time an epoch passes, a portion of previously non-spendable tokens
+ * are allowed to be transferred, and after all epochs have passed, the full
+ * account balance is unlocked
+ */
+abstract contract TimeLockedToken is VoteToken, ClaimableContract {
+    using SafeMath for uint256;
+
+    // represents total distribution for locked balances
+    mapping(address => uint256) distribution;
+
+    // start of the lockup period
+    // Friday, July 24, 2020 4:58:31 PM GMT
+    uint256 constant LOCK_START = 1595609911;
+    // length of time to delay first epoch
+    uint256 constant FIRST_EPOCH_DELAY = 30 days;
+    // how long does an epoch last
+    uint256 constant EPOCH_DURATION = 90 days;
+    // number of epochs
+    uint256 constant TOTAL_EPOCHS = 8;
+    // registry of locked addresses
+    address public timeLockRegistry;
+    // allow unlocked transfers to special account
+    bool public returnsLocked;
+
+    modifier onlyTimeLockRegistry() {
+        require(msg.sender == timeLockRegistry, "only TimeLockRegistry");
+        _;
+    }
+
+    /**
+     * @dev Set TimeLockRegistry address
+     * @param newTimeLockRegistry Address of TimeLockRegistry contract
+     */
+    function setTimeLockRegistry(address newTimeLockRegistry) external onlyOwner {
+        require(newTimeLockRegistry != address(0), "cannot be zero address");
+        require(newTimeLockRegistry != timeLockRegistry, "must be new TimeLockRegistry");
+        timeLockRegistry = newTimeLockRegistry;
+    }
+
+    /**
+     * @dev Permanently lock transfers to return address
+     * Lock returns so there isn't always a way to send locked tokens
+     */
+    function lockReturns() external onlyOwner {
+        returnsLocked = true;
+    }
+
+    /**
+     * @dev Transfer function which includes unlocked tokens
+     * Locked tokens can always be transfered back to the returns address
+     * Transferring to owner allows re-issuance of funds through registry
+     *
+     * @param _from The address to send tokens from
+     * @param _to The address that will receive the tokens
+     * @param _value The amount of tokens to be transferred
+     */
+    function _transfer(
+        address _from,
+        address _to,
+        uint256 _value
+    ) internal virtual override {
+        require(balanceOf[_from] >= _value, "insufficient balance");
+
+        // transfers to owner proceed as normal when returns allowed
+        if (!returnsLocked && _to == owner_) {
+            transferToOwner(_from, _value);
+            return;
+        }
+        // check if enough unlocked balance to transfer
+        require(unlockedBalance(_from) >= _value, "attempting to transfer locked funds");
+        super._transfer(_from, _to, _value);
+    }
+
+    /**
+     * @dev Transfer tokens to owner. Used only when returns allowed.
+     * @param _from The address to send tokens from
+     * @param _value The amount of tokens to be transferred
+     */
+    function transferToOwner(address _from, uint256 _value) internal {
+        uint256 unlocked = unlockedBalance(_from);
+
+        if (unlocked < _value) {
+            // We want to have unlocked = value, i.e.
+            // value = balance - distribution * epochsLeft / totalEpochs
+            // distribution = (balance - value) * totalEpochs / epochsLeft
+            distribution[_from] = balanceOf[_from].sub(_value).mul(TOTAL_EPOCHS).div(epochsLeft());
+        }
+        super._transfer(_from, owner_, _value);
+    }
+
+    /**
+     * @dev Check if amount we want to burn is unlocked before burning
+     * @param _from The address whose tokens will burn
+     * @param _value The amount of tokens to be burnt
+     */
+    function _burn(address _from, uint256 _value) internal override {
+        require(balanceOf[_from] >= _value, "insufficient balance");
+        require(unlockedBalance(_from) >= _value, "attempting to burn locked funds");
+
+        super._burn(_from, _value);
+    }
+
+    /**
+     * @dev Transfer tokens to another account under the lockup schedule
+     * Emits a transfer event showing a transfer to the recipient
+     * Only the registry can call this function
+     * @param receiver Address to receive the tokens
+     * @param amount Tokens to be transferred
+     */
+    function registerLockup(address receiver, uint256 amount) external onlyTimeLockRegistry {
+        require(balanceOf[msg.sender] >= amount, "insufficient balance");
+
+        // add amount to locked distribution
+        distribution[receiver] = distribution[receiver].add(amount);
+
+        // transfer to recipient
+        _transfer(msg.sender, receiver, amount);
+    }
+
+    /**
+     * @dev Get locked balance for an account
+     * @param account Account to check
+     * @return Amount locked
+     */
+    function lockedBalance(address account) public view returns (uint256) {
+        // distribution * (epochsLeft / totalEpochs)
+        return distribution[account].mul(epochsLeft()).div(TOTAL_EPOCHS);
+    }
+
+    /**
+     * @dev Get unlocked balance for an account
+     * @param account Account to check
+     * @return Amount that is unlocked and available eg. to transfer
+     */
+    function unlockedBalance(address account) public view returns (uint256) {
+        // totalBalance - lockedBalance
+        return balanceOf[account].sub(lockedBalance(account));
+    }
+
+    function _balanceOf(address account) internal override returns (uint256) {
+        return unlockedBalance(account);
+    }
+
+    /*
+     * @dev Get number of epochs passed
+     * @return Value between 0 and 8 of lockup epochs already passed
+     */
+    function epochsPassed() public view returns (uint256) {
+        // return 0 if timestamp is lower than start time
+        if (block.timestamp < LOCK_START) {
+            return 0;
+        }
+
+        // how long it has been since the beginning of lockup period
+        uint256 timePassed = block.timestamp.sub(LOCK_START);
+
+        // 1st epoch is FIRST_EPOCH_DELAY longer; we check to prevent subtraction underflow
+        if (timePassed < FIRST_EPOCH_DELAY) {
+            return 0;
+        }
+
+        // subtract the FIRST_EPOCH_DELAY, so that we can count all epochs as lasting EPOCH_DURATION
+        uint256 totalEpochsPassed = timePassed.sub(FIRST_EPOCH_DELAY).div(EPOCH_DURATION);
+
+        // epochs don't count over TOTAL_EPOCHS
+        if (totalEpochsPassed > TOTAL_EPOCHS) {
+            return TOTAL_EPOCHS;
+        }
+
+        return totalEpochsPassed;
+    }
+
+    function epochsLeft() public view returns (uint256) {
+        return TOTAL_EPOCHS.sub(epochsPassed());
+    }
+
+    /**
+     * @dev Get timestamp of next epoch
+     * Will revert if all epochs have passed
+     * @return Timestamp of when the next epoch starts
+     */
+    function nextEpoch() public view returns (uint256) {
+        // get number of epochs passed
+        uint256 passed = epochsPassed();
+
+        // if all epochs passed, return
+        if (passed == TOTAL_EPOCHS) {
+            // return INT_MAX
+            return uint256(-1);
+        }
+
+        // if no epochs passed, return latest epoch + delay + standard duration
+        if (passed == 0) {
+            return latestEpoch().add(FIRST_EPOCH_DELAY).add(EPOCH_DURATION);
+        }
+
+        // otherwise return latest epoch + epoch duration
+        return latestEpoch().add(EPOCH_DURATION);
+    }
+
+    /**
+     * @dev Get timestamp of latest epoch
+     * @return Timestamp of when the current epoch has started
+     */
+    function latestEpoch() public view returns (uint256) {
+        // get number of epochs passed
+        uint256 passed = epochsPassed();
+
+        // if no epochs passed, return lock start time
+        if (passed == 0) {
+            return LOCK_START;
+        }
+
+        // accounts for first epoch being longer
+        // lockStart + firstEpochDelay + (epochsPassed * epochDuration)
+        return LOCK_START.add(FIRST_EPOCH_DELAY).add(passed.mul(EPOCH_DURATION));
+    }
+
+    /**
+     * @dev Get timestamp of final epoch
+     * @return Timestamp of when the last epoch ends and all funds are released
+     */
+    function finalEpoch() public pure returns (uint256) {
+        // lockStart + firstEpochDelay + (epochDuration * totalEpochs)
+        return LOCK_START.add(FIRST_EPOCH_DELAY).add(EPOCH_DURATION.mul(TOTAL_EPOCHS));
+    }
+
+    /**
+     * @dev Get timestamp of locking period start
+     * @return Timestamp of locking period start
+     */
+    function lockStart() public pure returns (uint256) {
+        return LOCK_START;
+    }
+}
+
+
+// Root file: contracts/trusttoken/TrustToken.sol
+
+pragma solidity 0.6.10;
+
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {TimeLockedToken} from "contracts/trusttoken/TimeLockedToken.sol";
+
+/**
+ * @title TrustToken
+ * @dev The TrustToken contract is a claimable contract where the
+ * owner can only mint or transfer ownership. TrustTokens use 8 decimals
+ * in order to prevent rewards from getting stuck in the remainder on division.
+ * Tolerates dilution to slash stake and accept rewards.
+ */
+contract TrustToken is TimeLockedToken {
+    using SafeMath for uint256;
+
+    uint256 constant MAX_SUPPLY = 145000000000000000;
+
+    /**
+     * @dev initialize trusttoken and give ownership to sender
+     * This is necessary to set ownership for proxy
+     */
+    function initialize() public {
+        require(!initalized, "already initialized");
+        owner_ = msg.sender;
+        initalized = true;
+    }
+
+    /**
+     * @dev mint TRU
+     * Can never mint more than MAX_SUPPLY = 1.45 billion
+     */
+    function mint(address _to, uint256 _amount) external onlyOwner {
+        if (totalSupply.add(_amount) <= MAX_SUPPLY) {
+            _mint(_to, _amount);
+        } else {
+            revert("Max supply exceeded");
+        }
+    }
+
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    function decimals() public override pure returns (uint8) {
+        return 8;
+    }
+
+    function rounding() public pure returns (uint8) {
+        return 8;
+    }
+
+    function name() public override pure returns (string memory) {
+        return "TrueFi";
+    }
+
+    function symbol() public override pure returns (string memory) {
+        return "TRU";
+    }
+}

--- a/flatten/UpgradeableERC20.sol
+++ b/flatten/UpgradeableERC20.sol
@@ -1,0 +1,837 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Root file: contracts/truefi/common/UpgradeableERC20.sol
+
+pragma solidity 0.6.10;
+
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20 is Initializable, Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    mapping(address => uint256) private _balances;
+
+    mapping(address => mapping(address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    function __ERC20_initialize(string memory name, string memory symbol) internal initializer {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public override view returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public override view returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public virtual override view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(
+            _msgSender(),
+            spender,
+            _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero")
+        );
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {}
+}

--- a/flatten/UpgradeableOwnable.sol
+++ b/flatten/UpgradeableOwnable.sol
@@ -1,0 +1,193 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: contracts/truefi/common/Initializable.sol
+
+// Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+
+// pragma solidity 0.6.10;
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
+}
+
+
+// Root file: contracts/truefi/common/UpgradeableOwnable.sol
+
+pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+
+// import {Initializable} from "contracts/truefi/common/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is Initializable, Context {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function initialize() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}

--- a/flatten/VoteToken.sol
+++ b/flatten/VoteToken.sol
@@ -1,0 +1,1212 @@
+/*
+    .'''''''''''..     ..''''''''''''''''..       ..'''''''''''''''..
+    .;;;;;;;;;;;'.   .';;;;;;;;;;;;;;;;;;,.     .,;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;,.    .,;;;;;;;;;;;;;;;;;;,.
+    .;;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.   .;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;;;;'.  .';;;;;;;;;;;;;;;;;;;;;;,. .';;;;;;;;;;;;;;;;;;;;;,.
+    ';;;;;,..   .';;;;;;;;;;;;;;;;;;;;;;;,..';;;;;;;;;;;;;;;;;;;;;;,.
+    ......     .';;;;;;;;;;;;;,'''''''''''.,;;;;;;;;;;;;;,'''''''''..
+              .,;;;;;;;;;;;;;.           .,;;;;;;;;;;;;;.
+             .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+            .,;;;;;;;;;;;;,.           .,;;;;;;;;;;;;,.
+           .,;;;;;;;;;;;;,.           .;;;;;;;;;;;;;,.     .....
+          .;;;;;;;;;;;;;'.         ..';;;;;;;;;;;;;'.    .',;;;;,'.
+        .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.   .';;;;;;;;;;.
+       .';;;;;;;;;;;;;'.         .';;;;;;;;;;;;;;'.    .;;;;;;;;;;;,.
+      .,;;;;;;;;;;;;;'...........,;;;;;;;;;;;;;;.      .;;;;;;;;;;;,.
+     .,;;;;;;;;;;;;,..,;;;;;;;;;;;;;;;;;;;;;;;,.       ..;;;;;;;;;,.
+    .,;;;;;;;;;;;;,. .,;;;;;;;;;;;;;;;;;;;;;;,.          .',;;;,,..
+   .,;;;;;;;;;;;;,.  .,;;;;;;;;;;;;;;;;;;;;;,.              ....
+    ..',;;;;;;;;,.   .,;;;;;;;;;;;;;;;;;;;;,.
+       ..',;;;;'.    .,;;;;;;;;;;;;;;;;;;;'.
+          ...'..     .';;;;;;;;;;;;;;,,,'.
+                       ...............
+*/
+
+// https://github.com/trusttoken/smart-contracts
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/registry/interface/IRegistryClone.sol
+
+// pragma solidity 0.6.10;
+
+interface IRegistryClone {
+    function syncAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) external;
+}
+
+
+// Dependency file: contracts/registry/Registry.sol
+
+// pragma solidity 0.6.10;
+
+// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import {IRegistryClone as RegistryClone} from "contracts/registry/interface/IRegistryClone.sol";
+
+contract Registry {
+    struct AttributeData {
+        uint256 value;
+        bytes32 notes;
+        address adminAddr;
+        uint256 timestamp;
+    }
+
+    // never remove any storage variables
+    address public owner;
+    address public pendingOwner;
+    bool initialized;
+
+    // Stores arbitrary attributes for users. An example use case is an IERC20
+    // token that requires its users to go through a KYC/AML check - in this case
+    // a validator can set an account's "hasPassedKYC/AML" attribute to 1 to indicate
+    // that account can use the token. This mapping stores that value (1, in the
+    // example) as well as which validator last set the value and at what time,
+    // so that e.g. the check can be renewed at appropriate intervals.
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
+    // The logic governing who is allowed to set what attributes is abstracted as
+    // this accessManager, so that it may be replaced by the owner as needed
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    mapping(bytes32 => RegistryClone[]) subscribers;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetManager(address indexed oldManager, address indexed newManager);
+    event StartSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+    event StopSubscription(bytes32 indexed attribute, RegistryClone indexed subscriber);
+
+    // Allows a write if either a) the writer is that Registry's owner, or
+    // b) the writer is writing to attribute foo and that writer already has
+    // the canWriteTo-foo attribute set (in that same Registry)
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
+        return (_admin == owner || hasAttribute(_admin, keccak256(abi.encodePacked(WRITE_PERMISSION ^ _attribute))));
+    }
+
+    // Writes are allowed only if the accessManager approves
+    function setAttribute(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value,
+        bytes32 _notes
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
+
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    function subscribe(bytes32 _attribute, RegistryClone _syncer) external onlyOwner {
+        subscribers[_attribute].push(_syncer);
+        emit StartSubscription(_attribute, _syncer);
+    }
+
+    function unsubscribe(bytes32 _attribute, uint256 _index) external onlyOwner {
+        uint256 length = subscribers[_attribute].length;
+        require(_index < length);
+        emit StopSubscription(_attribute, subscribers[_attribute][_index]);
+        subscribers[_attribute][_index] = subscribers[_attribute][length - 1];
+        subscribers[_attribute].pop();
+    }
+
+    function subscriberCount(bytes32 _attribute) public view returns (uint256) {
+        return subscribers[_attribute].length;
+    }
+
+    function setAttributeValue(
+        address _who,
+        bytes32 _attribute,
+        uint256 _value
+    ) public {
+        require(confirmWrite(_attribute, msg.sender));
+        attributes[_who][_attribute] = AttributeData(_value, "", msg.sender, block.timestamp);
+        emit SetAttribute(_who, _attribute, _value, "", msg.sender);
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > 0) {
+            targets[index].syncAttributeValue(_who, _attribute, _value);
+        }
+    }
+
+    // Returns true if the uint256 value stored for this attribute is non-zero
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
+        return attributes[_who][_attribute].value != 0;
+    }
+
+    // Returns the exact value of the attribute, as well as its metadata
+    function getAttribute(address _who, bytes32 _attribute)
+        public
+        view
+        returns (
+            uint256,
+            bytes32,
+            address,
+            uint256
+        )
+    {
+        AttributeData memory data = attributes[_who][_attribute];
+        return (data.value, data.notes, data.adminAddr, data.timestamp);
+    }
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].value;
+    }
+
+    function getAttributeAdminAddr(address _who, bytes32 _attribute) public view returns (address) {
+        return attributes[_who][_attribute].adminAddr;
+    }
+
+    function getAttributeTimestamp(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute].timestamp;
+    }
+
+    function syncAttribute(
+        bytes32 _attribute,
+        uint256 _startIndex,
+        address[] calldata _addresses
+    ) external {
+        RegistryClone[] storage targets = subscribers[_attribute];
+        uint256 index = targets.length;
+        while (index-- > _startIndex) {
+            RegistryClone target = targets[index];
+            for (uint256 i = _addresses.length; i-- > 0; ) {
+                address who = _addresses[i];
+                target.syncAttributeValue(who, _attribute, attributes[who][_attribute].value);
+            }
+        }
+    }
+
+    function reclaimEther(address payable _to) external onlyOwner {
+        _to.transfer(address(this).balance);
+    }
+
+    function reclaimToken(IERC20 token, address _to) external onlyOwner {
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(_to, balance);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only Owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        emit OwnershipTransferred(owner, pendingOwner);
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}
+
+
+// Dependency file: contracts/trusttoken/common/ProxyStorage.sol
+
+// pragma solidity 0.6.10;
+
+// import {Registry} from "contracts/registry/Registry.sol";
+
+/**
+ * All storage must be declared here
+ * New storage must be appended to the end
+ * Never remove items from this list
+ */
+contract ProxyStorage {
+    bool initalized;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    mapping(uint144 => uint256) attributes; // see RegistrySubscriber
+
+    address owner_;
+    address pendingOwner_;
+
+    mapping(address => address) public delegates; // A record of votes checkpoints for each account, by index
+    struct Checkpoint {
+        // A checkpoint for marking number of votes from a given block
+        uint32 fromBlock;
+        uint96 votes;
+    }
+    mapping(address => mapping(uint32 => Checkpoint)) public checkpoints; // A record of votes checkpoints for each account, by index
+    mapping(address => uint32) public numCheckpoints; // The number of checkpoints for each account
+    mapping(address => uint256) public nonces;
+
+    /* Additionally, we have several keccak-based storage locations.
+     * If you add more keccak-based storage mappings, such as mappings, you must document them here.
+     * If the length of the keccak input is the same as an existing mapping, it is possible there could be a preimage collision.
+     * A preimage collision can be used to attack the contract by treating one storage location as another,
+     * which would always be a critical issue.
+     * Carefully examine future keccak-based storage to ensure there can be no preimage collisions.
+     *******************************************************************************************************
+     ** length     input                                                         usage
+     *******************************************************************************************************
+     ** 19         "trueXXX.proxy.owner"                                         Proxy Owner
+     ** 27         "trueXXX.pending.proxy.owner"                                 Pending Proxy Owner
+     ** 28         "trueXXX.proxy.implementation"                                Proxy Implementation
+     ** 64         uint256(address),uint256(1)                                   balanceOf
+     ** 64         uint256(address),keccak256(uint256(address),uint256(2))       allowance
+     ** 64         uint256(address),keccak256(bytes32,uint256(3))                attributes
+     **/
+}
+
+
+// Dependency file: contracts/trusttoken/common/ClaimableContract.sol
+
+// pragma solidity 0.6.10;
+
+// import {ProxyStorage} from "contracts/trusttoken/common/ProxyStorage.sol";
+
+/**
+ * @title ClaimableContract
+ * @dev The ClaimableContract contract is a copy of Claimable Contract by Zeppelin.
+ and provides basic authorization control functions. Inherits storage layout of
+ ProxyStorage.
+ */
+contract ClaimableContract is ProxyStorage {
+    function owner() public view returns (address) {
+        return owner_;
+    }
+
+    function pendingOwner() public view returns (address) {
+        return pendingOwner_;
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev sets the original `owner` of the contract to the sender
+     * at construction. Must then be reinitialized
+     */
+    constructor() public {
+        owner_ = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner_, "only owner");
+        _;
+    }
+
+    /**
+     * @dev Modifier throws if called by any account other than the pendingOwner.
+     */
+    modifier onlyPendingOwner() {
+        require(msg.sender == pendingOwner_);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to set the pendingOwner address.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        pendingOwner_ = newOwner;
+    }
+
+    /**
+     * @dev Allows the pendingOwner address to finalize the transfer.
+     */
+    function claimOwnership() public onlyPendingOwner {
+        address _pendingOwner = pendingOwner_;
+        emit OwnershipTransferred(owner_, _pendingOwner);
+        owner_ = _pendingOwner;
+        pendingOwner_ = address(0);
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/GSN/Context.sol
+
+
+// pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/math/SafeMath.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: @openzeppelin/contracts/utils/Address.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: contracts/trusttoken/common/ERC20.sol
+
+/**
+ * @notice This is a copy of openzeppelin ERC20 contract with removed state variables.
+ * Removing state variables has been necessary due to proxy pattern usage.
+ * Changes to Openzeppelin ERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/de99bccbfd4ecd19d7369d01b070aa72c64423c9/contracts/token/ERC20/ERC20.sol:
+ * - Remove state variables _name, _symbol, _decimals
+ * - Use state variables balances, allowances, totalSupply from ProxyStorage
+ * - Remove constructor
+ * - Solidity version changed from ^0.6.0 to 0.6.10
+ * - Contract made abstract
+ * - Remove inheritance from IERC20 because of ProxyStorage name conflicts
+ *
+ * See also: ClaimableOwnable.sol and ProxyStorage.sol
+ */
+
+
+// pragma solidity 0.6.10;
+
+// import {Context} from "@openzeppelin/contracts/GSN/Context.sol";
+// import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// import {ProxyStorage} from "contracts/trusttoken/common/ProxyStorage.sol";
+
+// prettier-ignore
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+abstract contract ERC20 is ProxyStorage, Context {
+    using SafeMath for uint256;
+    using Address for address;
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public virtual pure returns (string memory);
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public virtual pure returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), allowance[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, allowance[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        balanceOf[sender] = balanceOf[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        balanceOf[recipient] = balanceOf[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        totalSupply = totalSupply.add(amount);
+        balanceOf[account] = balanceOf[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        balanceOf[account] = balanceOf[account].sub(amount, "ERC20: burn amount exceeds balance");
+        totalSupply = totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        allowance[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}
+
+
+// Dependency file: contracts/governance/interface/IVoteToken.sol
+
+
+// pragma solidity ^0.6.10;
+
+interface IVoteToken {
+    function delegate(address delegatee) external;
+    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s) external;
+    function getCurrentVotes(address account) external view returns (uint96);
+    function getPriorVotes(address account, uint blockNumber) external view returns (uint96);
+}
+
+// Root file: contracts/governance/VoteToken.sol
+
+// AND COPIED FROM https://github.com/compound-finance/compound-protocol/blob/master/contracts/Governance/GovernorAlpha.sol
+// Copyright 2020 Compound Labs, Inc.
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Ctrl+f for OLD to see all the modifications.
+
+// OLD: pragma solidity ^0.5.16;
+pragma solidity 0.6.10;
+
+// import {ClaimableContract} from "contracts/trusttoken/common/ClaimableContract.sol";
+// import {ERC20} from "contracts/trusttoken/common/ERC20.sol";
+// import {IVoteToken} from "contracts/governance/interface/IVoteToken.sol";
+
+abstract contract VoteToken is ERC20, IVoteToken {
+    bytes32 public constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+    bytes32 public constant DELEGATION_TYPEHASH = keccak256("Delegation(address delegatee,uint256 nonce,uint256 expiry)");
+    
+    event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
+    event DelegateVotesChanged(address indexed delegate, uint previousBalance, uint newBalance);
+
+    function delegate(address delegatee) public override {
+        return _delegate(msg.sender, delegatee);
+    }
+
+    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s) public override {
+        //OLD: bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name)), getChainId(), address(this)));
+        bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH,keccak256(bytes(name())),getChainId(),address(this)));
+        bytes32 structHash = keccak256(abi.encode(DELEGATION_TYPEHASH, delegatee, nonce, expiry));
+        bytes32 digest = keccak256(abi.encodePacked("", domainSeparator, structHash));
+        address signatory = ecrecover(digest, v, r, s);
+        require(signatory != address(0), "TrustToken::delegateBySig: invalid signature");
+        require(nonce == nonces[signatory]++, "TrustToken::delegateBySig: invalid nonce");
+        require(now <= expiry, "TrustToken::delegateBySig: signature expired");
+        return _delegate(signatory, delegatee);
+    }
+
+    function getCurrentVotes(address account) external view override returns (uint96) {
+        uint32 nCheckpoints = numCheckpoints[account];
+        return nCheckpoints > 0 ? checkpoints[account][nCheckpoints - 1].votes : 0;
+    }
+
+    function getPriorVotes(address account, uint blockNumber) public view override returns (uint96) {
+        require(blockNumber < block.number, "TrustToken::getPriorVotes: not yet determined");
+
+        uint32 nCheckpoints = numCheckpoints[account];
+        if (nCheckpoints == 0) {
+            return 0;
+        }
+
+        // First check most recent balance
+        if (checkpoints[account][nCheckpoints - 1].fromBlock <= blockNumber) {
+            return checkpoints[account][nCheckpoints - 1].votes;
+        }
+
+        // Next check implicit zero balance
+        if (checkpoints[account][0].fromBlock > blockNumber) {
+            return 0;
+        }
+
+        uint32 lower = 0;
+        uint32 upper = nCheckpoints - 1;
+        while (upper > lower) {
+            uint32 center = upper - (upper - lower) / 2; // ceil, avoiding overflow
+            Checkpoint memory cp = checkpoints[account][center];
+            if (cp.fromBlock == blockNumber) {
+                return cp.votes;
+            } else if (cp.fromBlock < blockNumber) {
+                lower = center;
+            } else {
+                upper = center - 1;
+            }
+        }
+        return checkpoints[account][lower].votes;
+    }
+
+    function _delegate(address delegator, address delegatee) internal {
+        address currentDelegate = delegates[delegator];
+        // OLD: uint96 delegatorBalance = balanceOf(delegator);
+        uint96 delegatorBalance = uint96(_balanceOf(delegator));
+        delegates[delegator] = delegatee;
+
+        emit DelegateChanged(delegator, currentDelegate, delegatee);
+
+        _moveDelegates(currentDelegate, delegatee, delegatorBalance);
+    }
+
+    function _balanceOf(address account) internal virtual returns(uint256) {
+        return balanceOf[account];
+    }
+
+    function _transfer( address _from, address _to, uint256 _value) internal override virtual {
+        super._transfer(_from, _to, _value);
+        _moveDelegates(delegates[_from], delegates[_to], uint96(_value));
+    }
+
+    function _moveDelegates(address srcRep, address dstRep, uint96 amount) internal {
+        if (srcRep != dstRep && amount > 0) {
+            if (srcRep != address(0)) {
+                uint32 srcRepNum = numCheckpoints[srcRep];
+                uint96 srcRepOld = srcRepNum > 0 ? checkpoints[srcRep][srcRepNum - 1].votes : 0;
+                uint96 srcRepNew = sub96(srcRepOld, amount, "TrustToken::_moveVotes: vote amount underflows");
+                _writeCheckpoint(srcRep, srcRepNum, srcRepOld, srcRepNew);
+            }
+
+            if (dstRep != address(0)) {
+                uint32 dstRepNum = numCheckpoints[dstRep];
+                uint96 dstRepOld = dstRepNum > 0 ? checkpoints[dstRep][dstRepNum - 1].votes : 0;
+                uint96 dstRepNew = add96(dstRepOld, amount, "TrustToken::_moveVotes: vote amount overflows");
+                _writeCheckpoint(dstRep, dstRepNum, dstRepOld, dstRepNew);
+            }
+        }
+    }
+
+    function _writeCheckpoint(address delegatee, uint32 nCheckpoints, uint96 oldVotes, uint96 newVotes) internal {
+        uint32 blockNumber = safe32(block.number, "TrustToken::_writeCheckpoint: block number exceeds 32 bits");
+
+        if (nCheckpoints > 0 && checkpoints[delegatee][nCheckpoints - 1].fromBlock == blockNumber) {
+            checkpoints[delegatee][nCheckpoints - 1].votes = newVotes;
+        } else {
+            checkpoints[delegatee][nCheckpoints] = Checkpoint(blockNumber, newVotes);
+            numCheckpoints[delegatee] = nCheckpoints + 1;
+        }
+
+        emit DelegateVotesChanged(delegatee, oldVotes, newVotes);
+    }
+
+    function safe32(uint n, string memory errorMessage) internal pure returns (uint32) {
+        require(n < 2**32, errorMessage);
+        return uint32(n);
+    }
+
+    function safe96(uint n, string memory errorMessage) internal pure returns (uint96) {
+        require(n < 2**96, errorMessage);
+        return uint96(n);
+    }
+
+    function add96(uint96 a, uint96 b, string memory errorMessage) internal pure returns (uint96) {
+        uint96 c = a + b;
+        require(c >= a, errorMessage);
+        return c;
+    }
+
+    function sub96(uint96 a, uint96 b, string memory errorMessage) internal pure returns (uint96) {
+        require(b <= a, errorMessage);
+        return a - b;
+    }
+
+    function getChainId() internal pure returns (uint) {
+        uint256 chainId;
+        assembly { chainId := chainid() }
+        return chainId;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "postinstall": "patch-package",
-    "flatten": "./flatten-all",
+    "flatten": "./flatten.sh",
     "clean": "rm -rf ./build",
     "typecheck": "tsc --noEmit",
     "lint:sol": "solhint 'contracts/**/*.sol' && prettylint 'contracts/**/*.sol'",

--- a/test/truefi/TrueFarm.test.ts
+++ b/test/truefi/TrueFarm.test.ts
@@ -193,6 +193,17 @@ describe('TrueFarm', () => {
       expect(await farm.claimable(staker1.address)).to.equal(0)
     })
 
+    it('claimable is zero from the start', async () => {
+      expect(await farm.claimable(staker1.address)).to.equal(0)
+    })
+
+    it('claimable is callable after unstake', async () => {
+      await farm.connect(staker1).stake(parseEth(500), txArgs)
+      await timeTravel(provider, DAY)
+      await farm.connect(staker1).unstake(parseEth(500), txArgs)
+      expect(await farm.claimable(staker1.address)).to.be.gt(0)
+    })
+
     it('calling distribute does not break reward calculations', async () => {
       await farm.connect(staker1).stake(parseEth(500), txArgs)
       await timeTravel(provider, DAY)


### PR DESCRIPTION
Currently if totalStaked is 0 (which will likely never happen in ordinary operation, but is possible), claimable reverts with a division by zero error. This PR fixes that issue, and should have almost no effect on anything else (gas difference should be tiny, and is zero when called from e.g. Etherscan since it's a view-only function).