### PR TITLE
Check downcast

### DIFF
--- a/contracts/governance/VoteToken.sol
+++ b/contracts/governance/VoteToken.sol
@@ -104,7 +104,7 @@ abstract contract VoteToken is ERC20, IVoteToken {
         uint256 _value
     ) internal virtual override {
         super._transfer(_from, _to, _value);
-        _moveDelegates(delegates[_from], delegates[_to], uint96(_value));
+        _moveDelegates(delegates[_from], delegates[_to], safe96(_value, "StkTruToken: uint96 overflow"));
     }
 
     function _mint(address account, uint256 amount) internal virtual override {


### PR DESCRIPTION
...or if it was purposefully unchecked to save on gas, then instead you should add a comment (e.g. "This cast is unchecked to save on gas; it is safe because the total supply of each of our tokens can fit in a uint96. If future governance ever greatly increases the total supply, it should make sure to also change this cast to safe96.")