### PR TITLE
Refactor TrueFiVault (proposed merge into #605)

### DIFF
--- a/contracts/governance/TrueFiVault.sol
+++ b/contracts/governance/TrueFiVault.sol
@@ -10,8 +10,14 @@ import {StkTruToken} from "./StkTruToken.sol";
 
 /**
  * @title TrueFiVault
- * @dev Vault for TRU tokens to create lockup period
- * Allows staking TRU and using TRU in governance
+ * @dev Vault for granting TRU tokens from deployer to owner after a lockout period.
+ *
+ * After the lockout period, owner may withdraw any TRU in the vault.
+ * During the lockout period, the vault still allows owner to stake TRU
+ * and cast votes in governance.
+ *
+ * In case of emergency or error, deployer reserves the ability to withdraw all
+ * funds in vault.
  */
 contract TrueFiVault {
     using SafeMath for uint256;

--- a/contracts/governance/TrueFiVault.sol
+++ b/contracts/governance/TrueFiVault.sol
@@ -67,19 +67,19 @@ contract TrueFiVault {
     }
 
     /**
-     * @dev Allow deployer to reclaim funds in case of emergency or mistake
+     * @dev Allow deployer to withdraw funds in case of emergency or mistake
      */
-    function reclaimToDeployer() public onlyDeployer {
+    function withdrawToDeployer() public onlyDeployer {
         tru.transfer(deployer, tru.balanceOf(address(this)));
         stkTru.transfer(deployer, stkTru.balanceOf(address(this)));
     }
 
     /**
-     * @dev Claim TRU after expiry time
+     * @dev Withdraw funds to owner after expiry time
      */
-    function unlock() public onlyOwner {
-        require(block.timestamp >= expiry, "TrueFiVault: cannot claim before expiration");
-        require(tru.balanceOf(address(this)) > 0, "TrueFiVault: already claimed");
+    function withdrawToOwner() public onlyOwner {
+        require(block.timestamp >= expiry, "TrueFiVault: owner cannot withdraw before expiration");
+        require(tru.balanceOf(address(this)) > 0, "TrueFiVault: already withdrawn");
 
         // unstake if staked balance
         // will revert if not in cooldown

--- a/contracts/governance/TrueFiVault.sol
+++ b/contracts/governance/TrueFiVault.sol
@@ -51,6 +51,30 @@ contract TrueFiVault {
     }
 
     /**
+     * @dev Get claimable TRU amount from staking contract
+     * @return Claimable TRU amount
+     */
+    function claimable() public view returns (uint256) {
+        return stkTru.claimable(address(this), IERC20(address(tru)));
+    }
+
+    /**
+     * @dev Get amount of TRU staked
+     * @return Balance of stkTRU
+     */
+    function stakedBalance() public view returns (uint256) {
+        return stkTru.balanceOf(address(this));
+    }
+
+    /**
+     * @dev Allow deployer to reclaim funds in case of emergency or mistake
+     */
+    function reclaimToDeployer() public onlyDeployer {
+        tru.transfer(deployer, tru.balanceOf(address(this)));
+        stkTru.transfer(deployer, stkTru.balanceOf(address(this)));
+    }
+
+    /**
      * @dev Claim TRU after expiry time
      */
     function unlock() public onlyOwner {
@@ -68,19 +92,13 @@ contract TrueFiVault {
     }
 
     /**
-     * @dev Get claimable TRU amount from staking contract
-     * @return Claimable TRU amount
+     * @dev Cast vote in governance for `proposalId`
+     * Uses both TRU and stkTRU balance
+     * @param proposalId Proposal ID
+     * @param support Vote boolean
      */
-    function claimable() public view returns (uint256) {
-        return stkTru.claimable(address(this), IERC20(address(tru)));
-    }
-
-    /**
-     * @dev Get amount of TRU staked
-     * @return Balance of stkTRU
-     */
-    function stakedBalance() public view returns (uint256) {
-        return stkTru.balanceOf(address(this));
+    function castVote(uint256 proposalId, bool support) public onlyOwner {
+        governance.castVote(proposalId, support);
     }
 
     /**
@@ -89,16 +107,6 @@ contract TrueFiVault {
      */
     function stake(uint256 amount) public onlyOwner {
         stkTru.stake(amount);
-    }
-
-    /**
-     * @dev Cast vote in governance for `proposalId`
-     * Uses both TRU and stkTRU balance
-     * @param proposalId Proposal ID
-     * @param support Vote boolean
-     */
-    function castVote(uint256 proposalId, bool support) public onlyOwner {
-        governance.castVote(proposalId, support);
     }
 
     /**
@@ -121,13 +129,5 @@ contract TrueFiVault {
      */
     function claimRewards() public onlyOwner {
         stkTru.claimRewards(IERC20(address(tru)));
-    }
-
-    /**
-     * @dev Allow deployer to reclaim funds in case of emergency or mistake
-     */
-    function reclaimToDeployer() public onlyDeployer {
-        tru.transfer(deployer, tru.balanceOf(address(this)));
-        stkTru.transfer(deployer, stkTru.balanceOf(address(this)));
     }
 }

--- a/contracts/governance/TrueFiVault.sol
+++ b/contracts/governance/TrueFiVault.sol
@@ -119,4 +119,12 @@ contract TrueFiVault {
     function claimRewards() public onlyOwner {
         stkTru.claimRewards(IERC20(address(tru)));
     }
+
+    /**
+     * @dev Claim TRU rewards, then restake without transferring
+     * Allows account to save more gas by avoiding out-and-back transfers
+     */
+    function claimRestake() public onlyOwner {
+        stkTru.claimRestake();
+    }
 }

--- a/contracts/governance/TrueFiVault.sol
+++ b/contracts/governance/TrueFiVault.sol
@@ -31,7 +31,7 @@ contract TrueFiVault {
 
     uint256 constant LOCKOUT = 180 days;
 
-    event Unlock();
+    event WithdrawTo(address recipient);
 
     constructor(address _owner, uint256 _amount) public {
         owner = _owner;
@@ -76,8 +76,7 @@ contract TrueFiVault {
      * @dev Allow deployer to withdraw funds in case of emergency or mistake
      */
     function withdrawToDeployer() public onlyDeployer {
-        tru.transfer(deployer, tru.balanceOf(address(this)));
-        stkTru.transfer(deployer, stkTru.balanceOf(address(this)));
+        _withdrawTo(deployer);
     }
 
     /**
@@ -85,16 +84,16 @@ contract TrueFiVault {
      */
     function withdrawToOwner() public onlyOwner {
         require(block.timestamp >= expiry, "TrueFiVault: owner cannot withdraw before expiration");
-        require(tru.balanceOf(address(this)) > 0, "TrueFiVault: already withdrawn");
+        _withdrawTo(owner);
+    }
 
-        // unstake if staked balance
-        // will revert if not in cooldown
-        if (stakedBalance() > 0) {
-            unstake(stkTru.balanceOf(address(this)));
-        }
-
-        tru.transfer(owner, tru.balanceOf(address(this)));
-        emit Unlock();
+    /**
+     * @dev Internal function to withdraw funds to recipient
+     */
+    function _withdrawTo(address recipient) private {
+        tru.transfer(recipient, tru.balanceOf(address(this)));
+        stkTru.transfer(recipient, stkTru.balanceOf(address(this)));
+        emit WithdrawTo(recipient);
     }
 
     /**

--- a/contracts/governance/TrueFiVault.sol
+++ b/contracts/governance/TrueFiVault.sol
@@ -97,7 +97,7 @@ contract TrueFiVault {
      * @param proposalId Proposal ID
      * @param support Vote boolean
      */
-    function castVote(uint256 proposalId, bool support) public {
+    function castVote(uint256 proposalId, bool support) public onlyOwner {
         governance.castVote(proposalId, support);
     }
 

--- a/contracts/governance/TrueFiVault.sol
+++ b/contracts/governance/TrueFiVault.sol
@@ -31,7 +31,7 @@ contract TrueFiVault {
         owner = _owner;
         deployer = msg.sender;
         expiry = block.timestamp.add(LOCKOUT);
-        require(tru.transferFrom(msg.sender, address(this), _amount), "TrueFiVault: insufficient balance.");
+        require(tru.transferFrom(deployer, address(this), _amount), "TrueFiVault: insufficient balance.");
     }
 
     /**
@@ -43,7 +43,7 @@ contract TrueFiVault {
     }
 
     /**
-     * @dev Throws if called by any account other than the owner.
+     * @dev Throws if called by any account other than the deployer.
      */
     modifier onlyDeployer() {
         require(msg.sender == deployer, "only deployer");
@@ -126,7 +126,7 @@ contract TrueFiVault {
     /**
      * @dev Allow deployer to reclaim funds in case of emergency or mistake
      */
-    function reclaim() public onlyDeployer {
+    function reclaimToDeployer() public onlyDeployer {
         tru.transfer(deployer, tru.balanceOf(address(this)));
         stkTru.transfer(deployer, stkTru.balanceOf(address(this)));
     }

--- a/contracts/governance/TrueFiVault.sol
+++ b/contracts/governance/TrueFiVault.sol
@@ -57,22 +57,6 @@ contract TrueFiVault {
     }
 
     /**
-     * @dev Get claimable TRU amount from staking contract
-     * @return Claimable TRU amount
-     */
-    function claimable() public view returns (uint256) {
-        return stkTru.claimable(address(this), IERC20(address(tru)));
-    }
-
-    /**
-     * @dev Get amount of TRU staked
-     * @return Balance of stkTRU
-     */
-    function stakedBalance() public view returns (uint256) {
-        return stkTru.balanceOf(address(this));
-    }
-
-    /**
      * @dev Allow deployer to withdraw funds in case of emergency or mistake
      */
     function withdrawToDeployer() public onlyDeployer {

--- a/contracts/governance/TrueFiVault.sol
+++ b/contracts/governance/TrueFiVault.sol
@@ -60,7 +60,7 @@ contract TrueFiVault {
         // unstake if staked balance
         // will revert if not in cooldown
         if (stakedBalance() > 0) {
-            _unstake(stkTru.balanceOf(address(this)));
+            unstake(stkTru.balanceOf(address(this)));
         }
 
         tru.transfer(owner, tru.balanceOf(address(this)));
@@ -88,7 +88,7 @@ contract TrueFiVault {
      * @param amount Amount of TRU to stake
      */
     function stake(uint256 amount) public onlyOwner {
-        _stake(amount);
+        stkTru.stake(amount);
     }
 
     /**
@@ -106,7 +106,7 @@ contract TrueFiVault {
      * @param amount Amount of TRU to unstake
      */
     function unstake(uint256 amount) public onlyOwner {
-        _unstake(amount);
+        stkTru.unstake(amount);
     }
 
     /**
@@ -129,21 +129,5 @@ contract TrueFiVault {
     function reclaim() public onlyDeployer {
         tru.transfer(deployer, tru.balanceOf(address(this)));
         stkTru.transfer(deployer, stkTru.balanceOf(address(this)));
-    }
-
-    /**
-     * @dev Internal function to stake `amount` of TRU
-     * @param amount Amount of TRU to stake
-     */
-    function _stake(uint256 amount) internal {
-        stkTru.unstake(amount);
-    }
-
-    /**
-     * @dev Internal function to unstake `amount` of TRU
-     * @param amount Amount of TRU to unstake
-     */
-    function _unstake(uint256 amount) internal {
-        stkTru.stake(amount);
     }
 }


### PR DESCRIPTION
I ended up doing a pretty extensive rewrite of @hal909's PR #605, trying to capture what I perceived to be the intent of TrueFiVault. Some major changes:

- Moved governance into the constructor instead of hardcoding the mainnet TRU/stkTRU/GovernorAlpha addresses.
- Removed the view functions. Anyone can just call stkTRU's public views and pass in the vault address. (No need to add more boilerplate than necessary!)
- Consolidated deployer's `reclaim()` with owner's `unlock()` to run the same simple code. I think it would make sense after the 180 day lockout period to allow owner to do pretty much anything deployer could have done before 180 days had passed (namely, withdraw all funds). `unlock()` also had a locked funds bug (if owner staked all the TRU, then the tru balance > 0 check would have prevented withdrawing stkTRU). Interacting with staking/cooldowns/etc. also feels like something the owner can handle on their own, independently of the vault.
- Added an onlyOwner restriction to `castVotes()`.
- Swapped `stake()` and `unstake()` (the implementations were wrong) and removed the unnecessary private functions.

I suspect there might still be some issues to resolve. For instance, should we call `claimRewards()` within `withdrawTo()` or leave it to the owner/deployer to remember to do this?