### PR TITLE
Settle LoanTokens when fully repaid via function call

### DIFF
--- a/contracts/truefi/LoanToken.sol
+++ b/contracts/truefi/LoanToken.sol
@@ -347,10 +347,28 @@ contract LoanToken is ILoanToken, ERC20 {
      * @param _sender account sending currencyToken to repay
      * @param _amount amount of currencyToken to repay
      */
-    function repay(address _sender, uint256 _amount) external override onlyAfterWithdraw {
+    function repay(address _sender, uint256 _amount) external override {
+        _repay(_sender, _amount);
+    }
+
+    /**
+     * @dev Function for borrower to repay all of the remaining loan balance
+     * Borrower should use this to ensure full repayment
+     * @param _sender account sending currencyToken to repay
+     */
+    function repayInFull(address _sender) external override {
+        _repay(_sender, debt.sub(_balance()));
+    }
+
+    /**
+     * @dev Internal function for loan repayment
+     * @param _sender account sending currencyToken to repay
+     * @param _amount amount of currencyToken to repay
+     */
+    function _repay(address _sender, uint256 _amount) internal onlyAfterWithdraw {
         require(_amount <= debt.sub(_balance()), "LoanToken: Cannot repay over the debt");
-        require(currencyToken.transferFrom(_sender, address(this), _amount));
         emit Repaid(_sender, _amount);
+        require(currencyToken.transferFrom(_sender, address(this), _amount));
     }
 
     /**

--- a/contracts/truefi/LoanToken.sol
+++ b/contracts/truefi/LoanToken.sol
@@ -378,12 +378,11 @@ contract LoanToken is ILoanToken, ERC20 {
      * @param _amount amount of currencyToken to repay
      */
     function _repay(address _sender, uint256 _amount) internal onlyAfterWithdraw {
-        uint256 outstandingDebt = debt.sub(_balance());
-        require(_amount <= outstandingDebt, "LoanToken: Cannot repay over the debt");
+        require(_amount <= debt.sub(_balance()), "LoanToken: Cannot repay over the debt");
         emit Repaid(_sender, _amount);
 
         currencyToken.safeTransferFrom(_sender, address(this), _amount);
-        if (_amount >= outstandingDebt) {
+        if (isRepaid()) {
             settle();
         }
     }

--- a/contracts/truefi/LoanToken.sol
+++ b/contracts/truefi/LoanToken.sol
@@ -313,7 +313,7 @@ contract LoanToken is ILoanToken, ERC20 {
     /**
      * @dev Settle the loan after checking it has been repaid
      */
-    function settle() external override onlyOngoing {
+    function settle() public override onlyOngoing {
         require(isRepaid(), "LoanToken: loan must be repaid to settle");
         status = Status.Settled;
         emit Settled(_balance());
@@ -381,12 +381,11 @@ contract LoanToken is ILoanToken, ERC20 {
         uint256 outstandingDebt = debt.sub(_balance());
         require(_amount <= outstandingDebt, "LoanToken: Cannot repay over the debt");
         emit Repaid(_sender, _amount);
-        if (_amount >= outstandingDebt) {
-            status = Status.Settled;
-            emit Settled(_balance().add(_amount));
-        }
 
         currencyToken.safeTransferFrom(_sender, address(this), _amount);
+        if (_amount >= outstandingDebt) {
+            settle();
+        }
     }
 
     /**

--- a/contracts/truefi/interface/ILoanToken.sol
+++ b/contracts/truefi/interface/ILoanToken.sol
@@ -51,6 +51,8 @@ interface ILoanToken is IERC20 {
 
     function repay(address _sender, uint256 _amount) external;
 
+    function repayInFull(address _sender) external;
+
     function reclaim() external;
 
     function allowTransfer(address account, bool _status) external;

--- a/test/truefi/LoanToken.test.ts
+++ b/test/truefi/LoanToken.test.ts
@@ -672,7 +672,6 @@ describe('LoanToken', () => {
     it('returns true after transfer repayment', async () => {
       await loanToken.fund()
       await withdraw(borrower)
-      const debt = await loanToken.debt()
       await tusd.connect(borrower).approve(loanToken.address, parseEth(900))
       await loanToken.repay(borrower.address, parseEth(900))
       await tusd.mint(loanToken.address, parseEth(300))

--- a/test/truefi/LoanToken.test.ts
+++ b/test/truefi/LoanToken.test.ts
@@ -380,7 +380,7 @@ describe('LoanToken', () => {
       await tusd.mint(borrower.address, parseEth(300))
       await expect(loanToken.repayInFull(borrower.address))
         .to.emit(loanToken, 'Closed')
-        .withArgs(borrower.address, debt)
+        .withArgs(LoanTokenStatus.Settled, debt)
     })
   })
 

--- a/test/truefi/LoanToken.test.ts
+++ b/test/truefi/LoanToken.test.ts
@@ -361,7 +361,7 @@ describe('LoanToken', () => {
       expect(await tusd.balanceOf(loanToken.address)).to.equal(debt)
     })
 
-    it('emits proper event', async () => {
+    it('emits Repaid event', async () => {
       await loanToken.fund()
       await withdraw(borrower)
       const debt = await loanToken.debt()
@@ -369,6 +369,17 @@ describe('LoanToken', () => {
       await tusd.mint(borrower.address, parseEth(300))
       await expect(loanToken.repayInFull(borrower.address))
         .to.emit(loanToken, 'Repaid')
+        .withArgs(borrower.address, debt)
+    })
+
+    it('emits Closed event', async () => {
+      await loanToken.fund()
+      await withdraw(borrower)
+      const debt = await loanToken.debt()
+      await tusd.connect(borrower).approve(loanToken.address, debt)
+      await tusd.mint(borrower.address, parseEth(300))
+      await expect(loanToken.repayInFull(borrower.address))
+        .to.emit(loanToken, 'Closed')
         .withArgs(borrower.address, debt)
     })
   })

--- a/test/truefi/LoanToken.test.ts
+++ b/test/truefi/LoanToken.test.ts
@@ -374,15 +374,15 @@ describe('LoanToken', () => {
         .withArgs(borrower.address, debt)
     })
 
-    it('emits Closed event', async () => {
+    it('emits Settled event', async () => {
       await loanToken.fund()
       await withdraw(borrower)
       const debt = await loanToken.debt()
       await tusd.connect(borrower).approve(loanToken.address, debt)
       await tusd.mint(borrower.address, parseEth(300))
       await expect(loanToken.repayInFull(borrower.address))
-        .to.emit(loanToken, 'Closed')
-        .withArgs(LoanTokenStatus.Settled, debt)
+        .to.emit(loanToken, 'Settled')
+        .withArgs(debt)
     })
   })
 
@@ -650,14 +650,13 @@ describe('LoanToken', () => {
       await expect(loanToken.isRepaid()).to.be.revertedWith('LoanToken: Current status should be Funded or Withdrawn')
     })
 
-    it('reverts if called after closing', async () => {
+    it('reverts if called after settling', async () => {
       await loanToken.fund()
       await withdraw(borrower)
       const debt = await loanToken.debt()
       await tusd.connect(borrower).approve(loanToken.address, debt)
       await tusd.mint(borrower.address, parseEth(300))
       await loanToken.repayInFull(borrower.address)
-      await loanToken.settle()
       await expect(loanToken.isRepaid()).to.be.revertedWith('LoanToken: Current status should be Funded or Withdrawn')
     })
 
@@ -670,13 +669,13 @@ describe('LoanToken', () => {
       expect(await loanToken.isRepaid()).to.be.false
     })
 
-    it('returns true after full repayment', async () => {
+    it('returns true after transfer repayment', async () => {
       await loanToken.fund()
       await withdraw(borrower)
       const debt = await loanToken.debt()
-      await tusd.connect(borrower).approve(loanToken.address, debt)
-      await tusd.mint(borrower.address, parseEth(300))
-      await loanToken.repayInFull(borrower.address)
+      await tusd.connect(borrower).approve(loanToken.address, parseEth(900))
+      await loanToken.repay(borrower.address, parseEth(900))
+      await tusd.mint(loanToken.address, parseEth(300))
 
       expect(await loanToken.isRepaid()).to.be.true
     })


### PR DESCRIPTION
We discussed this in standup, but I don't recall if we decided to move forward with it.

Pros:
- atomically repay in full and then settle the loan in a single transaction
- reduce the lag of closing loans, whether it's manually initiated or scheduled in a keeper

Cons:
- costs borrowers slightly more gas