### PR TITLE
Shortcircuit claimable() calculation when nothing is staked

### DIFF
--- a/contracts/truefi/TrueFarm.sol
+++ b/contracts/truefi/TrueFarm.sol
@@ -150,6 +150,9 @@ contract TrueFarm is ITrueFarm, Initializable {
      * @return claimable rewards for account
      */
     function claimable(address account) external view returns (uint256) {
+        if (staked[account] == 0) {
+            return claimableReward[account];
+        }
         // estimate pending reward from distributor
         uint256 pending = trueDistributor.nextDistribution();
         // calculate total rewards (including pending)

--- a/flatten/TrueFarm.sol
+++ b/flatten/TrueFarm.sol
@@ -536,6 +536,9 @@ contract TrueFarm is ITrueFarm, Initializable {
      * @return claimable rewards for account
      */
     function claimable(address account) external view returns (uint256) {
+        if (staked[account] == 0) {
+            return claimableReward[account];
+        }
         // estimate pending reward from distributor
         uint256 pending = trueDistributor.nextDistribution();
         // calculate total rewards (including pending)

--- a/test/truefi/TrueFarm.test.ts
+++ b/test/truefi/TrueFarm.test.ts
@@ -193,6 +193,17 @@ describe('TrueFarm', () => {
       expect(await farm.claimable(staker1.address)).to.equal(0)
     })
 
+    it('claimable is zero from the start', async () => {
+      expect(await farm.claimable(staker1.address)).to.equal(0)
+    })
+
+    it('claimable is callable after unstake', async () => {
+      await farm.connect(staker1).stake(parseEth(500), txArgs)
+      await timeTravel(provider, DAY)
+      await farm.connect(staker1).unstake(parseEth(500), txArgs)
+      expect(await farm.claimable(staker1.address)).to.be.gt(0)
+    })
+
     it('calling distribute does not break reward calculations', async () => {
       await farm.connect(staker1).stake(parseEth(500), txArgs)
       await timeTravel(provider, DAY)


### PR DESCRIPTION
Replacing #457 because I'm switching branches; see that PR for previous discussion.