### PR TITLE
Usdc support for StkTruToken

### DIFF
--- a/contracts/governance/StkTruToken.sol
+++ b/contracts/governance/StkTruToken.sol
@@ -134,6 +134,8 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
         updateClaimableRewards(tru, account);
         updateTotalRewards(tfusd);
         updateClaimableRewards(tfusd, account);
+        updateTotalRewards(feeToken);
+        updateClaimableRewards(feeToken, account);
         _;
     }
 
@@ -149,6 +151,9 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
         } else if (token == tfusd) {
             updateTotalRewards(tfusd);
             updateClaimableRewards(tfusd, account);
+        } else if (token == feeToken) {
+            updateTotalRewards(feeToken);
+            updateClaimableRewards(feeToken, account);
         }
         _;
     }
@@ -262,6 +267,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
 
         _claim(tru);
         _claim(tfusd);
+        _claim(feeToken);
 
         uint256 amountToTransfer = amount.mul(stakeSupply).div(totalSupply);
 
@@ -328,6 +334,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
     function claim() external distribute update(msg.sender) {
         _claim(tru);
         _claim(tfusd);
+        _claim(feeToken);
     }
 
     /**
@@ -336,7 +343,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
      * @param token Token to claim rewards for
      */
     function claimRewards(IERC20 token) external distribute updateRewards(msg.sender, token) {
-        require(token == tfusd || token == tru, "Token not supported for rewards");
+        require(token == tfusd || token == tru || token == feeToken, "Token not supported for rewards");
         _claim(token);
     }
 
@@ -505,6 +512,9 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
         }
         if (token == tfusd) {
             return token.balanceOf(address(this)).sub(undistributedTfusdRewards);
+        }
+        if (token == feeToken) {
+            return token.balanceOf(address(this));
         }
         return 0;
     }

--- a/contracts/governance/StkTruToken.sol
+++ b/contracts/governance/StkTruToken.sol
@@ -73,6 +73,8 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
     // allow pausing of deposits
     bool public pauseStatus;
 
+    IERC20 public feeToken;
+
     // ======= STORAGE DECLARATION END ============
 
     event Stake(address indexed staker, uint256 amount);
@@ -84,6 +86,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
     event UnstakePeriodDurationChanged(uint256 newUnstakePeriodDuration);
     event FeePayerWhitelistingStatusChanged(address payer, bool status);
     event PauseStatusChanged(bool pauseStatus);
+    event FeeTokenChanged(IERC20 token);
 
     /**
      * @dev pool can only be joined when it's unpaused
@@ -154,18 +157,21 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
      * @dev Initialize contract and set default values
      * @param _tru TRU token
      * @param _tfusd tfUSD token
+     * @param _feeToken Token for fees, currently tfUSDC
      * @param _distributor Distributor for this contract
      * @param _liquidator Liquidator for staked TRU
      */
     function initialize(
         IERC20 _tru,
         IERC20 _tfusd,
+        IERC20 _feeToken,
         ITrueDistributor _distributor,
         address _liquidator
     ) public {
         require(!initalized, "StkTruToken: Already initialized");
         tru = _tru;
         tfusd = _tfusd;
+        feeToken = _feeToken;
         distributor = _distributor;
         liquidator = _liquidator;
 
@@ -174,6 +180,15 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
 
         owner_ = msg.sender;
         initalized = true;
+    }
+
+    /**
+     * @dev Set tfUSDC address
+     * @param _feeToken Address of tfUSDC to be set
+     */
+    function setFeeToken(IERC20 _feeToken) external onlyOwner {
+        feeToken = _feeToken;
+        emit FeeTokenChanged(_feeToken);
     }
 
     /**

--- a/contracts/governance/StkTruToken.sol
+++ b/contracts/governance/StkTruToken.sol
@@ -443,6 +443,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
     ) internal override distribute update(sender) {
         updateClaimableRewards(tru, recipient);
         updateClaimableRewards(tfusd, recipient);
+        updateClaimableRewards(feeToken, recipient);
         // unlockTime returns MAX_UINT256 when there's no ongoing cooldown for the address
         if (unlockTime(recipient) != type(uint256).max) {
             receivedDuringCooldown[recipient] = receivedDuringCooldown[recipient].add(amount);

--- a/contracts/governance/StkTruToken.sol
+++ b/contracts/governance/StkTruToken.sol
@@ -192,6 +192,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
      * @param _feeToken Address of tfUSDC to be set
      */
     function setFeeToken(IERC20 _feeToken) external onlyOwner {
+        require(rewardBalance(feeToken) == 0, "StkTruToken: Cannot replace fee token with underlying rewards");
         feeToken = _feeToken;
         emit FeeTokenChanged(_feeToken);
     }

--- a/test/governance/StkTruToken.test.ts
+++ b/test/governance/StkTruToken.test.ts
@@ -98,6 +98,12 @@ describe('StkTruToken', () => {
         .to.be.revertedWith('only owner')
     })
 
