### PR TITLE
Add a repayInFull function to LoanToken

### DIFF
--- a/contracts/truefi/LoanToken.sol
+++ b/contracts/truefi/LoanToken.sol
@@ -347,10 +347,28 @@ contract LoanToken is ILoanToken, ERC20 {
      * @param _sender account sending currencyToken to repay
      * @param _amount amount of currencyToken to repay
      */
-    function repay(address _sender, uint256 _amount) external override onlyAfterWithdraw {
+    function repay(address _sender, uint256 _amount) external override {
+        _repay(_sender, _amount);
+    }
+
+    /**
+     * @dev Function for borrower to repay all of the remaining loan balance
+     * Borrower should use this to ensure full repayment
+     * @param _sender account sending currencyToken to repay
+     */
+    function repayInFull(address _sender) external override {
+        _repay(_sender, debt.sub(_balance()));
+    }
+
+    /**
+     * @dev Internal function for loan repayment
+     * @param _sender account sending currencyToken to repay
+     * @param _amount amount of currencyToken to repay
+     */
+    function _repay(address _sender, uint256 _amount) internal onlyAfterWithdraw {
         require(_amount <= debt.sub(_balance()), "LoanToken: Cannot repay over the debt");
-        require(currencyToken.transferFrom(_sender, address(this), _amount));
         emit Repaid(_sender, _amount);
+        require(currencyToken.transferFrom(_sender, address(this), _amount));
     }
 
     /**

--- a/contracts/truefi/interface/ILoanToken.sol
+++ b/contracts/truefi/interface/ILoanToken.sol
@@ -51,6 +51,8 @@ interface ILoanToken is IERC20 {
 
     function repay(address _sender, uint256 _amount) external;
 
+    function repayInFull(address _sender) external;
+
     function reclaim() external;
 
     function allowTransfer(address account, bool _status) external;


### PR DESCRIPTION
We called this 'repayAll' in Asana, but I think 'repayInFull' would be a better name. 'All' might cause users to misinterpret this as repaying multiple loans instead of repaying the full balance of a single loan. 'Paying a loan in full' also sounds more to me like established banking nomenclature, though I'm certainly no expert.

I moved duplicate code (including the onlyAfterWithdraw modifier) to an internal function and reordered the emit line to be above the transferFrom() call, per the checks-effects-interactions pattern.

Thanks in advance for reviewing!