### PR TITLE
Another minimum contract to trigger Timelock test failures

### DIFF
--- a/contracts/governance/Test.sol
+++ b/contracts/governance/Test.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+
+import {StkTruToken} from "./StkTruToken.sol";
+import {ITrueRatingAgencyV2} from "../truefi/interface/ITrueRatingAgencyV2.sol";
+
+contract Test {
+    constructor() public {
+        block.timestamp;
+    }
+}


### PR DESCRIPTION
This is another minimum POC that triggers the 4 Timelock test failures.

Confusing prerequisites:
- All three imports must be included (SafeMath, StkTruToken, ITrueRatingAgencyV2).
- None of the imported contracts are required to show up in the Test contract.
- `block.timestamp` must appear in the constructor.