+    it('cannot change when rewards were not claimed', async () => {
+      await feeToken.mint(stkToken.address, 1)
+      await expect(stkToken.setFeeToken(tfusd.address))
+        .to.be.revertedWith('StkTruToken: Cannot replace fee token with underlying rewards')
+    })
+
     it('changes value', async () => {
       await stkToken.setFeeToken(tfusd.address)
       expect(await stkToken.feeToken()).to.eq(tfusd.address)

--- a/test/governance/StkTruToken.test.ts
+++ b/test/governance/StkTruToken.test.ts
@@ -504,18 +504,22 @@ describe('StkTruToken', () => {
     it('updates claim state on transfer', async () => {
       await timeTravel(provider, DAY)
       await tfusd.mint(stkToken.address, parseEth(1), { gasLimit: 3000000 })
+      await feeToken.mint(stkToken.address, parseEth(2))
 
       expectScaledCloseTo(await stkToken.claimable(owner.address, tru.address), parseTRU(1000))
       expect(await stkToken.claimable(owner.address, tfusd.address)).to.equal(parseEth(1))
+      expect(await stkToken.claimable(owner.address, feeToken.address)).to.equal(parseEth(2))
 
       await stkToken.transfer(staker.address, amount.div(2), { gasLimit: 3000000 })
       await stkToken.claim({ gasLimit: 300000 })
 
       expectScaledCloseTo(await tru.balanceOf(owner.address), parseTRU(1000))
       expect(await tfusd.balanceOf(owner.address)).to.equal(parseEth(1))
+      expect(await feeToken.balanceOf(owner.address)).to.equal(parseEth(2))
 
       expectCloseTo(await stkToken.claimable(staker.address, tru.address), parseTRU(0))
       expect(await stkToken.claimable(staker.address, tfusd.address)).to.equal(0)
+      expect(await stkToken.claimable(staker.address, feeToken.address)).to.equal(0)
     })
 
     it('gas cost', async () => {

--- a/test/truefi/Liquidator.test.ts
+++ b/test/truefi/Liquidator.test.ts
@@ -65,6 +65,7 @@ describe('Liquidator', () => {
     await stakingPool.initialize(
       tru.address,
       pool.address,
+      pool.address,
       distributor.address,
       liquidator.address,
     )

--- a/test/truefi/TrueRatingAgencyV2.test.ts
+++ b/test/truefi/TrueRatingAgencyV2.test.ts
@@ -70,7 +70,7 @@ describe('TrueRatingAgencyV2', () => {
     linearDistributor = await new LinearTrueDistributorFactory(owner).deploy()
 
     stakedTrustToken = await new StkTruTokenFactory(owner).deploy()
-    await stakedTrustToken.initialize(trustToken.address, tusd.address, linearDistributor.address, liquidator.address)
+    await stakedTrustToken.initialize(trustToken.address, tusd.address, AddressZero, linearDistributor.address, liquidator.address)
 
     loanToken = await new LoanTokenFactory(owner).deploy(
       tusd.address,

--- a/test/truefi/TrueRatingAgencyV2.test.ts
+++ b/test/truefi/TrueRatingAgencyV2.test.ts
@@ -70,7 +70,7 @@ describe('TrueRatingAgencyV2', () => {
     linearDistributor = await new LinearTrueDistributorFactory(owner).deploy()
 
     stakedTrustToken = await new StkTruTokenFactory(owner).deploy()
-    await stakedTrustToken.initialize(trustToken.address, tusd.address, AddressZero, linearDistributor.address, liquidator.address)
+    await stakedTrustToken.initialize(trustToken.address, tusd.address, tusd.address, linearDistributor.address, liquidator.address)
 
     loanToken = await new LoanTokenFactory(owner).deploy(
       tusd.address,

--- a/test/truefi2/TrueFiPool2.test.ts
+++ b/test/truefi2/TrueFiPool2.test.ts
@@ -67,7 +67,7 @@ describe('TrueFiPool2', () => {
     pool = poolImplementation.attach(await poolFactory.pool(tusd.address))
 
     const distributor = await deployContract(LinearTrueDistributorFactory)
-    await stakingToken.initialize(stakingToken.address, pool.address, distributor.address, AddressZero)
+    await stakingToken.initialize(stakingToken.address, pool.address, AddressZero, distributor.address, AddressZero)
 
     await lender.initialize(stakingToken.address, poolFactory.address, rater.address)
     await stakingToken.setPayerWhitelistingStatus(lender.address, true)

--- a/test/truefi2/TrueLender2.test.ts
+++ b/test/truefi2/TrueLender2.test.ts
@@ -77,7 +77,7 @@ describe('TrueLender2', () => {
 
     const tfusd = await deployContract(owner, MockTrueCurrencyFactory) // just for testing, change this in origination fees development
     const trueDistributor = await deployContract(owner, LinearTrueDistributorFactory)
-    await stkTru.initialize(tru.address, tfusd.address, trueDistributor.address, AddressZero)
+    await stkTru.initialize(tru.address, tfusd.address, AddressZero, trueDistributor.address, AddressZero)
 
     lender = await deployContract(owner, TestTrueLenderFactory)
     await poolFactory.initialize(implementationReference.address, AddressZero, lender.address)

--- a/test/truefi2/TrueLender2.test.ts
+++ b/test/truefi2/TrueLender2.test.ts
@@ -77,7 +77,7 @@ describe('TrueLender2', () => {
 
     const tfusd = await deployContract(owner, MockTrueCurrencyFactory) // just for testing, change this in origination fees development
     const trueDistributor = await deployContract(owner, LinearTrueDistributorFactory)
-    await stkTru.initialize(tru.address, tfusd.address, AddressZero, trueDistributor.address, AddressZero)
+    await stkTru.initialize(tru.address, tfusd.address, tfusd.address, trueDistributor.address, AddressZero)
 
     lender = await deployContract(owner, TestTrueLenderFactory)
     await poolFactory.initialize(implementationReference.address, AddressZero, lender.address)


### PR DESCRIPTION
Include any ERC20 feeToken (probably usdc) support for StkTruToken. Simply includes it in all calculations, claimable updates, transfers, balances etc.

Once all of origination fees in tfusd are paid, we can remove tfusd related methods (keeping claiming only), which would save a lot of gas.