### PR TITLE
Add TrueFarm.claimRestake() to skip transfers

### DIFF
--- a/contracts/truefi/TrueFarm.sol
+++ b/contracts/truefi/TrueFarm.sol
@@ -141,6 +141,22 @@ contract TrueFarm is ITrueFarm, Initializable {
     }
 
     /**
+     * @dev Claim TRU rewards and immediately restake them without transferring in/out
+     */
+    function claimRestake() external override update {
+        uint256 rewardToClaim = claimableReward[msg.sender];
+
+        claimableReward[msg.sender] = 0;
+        totalClaimedRewards = totalClaimedRewards.add(rewardToClaim);
+
+        staked[msg.sender] = staked[msg.sender].add(rewardToClaim);
+        totalStaked = totalStaked.add(rewardToClaim);
+
+        emit Claim(msg.sender, rewardToClaim);
+        emit Stake(msg.sender, rewardToClaim);
+    }
+
+    /**
      * @dev Unstake amount and claim rewards
      * @param amount Amount of tokens to unstake
      */

--- a/contracts/truefi/interface/ITrueFarm.sol
+++ b/contracts/truefi/interface/ITrueFarm.sol
@@ -22,5 +22,7 @@ interface ITrueFarm {
 
     function claim() external;
 
+    function claimRestake() external;
+
     function exit(uint256 amount) external;
 }

--- a/test/truefi/TrueFarm.test.ts
+++ b/test/truefi/TrueFarm.test.ts
@@ -202,6 +202,28 @@ describe('TrueFarm', () => {
       expect(await farm.claimable(staker1.address)).to.equal(0)
     })
 
+    it('claimRestake clears claimableRewards', async () => {
+      await farm.connect(staker1).stake(parseEth(500), txArgs)
+      await timeTravel(provider, DAY)
+      // force an update to claimableReward:
+      await farm.connect(staker1).unstake(parseEth(1), txArgs)
+      expect(await farm.claimableReward(staker1.address)).to.be.gt(0)
+
+      await farm.connect(staker1).claimRestake(txArgs)
+      expect(await farm.claimableReward(staker1.address)).to.equal(0)
+    })
+
+    it('claimRestake stakes claimableReward', async () => {
+      await farm.connect(staker1).stake(parseEth(500), txArgs)
+      await timeTravel(provider, DAY)
+      // force an update to claimableReward:
+      await farm.connect(staker1).unstake(parseEth(1), txArgs)
+      expect(await farm.staked(staker1.address)).to.equal(parseEth(500 - 1))
+
+      await farm.connect(staker1).claimRestake(txArgs)
+      expect(await farm.staked(staker1.address)).to.be.gt(parseEth(500 - 1))
+    })
+
     it('claimable is zero from the start', async () => {
       expect(await farm.claimable(staker1.address)).to.equal(0)
     })


### PR DESCRIPTION
Avoid wasting gas + user effort on transferring to/from msg.sender when a user wants to claim and immediately restake all claimable reward.

I should add some tests, though I haven't looked into the testing framework yet. Just want to make sure this is on the right track.