### PR TITLE
Split LoanToken.close() into settle() and enterDefault()

### DIFF
--- a/contracts/truefi/LoanToken.sol
+++ b/contracts/truefi/LoanToken.sol
@@ -163,7 +163,7 @@ contract LoanToken is ILoanToken, ERC20 {
     /**
      * @dev Only when loan is Settled
      */
-    modifier onlyClosed() {
+    modifier onlySettled() {
         require(status >= Status.Settled, "LoanToken: Current status should be Settled or Defaulted");
         _;
     }
@@ -339,10 +339,10 @@ contract LoanToken is ILoanToken, ERC20 {
 
     /**
      * @dev Redeem LoanToken balances for underlying currencyToken
-     * Can only call this function after the loan is Closed
+     * Can only call this function after the loan is Settled
      * @param _amount amount to redeem
      */
-    function redeem(uint256 _amount) external override onlyClosed {
+    function redeem(uint256 _amount) external override onlySettled {
         uint256 amountToReturn = _amount.mul(_balance()).div(totalSupply());
         redeemed = redeemed.add(amountToReturn);
         _burn(msg.sender, _amount);
@@ -383,10 +383,10 @@ contract LoanToken is ILoanToken, ERC20 {
 
     /**
      * @dev Function for borrower to reclaim stuck currencyToken
-     * Can only call this function after the loan is Closed
+     * Can only call this function after the loan is Settled
      * and all of LoanToken holders have been burnt
      */
-    function reclaim() external override onlyClosed onlyBorrower {
+    function reclaim() external override onlySettled onlyBorrower {
         require(totalSupply() == 0, "LoanToken: Cannot reclaim when LoanTokens are in circulation");
         uint256 balanceRemaining = _balance();
         require(balanceRemaining > 0, "LoanToken: Cannot reclaim when balance 0");

--- a/contracts/truefi/LoanToken.sol
+++ b/contracts/truefi/LoanToken.sol
@@ -161,7 +161,7 @@ contract LoanToken is ILoanToken, ERC20 {
     }
 
     /**
-     * @dev Only when loan is Settled
+     * @dev Only when loan is Settled, Defaulted, or Liquidated
      */
     modifier onlyClosed() {
         require(status >= Status.Settled, "LoanToken: Current status should be Settled or Defaulted");

--- a/contracts/truefi/LoanToken.sol
+++ b/contracts/truefi/LoanToken.sol
@@ -163,10 +163,10 @@ contract LoanToken is ILoanToken, ERC20 {
     }
 
     /**
-     * @dev Only when loan is Settled, Defaulted, or Liquidated
+     * @dev Only after loan has been closed: Settled, Defaulted, or Liquidated
      */
-    modifier onlyClosed() {
-        require(status >= Status.Settled, "LoanToken: Current status should be Settled or Defaulted");
+    modifier onlyAfterClose() {
+        require(status >= Status.Settled, "LoanToken: Only after loan has been closed");
         _;
     }
 
@@ -344,7 +344,7 @@ contract LoanToken is ILoanToken, ERC20 {
      * Can only call this function after the loan is Closed
      * @param _amount amount to redeem
      */
-    function redeem(uint256 _amount) external override onlyClosed {
+    function redeem(uint256 _amount) external override onlyAfterClose {
         uint256 amountToReturn = _amount.mul(_balance()).div(totalSupply());
         redeemed = redeemed.add(amountToReturn);
         _burn(msg.sender, _amount);
@@ -388,7 +388,7 @@ contract LoanToken is ILoanToken, ERC20 {
      * Can only call this function after the loan is Closed
      * and all of LoanToken holders have been burnt
      */
-    function reclaim() external override onlyClosed onlyBorrower {
+    function reclaim() external override onlyAfterClose onlyBorrower {
         require(totalSupply() == 0, "LoanToken: Cannot reclaim when LoanTokens are in circulation");
         uint256 balanceRemaining = _balance();
         require(balanceRemaining > 0, "LoanToken: Cannot reclaim when balance 0");

--- a/contracts/truefi/LoanToken.sol
+++ b/contracts/truefi/LoanToken.sol
@@ -163,7 +163,7 @@ contract LoanToken is ILoanToken, ERC20 {
     /**
      * @dev Only when loan is Settled
      */
-    modifier onlySettled() {
+    modifier onlyClosed() {
         require(status >= Status.Settled, "LoanToken: Current status should be Settled or Defaulted");
         _;
     }
@@ -339,10 +339,10 @@ contract LoanToken is ILoanToken, ERC20 {
 
     /**
      * @dev Redeem LoanToken balances for underlying currencyToken
-     * Can only call this function after the loan is Settled
+     * Can only call this function after the loan is Closed
      * @param _amount amount to redeem
      */
-    function redeem(uint256 _amount) external override onlySettled {
+    function redeem(uint256 _amount) external override onlyClosed {
         uint256 amountToReturn = _amount.mul(_balance()).div(totalSupply());
         redeemed = redeemed.add(amountToReturn);
         _burn(msg.sender, _amount);
@@ -383,10 +383,10 @@ contract LoanToken is ILoanToken, ERC20 {
 
     /**
      * @dev Function for borrower to reclaim stuck currencyToken
-     * Can only call this function after the loan is Settled
+     * Can only call this function after the loan is Closed
      * and all of LoanToken holders have been burnt
      */
-    function reclaim() external override onlySettled onlyBorrower {
+    function reclaim() external override onlyClosed onlyBorrower {
         require(totalSupply() == 0, "LoanToken: Cannot reclaim when LoanTokens are in circulation");
         uint256 balanceRemaining = _balance();
         require(balanceRemaining > 0, "LoanToken: Cannot reclaim when balance 0");

--- a/contracts/truefi/LoanToken.sol
+++ b/contracts/truefi/LoanToken.sol
@@ -76,11 +76,16 @@ contract LoanToken is ILoanToken, ERC20 {
     event Withdrawn(address beneficiary);
 
     /**
-     * @dev Emitted when term is over
-     * @param status Final loan status
+     * @dev Emitted when loan has been fully repaid
+     * @param returnedAmount Amount that was returned
+     */
+    event Settled(uint256 returnedAmount);
+
+    /**
+     * @dev Emitted when term is over without full repayment
      * @param returnedAmount Amount that was returned before expiry
      */
-    event Closed(Status status, uint256 returnedAmount);
+    event Defaulted(uint256 returnedAmount);
 
     /**
      * @dev Emitted when a LoanToken is redeemed for underlying currencyTokens
@@ -310,7 +315,7 @@ contract LoanToken is ILoanToken, ERC20 {
     function settle() external override onlyOngoing {
         require(_balance() >= debt, "LoanToken: loan must be repaid to settle");
         status = Status.Settled;
-        emit Closed(status, _balance());
+        emit Settled(_balance());
     }
 
     /**
@@ -318,9 +323,9 @@ contract LoanToken is ILoanToken, ERC20 {
      */
     function enterDefault() external override onlyOngoing {
         require(_balance() < debt, "LoanToken: cannot default a repaid loan");
-        require(start.add(term).add(lastMinutePaybackDuration) <= block.timestamp, "LoanToken: Loan cannot be closed yet");
+        require(start.add(term).add(lastMinutePaybackDuration) <= block.timestamp, "LoanToken: Loan cannot be defaulted yet");
         status = Status.Defaulted;
-        emit Closed(status, _balance());
+        emit Defaulted(_balance());
     }
 
     /**

--- a/contracts/truefi/interface/ILoanToken.sol
+++ b/contracts/truefi/interface/ILoanToken.sol
@@ -43,7 +43,9 @@ interface ILoanToken is IERC20 {
 
     function withdraw(address _beneficiary) external;
 
-    function close() external;
+    function settle() external;
+
+    function enterDefault() external;
 
     function liquidate() external;
 

--- a/test/truefi/Liquidator.test.ts
+++ b/test/truefi/Liquidator.test.ts
@@ -147,7 +147,7 @@ describe('Liquidator', () => {
 
     it('anyone can call it', async () => {
       await timeTravel(provider, defaultedLoanCloseTime)
-      await loanToken.close()
+      await loanToken.enterDefault()
 
       await expect(liquidator.connect(otherWallet).liquidate(loanToken.address))
         .to.not.be.reverted
@@ -165,7 +165,7 @@ describe('Liquidator', () => {
     it('reverts if loan was not created via factory', async () => {
       await factory.mock.isLoanToken.returns(false)
       await timeTravel(provider, defaultedLoanCloseTime)
-      await loanToken.close()
+      await loanToken.enterDefault()
 
       await expect(liquidator.liquidate(loanToken.address))
         .to.be.revertedWith('Liquidator: Unknown loan')
@@ -173,7 +173,7 @@ describe('Liquidator', () => {
 
     it('changes loanToken status', async () => {
       await timeTravel(provider, defaultedLoanCloseTime)
-      await loanToken.close()
+      await loanToken.enterDefault()
 
       await liquidator.connect(otherWallet).liquidate(loanToken.address)
       expect(await loanToken.status()).to.equal(LoanTokenStatus.Liquidated)
@@ -182,7 +182,7 @@ describe('Liquidator', () => {
     describe('transfers correct amount of tru to trueFiPool', () => {
       beforeEach(async () => {
         await timeTravel(provider, defaultedLoanCloseTime)
-        await loanToken.close()
+        await loanToken.enterDefault()
       })
 
       it('0 tru in staking pool balance', async () => {
@@ -255,7 +255,7 @@ describe('Liquidator', () => {
 
     it('emits event', async () => {
       await timeTravel(provider, defaultedLoanCloseTime)
-      await loanToken.close()
+      await loanToken.enterDefault()
 
       await expect(liquidator.liquidate(loanToken.address))
         .to.emit(liquidator, 'Liquidated')

--- a/test/truefi/LoanToken.test.ts
+++ b/test/truefi/LoanToken.test.ts
@@ -206,7 +206,7 @@ describe('LoanToken', () => {
       await loanToken.fund()
       await withdraw(borrower)
       await timeTravel(provider, yearInSeconds + dayInSeconds / 2)
-      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
+      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be defaulted yet')
       await tusd.mint(loanToken.address, parseEth(1100))
       await loanToken.settle()
       expect(await loanToken.status()).to.equal(LoanTokenStatus.Settled)
@@ -237,14 +237,14 @@ describe('LoanToken', () => {
 
     it('reverts when closing right after funding', async () => {
       await loanToken.fund()
-      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
+      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be defaulted yet')
     })
 
     it('reverts when closing ongoing loan', async () => {
       await loanToken.fund()
-      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
+      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be defaulted yet')
       await timeTravel(provider, yearInSeconds - 10)
-      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
+      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be defaulted yet')
     })
 
     it('reverts when trying to close already closed loan', async () => {
@@ -259,7 +259,7 @@ describe('LoanToken', () => {
       await withdraw(borrower)
       await tusd.mint(loanToken.address, parseEth(1099))
       await timeTravel(provider, defaultedLoanCloseTime)
-      await expect(loanToken.enterDefault()).to.emit(loanToken, 'Closed').withArgs(LoanTokenStatus.Defaulted, parseEth(1099))
+      await expect(loanToken.enterDefault()).to.emit(loanToken, 'Defaulted').withArgs(parseEth(1099))
     })
   })
 

--- a/test/truefi/LoanToken.test.ts
+++ b/test/truefi/LoanToken.test.ts
@@ -646,7 +646,7 @@ describe('LoanToken', () => {
       await tusd.connect(borrower).approve(loanToken.address, debt)
       await tusd.mint(borrower.address, parseEth(300))
       await loanToken.repayInFull(borrower.address)
-      await loanToken.close()
+      await loanToken.settle()
       await expect(loanToken.isRepaid()).to.be.revertedWith('LoanToken: Current status should be Funded or Withdrawn')
     })
 

--- a/test/truefi/LoanToken.test.ts
+++ b/test/truefi/LoanToken.test.ts
@@ -381,18 +381,18 @@ describe('LoanToken', () => {
     })
 
     it('reverts if called before loan is closed', async () => {
-      await expect(loanToken.redeem(1)).to.be.revertedWith('LoanToken: Current status should be Settled or Defaulted')
+      await expect(loanToken.redeem(1)).to.be.revertedWith('LoanToken: Only after loan has been closed')
       await loanToken.fund()
-      await expect(loanToken.redeem(1)).to.be.revertedWith('LoanToken: Current status should be Settled or Defaulted')
+      await expect(loanToken.redeem(1)).to.be.revertedWith('LoanToken: Only after loan has been closed')
       await withdraw(borrower)
-      await expect(loanToken.redeem(1)).to.be.revertedWith('LoanToken: Current status should be Settled or Defaulted')
+      await expect(loanToken.redeem(1)).to.be.revertedWith('LoanToken: Only after loan has been closed')
     })
 
     it('reverts if redeeming more than own balance', async () => {
       await loanToken.fund()
       await timeTravel(provider, yearInSeconds)
       await payback(borrower, parseEth(100))
-      await expect(loanToken.redeem(parseEth(1100))).to.be.revertedWith('LoanToken: Current status should be Settled or Defaulted')
+      await expect(loanToken.redeem(parseEth(1100))).to.be.revertedWith('LoanToken: Only after loan has been closed')
     })
 
     it('emits event', async () => {
@@ -525,7 +525,7 @@ describe('LoanToken', () => {
 
     it('reverts when loan not closed', async () => {
       await expect(loanToken.connect(borrower).reclaim())
-        .to.be.revertedWith('LoanToken: Current status should be Settled or Defaulted')
+        .to.be.revertedWith('LoanToken: Only after loan has been closed')
     })
 
     it('reverts when not borrower tries access', async () => {

--- a/test/truefi/LoanToken.test.ts
+++ b/test/truefi/LoanToken.test.ts
@@ -169,7 +169,7 @@ describe('LoanToken', () => {
     it('reverts when withdrawing from closed loan', async () => {
       await loanToken.fund()
       await timeTravel(provider, defaultedLoanCloseTime)
-      await loanToken.close()
+      await loanToken.enterDefault()
       await expect(withdraw(borrower)).to.be.revertedWith('LoanToken: Current status should be Funded')
     })
 
@@ -184,12 +184,45 @@ describe('LoanToken', () => {
     })
   })
 
-  describe('Close', () => {
+  describe('Settle', () => {
+    it('sets status to Settled if whole debt has been returned after term has passed', async () => {
+      await loanToken.fund()
+      await withdraw(borrower)
+      await timeTravel(provider, yearInSeconds)
+      await tusd.mint(loanToken.address, parseEth(1100))
+      await loanToken.settle()
+      expect(await loanToken.status()).to.equal(LoanTokenStatus.Settled)
+    })
+
+    it('sets status to Settled if whole debt has been returned before term has passed', async () => {
+      await loanToken.fund()
+      await withdraw(borrower)
+      await tusd.mint(loanToken.address, parseEth(1100))
+      await loanToken.settle()
+      expect(await loanToken.status()).to.equal(LoanTokenStatus.Settled)
+    })
+
+    it('loan can be payed back 1 day after term has ended', async () => {
+      await loanToken.fund()
+      await withdraw(borrower)
+      await timeTravel(provider, yearInSeconds + dayInSeconds / 2)
+      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
+      await tusd.mint(loanToken.address, parseEth(1100))
+      await loanToken.settle()
+      expect(await loanToken.status()).to.equal(LoanTokenStatus.Settled)
+    })
+
+    it('reverts when closing not funded loan', async () => {
+      await expect(loanToken.settle()).to.be.revertedWith('LoanToken: Current status should be Funded or Withdrawn')
+    })
+  })
+
+  describe('Enter Default', () => {
     it('sets status to Defaulted if no debt has been returned', async () => {
       await loanToken.fund()
       await withdraw(borrower)
       await timeTravel(provider, defaultedLoanCloseTime)
-      await loanToken.close()
+      await loanToken.enterDefault()
       expect(await loanToken.status()).to.equal(LoanTokenStatus.Defaulted)
     })
 
@@ -198,58 +231,27 @@ describe('LoanToken', () => {
       await withdraw(borrower)
       await timeTravel(provider, defaultedLoanCloseTime)
       await tusd.mint(loanToken.address, parseEth(1099))
-      await loanToken.close()
+      await loanToken.enterDefault()
       expect(await loanToken.status()).to.equal(LoanTokenStatus.Defaulted)
-    })
-
-    it('sets status to Settled if whole debt has been returned after term has passed', async () => {
-      await loanToken.fund()
-      await withdraw(borrower)
-      await timeTravel(provider, yearInSeconds)
-      await tusd.mint(loanToken.address, parseEth(1100))
-      await loanToken.close()
-      expect(await loanToken.status()).to.equal(LoanTokenStatus.Settled)
-    })
-
-    it('sets status to Settled if whole debt has been returned before term has passed', async () => {
-      await loanToken.fund()
-      await withdraw(borrower)
-      await tusd.mint(loanToken.address, parseEth(1100))
-      await loanToken.close()
-      expect(await loanToken.status()).to.equal(LoanTokenStatus.Settled)
-    })
-
-    it('loan can be payed back 1 day after term has ended', async () => {
-      await loanToken.fund()
-      await withdraw(borrower)
-      await timeTravel(provider, yearInSeconds + dayInSeconds / 2)
-      await expect(loanToken.close()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
-      await tusd.mint(loanToken.address, parseEth(1100))
-      await loanToken.close()
-      expect(await loanToken.status()).to.equal(LoanTokenStatus.Settled)
-    })
-
-    it('reverts when closing not funded loan', async () => {
-      await expect(loanToken.close()).to.be.revertedWith('LoanToken: Current status should be Funded or Withdrawn')
     })
 
     it('reverts when closing right after funding', async () => {
       await loanToken.fund()
-      await expect(loanToken.close()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
+      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
     })
 
     it('reverts when closing ongoing loan', async () => {
       await loanToken.fund()
-      await expect(loanToken.close()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
+      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
       await timeTravel(provider, yearInSeconds - 10)
-      await expect(loanToken.close()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
+      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Loan cannot be closed yet')
     })
 
     it('reverts when trying to close already closed loan', async () => {
       await loanToken.fund()
       await timeTravel(provider, defaultedLoanCloseTime)
-      await loanToken.close()
-      await expect(loanToken.close()).to.be.revertedWith('LoanToken: Current status should be Funded or Withdrawn')
+      await loanToken.enterDefault()
+      await expect(loanToken.enterDefault()).to.be.revertedWith('LoanToken: Current status should be Funded or Withdrawn')
     })
 
     it('emits event', async () => {
@@ -257,7 +259,7 @@ describe('LoanToken', () => {
       await withdraw(borrower)
       await tusd.mint(loanToken.address, parseEth(1099))
       await timeTravel(provider, defaultedLoanCloseTime)
-      await expect(loanToken.close()).to.emit(loanToken, 'Closed').withArgs(LoanTokenStatus.Defaulted, parseEth(1099))
+      await expect(loanToken.enterDefault()).to.emit(loanToken, 'Closed').withArgs(LoanTokenStatus.Defaulted, parseEth(1099))
     })
   })
 
@@ -283,7 +285,7 @@ describe('LoanToken', () => {
       await loanToken.fund()
       await withdraw(borrower)
       await timeTravel(provider, defaultedLoanCloseTime)
-      await loanToken.close()
+      await loanToken.enterDefault()
 
       await expect(loanToken.connect(borrower).liquidate())
         .to.be.revertedWith('LoanToken: Caller is not the liquidator')
@@ -293,7 +295,7 @@ describe('LoanToken', () => {
       await loanToken.fund()
       await withdraw(borrower)
       await timeTravel(provider, defaultedLoanCloseTime)
-      await loanToken.close()
+      await loanToken.enterDefault()
 
       await loanToken.liquidate()
       expect(await loanToken.status()).to.equal(LoanTokenStatus.Liquidated)
@@ -396,7 +398,7 @@ describe('LoanToken', () => {
     it('emits event', async () => {
       await loanToken.fund()
       await timeTravel(provider, defaultedLoanCloseTime)
-      await loanToken.close()
+      await loanToken.enterDefault()
       await expect(loanToken.redeem(parseEth(1100))).to.emit(loanToken, 'Redeemed').withArgs(lender.address, parseEth(1100), removeFee(parseEth(1000)))
     })
 
@@ -405,7 +407,7 @@ describe('LoanToken', () => {
         await loanToken.fund()
         await timeTravel(provider, yearInSeconds)
         await payback(borrower, await addFee(parseEth(100)))
-        await loanToken.close()
+        await loanToken.settle()
         await expect(() => loanToken.redeem(parseEth(1100))).to.changeTokenBalance(tusd, lender, parseEth(1100))
       })
 
@@ -425,7 +427,7 @@ describe('LoanToken', () => {
         await timeTravel(provider, defaultedLoanCloseTime)
         await withdraw(borrower)
         await payback(borrower, parseEth(825))
-        await loanToken.close()
+        await loanToken.enterDefault()
         await expect(() => loanToken.redeem(parseEth(1100))).to.changeTokenBalance(tusd, lender, parseEth(825))
       })
 
@@ -445,7 +447,7 @@ describe('LoanToken', () => {
         await timeTravel(provider, defaultedLoanCloseTime)
         await withdraw(borrower)
         await payback(borrower, parseEth(550))
-        await loanToken.close()
+        await loanToken.enterDefault()
         await loanToken.redeem(parseEth(550))
         expect(await tusd.balanceOf(lender.address)).to.equal(await addFee(parseEth(275)))
         await payback(borrower, parseEth(550))
@@ -479,7 +481,7 @@ describe('LoanToken', () => {
         await timeTravel(provider, defaultedLoanCloseTime)
         await withdraw(borrower)
         await payback(borrower, parseEth(550))
-        await loanToken.close()
+        await loanToken.enterDefault()
         await loanToken.redeem(parseEth(275))
         expect(await tusd.balanceOf(lender.address)).to.equal(parseEth(275).div(2))
         await payback(borrower, parseEth(550))
@@ -527,19 +529,19 @@ describe('LoanToken', () => {
     })
 
     it('reverts when not borrower tries access', async () => {
-      await loanToken.close()
+      await loanToken.enterDefault()
       await expect(loanToken.reclaim())
         .to.be.revertedWith('LoanToken: Caller is not the borrower')
     })
 
     it('reverts when total supply is greater than 0', async () => {
-      await loanToken.close()
+      await loanToken.enterDefault()
       await expect(loanToken.connect(borrower).reclaim())
         .to.be.revertedWith('LoanToken: Cannot reclaim when LoanTokens are in circulation')
     })
 
     it('reverts when balance is 0', async () => {
-      await loanToken.close()
+      await loanToken.enterDefault()
       await payback(borrower, parseEth(1100))
       await loanToken.redeem(parseEth(1100))
       await expect(loanToken.connect(borrower).reclaim())
@@ -547,14 +549,14 @@ describe('LoanToken', () => {
     })
 
     it('reclaims surplus when conditions met', async () => {
-      await loanToken.close()
+      await loanToken.enterDefault()
       await paybackRedeemPayback()
       await expect(() => loanToken.connect(borrower).reclaim())
         .to.changeTokenBalance(tusd, borrower, parseEth(200))
     })
 
     it('reverts when reclaims twice', async () => {
-      await loanToken.close()
+      await loanToken.enterDefault()
       await paybackRedeemPayback()
       await loanToken.connect(borrower).reclaim()
       await expect(loanToken.connect(borrower).reclaim())
@@ -562,7 +564,7 @@ describe('LoanToken', () => {
     })
 
     it('reclaims, pays some more and reclaims again', async () => {
-      await loanToken.close()
+      await loanToken.enterDefault()
       await payback(borrower, parseEth(900))
       await loanToken.redeem(parseEth(1100))
       await payback(borrower, parseEth(100))
@@ -574,7 +576,7 @@ describe('LoanToken', () => {
     })
 
     it('emits event', async () => {
-      await loanToken.close()
+      await loanToken.enterDefault()
       await paybackRedeemPayback()
       await expect(loanToken.connect(borrower).reclaim()).to.emit(loanToken, 'Reclaimed')
         .withArgs(borrower.address, parseEth(200))
@@ -662,7 +664,7 @@ describe('LoanToken', () => {
 
     it('loan fully repaid and closed before term', async () => {
       await tusd.mint(loanToken.address, parseEth(1100))
-      await loanToken.close()
+      await loanToken.settle()
       expect(await loanToken.value(loanTokenBalance)).to.be.equal(parseEth(1100))
     })
   })

--- a/test/truefi/TrueLender.test.ts
+++ b/test/truefi/TrueLender.test.ts
@@ -588,7 +588,7 @@ describe('TrueLender', () => {
       await lender.fund(secondLoanToken.address)
       await timeTravel(provider, averageMonthInSeconds * 6)
       await tusd.mint(firstLoanToken.address, parseEth(12e5))
-      await firstLoanToken.close()
+      await firstLoanToken.settle()
       expectScaledCloseTo(await lender.value(), parseEth(33e5))
     })
 
@@ -617,7 +617,7 @@ describe('TrueLender', () => {
       await timeTravel(provider, yearInSeconds * 1.5)
       await lender.distribute(otherWallet.address, 1, 2)
       await tusd.mint(firstLoanToken.address, await firstLoanToken.debt())
-      await firstLoanToken.close()
+      await firstLoanToken.settle()
       await firstLoanToken.connect(otherWallet).redeem(await firstLoanToken.balanceOf(otherWallet.address))
       expectScaledCloseTo(await lender.value(), parseEth(175e4))
     })

--- a/test/truefi/TrueRatingAgency.test.ts
+++ b/test/truefi/TrueRatingAgency.test.ts
@@ -527,7 +527,7 @@ describe('TrueRatingAgency', () => {
           await loanToken.withdraw(owner.address, txArgs)
           await tusd.transfer(loanToken.address, await loanToken.debt())
           await timeTravel(yearInSeconds * 2)
-          await loanToken.close()
+          await loanToken.settle()
           expect(await rater.status(loanToken.address)).to.equal(LoanStatus.Settled)
         }
 
@@ -628,7 +628,7 @@ describe('TrueRatingAgency', () => {
           await loanToken.fund()
           await loanToken.withdraw(owner.address, txArgs)
           await timeTravel(yearInSeconds * 2 + dayInSeconds)
-          await loanToken.close()
+          await loanToken.enterDefault()
           expect(await rater.status(loanToken.address)).to.equal(LoanStatus.Defaulted)
         }
 
@@ -892,7 +892,7 @@ describe('TrueRatingAgency', () => {
         await timeTravel(yearInSeconds)
         await expectRoughTrustTokenBalanceChangeAfterClaim(parseTRU(2e4), owner)
         await timeTravel(averageMonthInSeconds * 30)
-        await loanToken.close()
+        await loanToken.enterDefault()
         await expectRoughTrustTokenBalanceChangeAfterClaim(parseTRU(2e4), owner)
         await rater.withdraw(loanToken.address, await rater.getYesVote(loanToken.address, owner.address), txArgs)
         await expectRoughTrustTokenBalanceChangeAfterClaim(parseTRU(6e4), otherWallet)
@@ -901,7 +901,7 @@ describe('TrueRatingAgency', () => {
       it('does not do anything when called multiple times', async () => {
         await loanToken.fund()
         await timeTravel(yearInSeconds * 2 + dayInSeconds)
-        await loanToken.close()
+        await loanToken.enterDefault()
 
         await expectRoughTrustTokenBalanceChangeAfterClaim(parseTRU(1e5), owner)
         await expectRoughTrustTokenBalanceChangeAfterClaim(0, owner)
@@ -911,7 +911,7 @@ describe('TrueRatingAgency', () => {
         await loanToken.fund()
         await timeTravel(yearInSeconds * 2)
         await tusd.mint(loanToken.address, parseEth(1312312312321))
-        await loanToken.close()
+        await loanToken.settle()
         const staked = await rater.getYesVote(loanToken.address, owner.address)
 
         await expect(async () => rater.withdraw(loanToken.address, staked, txArgs))
@@ -922,7 +922,7 @@ describe('TrueRatingAgency', () => {
         await loanToken.fund()
         await timeTravel(yearInSeconds * 2)
         await tusd.mint(loanToken.address, parseEth(1312312312321))
-        await loanToken.close()
+        await loanToken.settle()
         const staked = await rater.getYesVote(loanToken.address, owner.address)
 
         await expect(async () => rater.withdraw(loanToken.address, staked.div(2), txArgs))
@@ -934,7 +934,7 @@ describe('TrueRatingAgency', () => {
       it('calculates reward properly when closed early', async () => {
         await loanToken.fund()
         await tusd.mint(loanToken.address, parseEth(1312312312321))
-        await loanToken.close()
+        await loanToken.settle()
         await expectRoughTrustTokenBalanceChangeAfterClaim(parseTRU(1e5), owner)
       })
     })

--- a/test/truefi/TrueRatingAgencyV2.test.ts
+++ b/test/truefi/TrueRatingAgencyV2.test.ts
@@ -640,7 +640,7 @@ describe('TrueRatingAgencyV2', () => {
 
         await expectRoughTrustTokenBalanceChangeAfterClaim(parseTRU(1e5).div(11), owner)
         await timeTravel(averageMonthInSeconds * 30)
-        await loanToken.close()
+        await loanToken.enterDefault()
         await expectRoughTrustTokenBalanceChangeAfterClaim(parseTRU(0), owner)
         await expectRoughTrustTokenBalanceChangeAfterClaim(parseTRU(1e5).mul(10).div(11), otherWallet)
       })
@@ -648,7 +648,7 @@ describe('TrueRatingAgencyV2', () => {
       it('does not do anything when called multiple times', async () => {
         await loanToken.fund()
         await timeTravel(yearInSeconds * 2 + dayInSeconds)
-        await loanToken.close()
+        await loanToken.enterDefault()
 
         await expectRoughTrustTokenBalanceChangeAfterClaim(parseTRU(1e5), owner)
         await expectRoughTrustTokenBalanceChangeAfterClaim(0, owner)


### PR DESCRIPTION
This should reduce our hesitation to call settle() (née close()), since there won't be a possibility we accidentally default a loan that has passed its term. As a side benefit I think our tests are a little more legible as well, since after this we can see whether a loan was supposed to settle or default.

A note on naming: default is apparently a reserved keyword in Solidity (though as far as I know it hasn't been assigned a meaning yet), so I chose enterDefault() instead. Feel free to suggest an alternative.