### PR TITLE
Add CircleCI hooks to ensure mars deployment always works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - image: circleci/node:12.19.0
     steps:
       - attach_workspace:
-        at: .
+          at: .
       - run: yarn deploy:truefi --network kovan --dry-run
   integration:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,13 @@ jobs:
       - attach_workspace:
           at: .
       - run: yarn test:truefi2
-
+  deploy:
+    docker:
+      - image: circleci/node:12.19.0
+    steps:
+      - attach_workspace:
+        at: .
+      - run: yarn deploy:truefi --network kovan --dry-run
   integration:
     docker:
       - image: circleci/node:12.19.0
@@ -89,6 +95,9 @@ workflows:
           requires:
             - build
       - test-others:
+          requires:
+            - build
+      - deploy:
           requires:
             - build
       - integration:


### PR DESCRIPTION
Running this only takes ~54 s, in parallel with other checks, after build completes.