### PR TITLE
Add an isRepaidInFull() view to LoanToken

### DIFF
--- a/contracts/truefi/LoanToken.sol
+++ b/contracts/truefi/LoanToken.sol
@@ -308,7 +308,7 @@ contract LoanToken is ILoanToken, ERC20 {
      * @dev Close the loan and check if it has been repaid
      */
     function close() external override onlyOngoing {
-        if (_balance() >= debt) {
+        if (_isRepaidInFull()) {
             status = Status.Settled;
         } else {
             require(start.add(term).add(lastMinutePaybackDuration) <= block.timestamp, "LoanToken: Loan cannot be closed yet");
@@ -374,6 +374,14 @@ contract LoanToken is ILoanToken, ERC20 {
      */
     function repaid() external override view onlyAfterWithdraw returns (uint256) {
         return _balance().add(redeemed);
+    }
+
+    function isRepaidInFull() external override view returns (bool) {
+        return _isRepaidInFull();
+    }
+
+    function _isRepaidInFull() internal view onlyOngoing returns (bool) {
+        return _balance() >= debt;
     }
 
     /**

--- a/contracts/truefi/interface/ILoanToken.sol
+++ b/contracts/truefi/interface/ILoanToken.sol
@@ -57,6 +57,8 @@ interface ILoanToken is IERC20 {
 
     function repaid() external view returns (uint256);
 
+    function isRepaidInFull() external view returns (bool);
+
     function balance() external view returns (uint256);
 
     function value(uint256 _balance) external view returns (uint256);


### PR DESCRIPTION
We can deduplicate some logic in close(), so I've split this into external and internal versions.

I'm wondering whether it makes more sense to create an outstandingDebt() view that just returns debt.sub(_balance()), instead of taking this boolean approach. An outstandingDebt() view would also be useful in repay()'s overpayment check and #546's repayInFull()'s amount calculation. Is the concern that a UI might round an outstandingDebt() of 0.00000001 TUSD to 0.00 TUSD?