### PR TITLE
Add a public view of Initializable's initialized variable

### DIFF
--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -63,6 +63,7 @@ contract Initializable {
 
     /**
      * @dev Return true if and only if the contract has been initialized
+     * @return whether the contract has been initialized
      */
     function isInitialized() public view returns (bool) {
         return initialized;

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -1,4 +1,5 @@
 // Copied from https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/blob/v3.0.0/contracts/Initializable.sol
+// Added public isInitialized() view of private initialized bool.
 
 // SPDX-License-Identifier: MIT
 pragma solidity 0.6.10;
@@ -58,6 +59,13 @@ contract Initializable {
             cs := extcodesize(self)
         }
         return cs == 0;
+    }
+
+    /**
+     * @dev Return true if and only if the contract has been initialized
+     */
+    function isInitialized() public view returns (bool) {
+        return initialized;
     }
 
     // Reserved storage space to allow for layout changes in the future.


### PR DESCRIPTION
I think adding this view is reasonable so we can check initialization status, but perhaps we should be more cautious about making changes to library code.

Two possible concerns:
1. If OpenZeppelin updates this contract and we want to merge from upstream, would this present issues?
2. Would a change like this require that we redeploy impls that we'd rather not touch? May not be worth it in that case.