### PR TITLE
SushiRewarder timelock

### DIFF
--- a/contracts/proxy/TimeLockedOwnedUpgradeabilityProxy.sol
+++ b/contracts/proxy/TimeLockedOwnedUpgradeabilityProxy.sol
@@ -169,7 +169,14 @@ contract TimeLockedOwnedUpgradeabilityProxy {
         assembly {
             sstore(position, _delay)
         }
+        emit DelayChanged(_delay);
     }
+
+    /**
+     * @dev This event will be emitted every time the delay is changed
+     * @param _delay new delay
+     */
+    event DelayChanged(uint256 _delay);
 
     /**
      * @dev Allows the current owner to transfer control of the contract to a newOwner.

--- a/test/proxy/TimeLockedOwnedUpgradeabilityProxy.test.ts
+++ b/test/proxy/TimeLockedOwnedUpgradeabilityProxy.test.ts
@@ -1,8 +1,8 @@
 import { expect, use } from 'chai'
-import { solidity } from 'ethereum-waffle'
+import { MockProvider, solidity } from 'ethereum-waffle'
 import { Wallet } from 'ethers'
 
-import { beforeEachWithFixture, ZERO_ADDRESS } from 'utils'
+import { beforeEachWithFixture, DAY, timeTravel, ZERO_ADDRESS } from 'utils'
 
 import {
   MockTrueCurrency,
@@ -17,12 +17,15 @@ describe('TimeLockedOwnedUpgradeabilityProxy', () => {
   let owner: Wallet
   let anotherWallet: Wallet
   let thirdWallet: Wallet
+  let provider: MockProvider
 
   let proxy: TimeLockedOwnedUpgradeabilityProxy
   let tusd: MockTrueCurrency
 
-  beforeEachWithFixture(async (wallets) => {
+  beforeEachWithFixture(async (wallets, _provider) => {
     [owner, anotherWallet, thirdWallet] = wallets
+    provider = _provider
+    await provider.send('hardhat_reset', [])
     proxy = await new TimeLockedOwnedUpgradeabilityProxy__factory(owner).deploy()
     tusd = await new MockTrueCurrency__factory(owner).deploy()
   })
@@ -69,6 +72,57 @@ describe('TimeLockedOwnedUpgradeabilityProxy', () => {
       await expect(proxy.connect(anotherWallet).claimProxyOwnership())
         .to.emit(proxy, 'ProxyOwnershipTransferred')
         .withArgs(owner.address, anotherWallet.address)
+    })
+  })
+
+  describe('Setting delay', () => {
+    it('initially set to 10', async () => {
+      expect(await proxy.delay()).to.eq(10*DAY)
+    })
+
+    it('only proxy owner can initialize setter', async () => {
+      await expect(proxy.connect(anotherWallet).initializeSetDelay(3*DAY))
+        .to.be.revertedWith("only Proxy Owner")
+
+      await expect(proxy.initializeSetDelay(3*DAY))
+        .not.to.be.reverted
+    })
+
+    describe('setting delay process', () => {
+      beforeEach(async () => {
+        await proxy.initializeSetDelay(3*DAY)
+        timeTravel(provider, 10*DAY)
+      })
+
+      it('sets pendingDelay', async () => {
+        expect(await proxy.pendingDelay()).to.eq(3*DAY)
+      })
+
+      it('anyone execute setter', async () => {
+        await expect(proxy.connect(anotherWallet).executeSetDelay())
+          .not.to.be.reverted
+      })
+
+      it('sets new delay', async () => {
+        await proxy.executeSetDelay()
+        expect(await proxy.delay()).to.eq(3*DAY)
+      })
+
+      it('can execute multiple times', async () => {
+        await proxy.executeSetDelay()
+        expect(await proxy.delay()).to.eq(3*DAY)
+        await proxy.executeSetDelay()
+        expect(await proxy.delay()).to.eq(3*DAY)
+      })
+    })
+
+    it('initializing setter initializes cooldown', async () => {
+      await proxy.initializeSetDelay(3*DAY)
+      timeTravel(provider, 9*DAY)
+      expect(await proxy.delayUnlockTimestamp())
+        .to.be.gt((await provider.getBlock('latest')).timestamp)
+      await expect(proxy.executeSetDelay())
+        .to.be.revertedWith("not enough time has passed")
     })
   })
 

--- a/test/proxy/TimeLockedOwnedUpgradeabilityProxy.test.ts
+++ b/test/proxy/TimeLockedOwnedUpgradeabilityProxy.test.ts
@@ -118,7 +118,7 @@ describe('TimeLockedOwnedUpgradeabilityProxy', () => {
       it('emits event', async () => {
         await expect(proxy.connect(anotherWallet).executeSetDelay())
           .to.emit(proxy, 'DelayChanged')
-          .withArgs(DAY*3)
+          .withArgs(DAY * 3)
       })
     })
 

--- a/test/proxy/TimeLockedOwnedUpgradeabilityProxy.test.ts
+++ b/test/proxy/TimeLockedOwnedUpgradeabilityProxy.test.ts
@@ -77,25 +77,25 @@ describe('TimeLockedOwnedUpgradeabilityProxy', () => {
 
   describe('Setting delay', () => {
     it('initially set to 10', async () => {
-      expect(await proxy.delay()).to.eq(10*DAY)
+      expect(await proxy.delay()).to.eq(10 * DAY)
     })
 
     it('only proxy owner can initialize setter', async () => {
-      await expect(proxy.connect(anotherWallet).initializeSetDelay(3*DAY))
-        .to.be.revertedWith("only Proxy Owner")
+      await expect(proxy.connect(anotherWallet).initializeSetDelay(3 * DAY))
+        .to.be.revertedWith('only Proxy Owner')
 
-      await expect(proxy.initializeSetDelay(3*DAY))
+      await expect(proxy.initializeSetDelay(3 * DAY))
         .not.to.be.reverted
     })
 
     describe('setting delay process', () => {
       beforeEach(async () => {
-        await proxy.initializeSetDelay(3*DAY)
-        timeTravel(provider, 10*DAY)
+        await proxy.initializeSetDelay(3 * DAY)
+        timeTravel(provider, 10 * DAY)
       })
 
       it('sets pendingDelay', async () => {
-        expect(await proxy.pendingDelay()).to.eq(3*DAY)
+        expect(await proxy.pendingDelay()).to.eq(3 * DAY)
       })
 
       it('anyone execute setter', async () => {
@@ -105,24 +105,24 @@ describe('TimeLockedOwnedUpgradeabilityProxy', () => {
 
       it('sets new delay', async () => {
         await proxy.executeSetDelay()
-        expect(await proxy.delay()).to.eq(3*DAY)
+        expect(await proxy.delay()).to.eq(3 * DAY)
       })
 
       it('can execute multiple times', async () => {
         await proxy.executeSetDelay()
-        expect(await proxy.delay()).to.eq(3*DAY)
+        expect(await proxy.delay()).to.eq(3 * DAY)
         await proxy.executeSetDelay()
-        expect(await proxy.delay()).to.eq(3*DAY)
+        expect(await proxy.delay()).to.eq(3 * DAY)
       })
     })
 
     it('initializing setter initializes cooldown', async () => {
-      await proxy.initializeSetDelay(3*DAY)
-      timeTravel(provider, 9*DAY)
+      await proxy.initializeSetDelay(3 * DAY)
+      timeTravel(provider, 9 * DAY)
       expect(await proxy.delayUnlockTimestamp())
         .to.be.gt((await provider.getBlock('latest')).timestamp)
       await expect(proxy.executeSetDelay())
-        .to.be.revertedWith("not enough time has passed")
+        .to.be.revertedWith('not enough time has passed')
     })
   })
 

--- a/test/proxy/TimeLockedOwnedUpgradeabilityProxy.test.ts
+++ b/test/proxy/TimeLockedOwnedUpgradeabilityProxy.test.ts
@@ -114,6 +114,12 @@ describe('TimeLockedOwnedUpgradeabilityProxy', () => {
         await proxy.executeSetDelay()
         expect(await proxy.delay()).to.eq(3 * DAY)
       })
+
+      it('emits event', async () => {
+        await expect(proxy.connect(anotherWallet).executeSetDelay())
+          .to.emit(proxy, 'DelayChanged')
+          .withArgs(DAY*3)
+      })
     })
 
     it('initializing setter initializes cooldown', async () => {

--- a/test/proxy/TimeLockedOwnedUpgradeabilityProxy.test.ts
+++ b/test/proxy/TimeLockedOwnedUpgradeabilityProxy.test.ts
@@ -1,0 +1,98 @@
+import { expect, use } from 'chai'
+import { solidity } from 'ethereum-waffle'
+import { Wallet } from 'ethers'
+
+import { beforeEachWithFixture, ZERO_ADDRESS } from 'utils'
+
+import {
+  MockTrueCurrency,
+  MockTrueCurrency__factory,
+} from 'contracts'
+import { TimeLockedOwnedUpgradeabilityProxy } from 'build/types/TimeLockedOwnedUpgradeabilityProxy'
+import { TimeLockedOwnedUpgradeabilityProxy__factory } from 'build/types/factories/TimeLockedOwnedUpgradeabilityProxy__factory'
+
+use(solidity)
+
+describe('TimeLockedOwnedUpgradeabilityProxy', () => {
+  let owner: Wallet
+  let anotherWallet: Wallet
+  let thirdWallet: Wallet
+
+  let proxy: TimeLockedOwnedUpgradeabilityProxy
+  let tusd: MockTrueCurrency
+
+  beforeEachWithFixture(async (wallets) => {
+    [owner, anotherWallet, thirdWallet] = wallets
+    proxy = await new TimeLockedOwnedUpgradeabilityProxy__factory(owner).deploy()
+    tusd = await new MockTrueCurrency__factory(owner).deploy()
+  })
+
+  describe('Ownership', () => {
+    it('owner is the owner of the proxy', async () => {
+      expect(await proxy.proxyOwner()).to.equal(owner.address)
+    })
+
+    it('owner can transfer proxy ownership ', async () => {
+      expect(await proxy.pendingProxyOwner()).to.equal(ZERO_ADDRESS)
+      await proxy.transferProxyOwnership(anotherWallet.address)
+
+      expect(await proxy.pendingProxyOwner()).to.equal(anotherWallet.address)
+    })
+
+    it('pending owner can claim ownership ', async () => {
+      await proxy.transferProxyOwnership(anotherWallet.address)
+      await proxy.connect(anotherWallet).claimProxyOwnership()
+
+      expect(await proxy.proxyOwner()).to.equal(anotherWallet.address)
+    })
+
+    it('non owner cannot transfer ownership ', async () => {
+      await expect(proxy.connect(anotherWallet).transferProxyOwnership(anotherWallet.address))
+        .to.be.reverted
+    })
+
+    it('non pending owner cannot claim ownership ', async () => {
+      await proxy.transferProxyOwnership(anotherWallet.address)
+      await expect(proxy.connect(thirdWallet).claimProxyOwnership())
+        .to.be.reverted
+    })
+
+    it('zero address cannot be pending owner ', async () => {
+      await expect(proxy.transferProxyOwnership(ZERO_ADDRESS))
+        .to.be.reverted
+    })
+
+    it('emits proper events', async () => {
+      await expect(proxy.transferProxyOwnership(anotherWallet.address))
+        .to.emit(proxy, 'NewPendingOwner')
+        .withArgs(owner.address, anotherWallet.address)
+      await expect(proxy.connect(anotherWallet).claimProxyOwnership())
+        .to.emit(proxy, 'ProxyOwnershipTransferred')
+        .withArgs(owner.address, anotherWallet.address)
+    })
+  })
+
+  describe('Upgrading', () => {
+    it('sets up implementation contract ', async () => {
+      await proxy.upgradeTo(tusd.address)
+      expect(await proxy.implementation()).to.equal(tusd.address)
+    })
+
+    it('non owner cannot upgrade implementation contract', async () => {
+      await expect(proxy.connect(anotherWallet).upgradeTo(tusd.address))
+        .to.be.reverted
+    })
+
+    it('new implementation contract cannot be the same as the old', async () => {
+      await proxy.upgradeTo(tusd.address)
+      await expect(proxy.upgradeTo(tusd.address))
+        .to.be.reverted
+    })
+
+    it('emits proper event', async () => {
+      await expect(proxy.upgradeTo(tusd.address))
+        .to.emit(proxy, 'Upgraded')
+        .withArgs(tusd.address)
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces new Proxy for sushirewarder. There are 2 variables, that can only be changed with a certain delay. Implementation and of course delay. For both of them there are 2 types of functions that need to be called, in order to set new values.
 - initialize(SetDelay/UpgradeTo) sets new pending value and calculates timestamp, in which setter can be executed. This function can be only called by owner of the proxy.
 - execute(SetDelay/UpgradeTo) ensures that needed timestamp has passed and executes the setter. Since execute call will only set predeclared pending value and will only be able to set it once, it is not restricted for owner use only.

It does not use Timelock, beceause Timelock itself is initializable and could not be relied on that much by external users. 

