### PR TITLE
Make .to.be.calledOnContract work with Hardhat

### DIFF
--- a/test/governance/TrueFiVault.test.ts
+++ b/test/governance/TrueFiVault.test.ts
@@ -67,7 +67,7 @@ describe('TrueFiVault', () => {
       )).to.be.revertedWith('TrueFiVault: insufficient owner balance')
     })
 
-    xit('transfers amount from owner', async () => {
+    it('transfers amount from owner', async () => {
       await tru.mock.transferFrom.returns(true)
       const constructedVault = await new TrueFiVault__factory(owner).deploy(
         beneficiary.address,
@@ -79,7 +79,7 @@ describe('TrueFiVault', () => {
       expect('transferFrom').to.be.calledOnContractWith(tru, [owner.address, constructedVault.address, TRU_AMOUNT])
     })
 
-    xit('delegates stkTRU to beneficiary', async () => {
+    it('delegates stkTRU to beneficiary', async () => {
       await stkTru.mock.delegate.withArgs(beneficiary.address).returns()
       await new TrueFiVault__factory(owner).deploy(
         beneficiary.address,
@@ -105,17 +105,17 @@ describe('TrueFiVault', () => {
       await expect(trueFiVault.connect(beneficiary).withdrawToOwner()).to.be.revertedWith('TrueFiVault: only owner')
     })
 
-    xit('claims rewards', async () => {
+    it('claims rewards', async () => {
       await trueFiVault.connect(owner).withdrawToOwner()
       expect('claimRewards').to.be.calledOnContractWith(stkTru, [tru.address])
     })
 
-    xit('transfers TRU to owner', async () => {
+    it('transfers TRU to owner', async () => {
       await trueFiVault.connect(owner).withdrawToOwner()
       expect('transfer').to.be.calledOnContractWith(tru, [owner.address, TRU_AMOUNT])
     })
 
-    xit('transfers stkTRU to owner', async () => {
+    it('transfers stkTRU to owner', async () => {
       await trueFiVault.connect(owner).withdrawToOwner()
       expect('transfer').to.be.calledOnContractWith(stkTru, [owner.address, STKTRU_AMOUNT])
     })
@@ -144,19 +144,19 @@ describe('TrueFiVault', () => {
       await expect(trueFiVault.connect(beneficiary).withdrawToBeneficiary()).to.be.revertedWith('TrueFiVault: beneficiary cannot withdraw before expiration')
     })
 
-    xit('claims rewards', async () => {
+    it('claims rewards', async () => {
       await timeTravel(provider, DURATION + 1)
       await trueFiVault.connect(beneficiary).withdrawToBeneficiary()
       expect('claimRewards').to.be.calledOnContractWith(stkTru, [tru.address])
     })
 
-    xit('transfers TRU to beneficiary', async () => {
+    it('transfers TRU to beneficiary', async () => {
       await timeTravel(provider, DURATION + 1)
       await trueFiVault.connect(beneficiary).withdrawToBeneficiary()
       expect('transfer').to.be.calledOnContractWith(tru, [beneficiary.address, TRU_AMOUNT])
     })
 
-    xit('transfers stkTRU to beneficiary', async () => {
+    it('transfers stkTRU to beneficiary', async () => {
       await timeTravel(provider, DURATION + 1)
       await trueFiVault.connect(beneficiary).withdrawToBeneficiary()
       expect('transfer').to.be.calledOnContractWith(stkTru, [beneficiary.address, STKTRU_AMOUNT])
@@ -173,7 +173,7 @@ describe('TrueFiVault', () => {
       await expect(trueFiVault.connect(owner).stake(TRU_AMOUNT)).to.be.revertedWith('TrueFiVault: only beneficiary')
     })
 
-    xit('delegates stake from beneficiary', async () => {
+    it('delegates stake from beneficiary', async () => {
       await stkTru.mock.stake.withArgs(TRU_AMOUNT).returns()
       await trueFiVault.connect(beneficiary).stake(TRU_AMOUNT)
       expect('stake').to.be.calledOnContractWith(stkTru, [TRU_AMOUNT])
@@ -183,7 +183,7 @@ describe('TrueFiVault', () => {
       await expect(trueFiVault.connect(owner).unstake(TRU_AMOUNT)).to.be.revertedWith('TrueFiVault: only beneficiary')
     })
 
-    xit('delegates unstake from beneficiary', async () => {
+    it('delegates unstake from beneficiary', async () => {
       await stkTru.mock.unstake.withArgs(TRU_AMOUNT).returns()
       await trueFiVault.connect(beneficiary).unstake(TRU_AMOUNT)
       expect('unstake').to.be.calledOnContractWith(stkTru, [TRU_AMOUNT])
@@ -193,7 +193,7 @@ describe('TrueFiVault', () => {
       await expect(trueFiVault.connect(owner).cooldown()).to.be.revertedWith('TrueFiVault: only beneficiary')
     })
 
-    xit('delegates cooldown from beneficiary', async () => {
+    it('delegates cooldown from beneficiary', async () => {
       await stkTru.mock.cooldown.returns()
       await trueFiVault.connect(beneficiary).cooldown()
       expect('cooldown').to.be.calledOnContract(stkTru)
@@ -203,7 +203,7 @@ describe('TrueFiVault', () => {
       await expect(trueFiVault.connect(owner).claimRewards()).to.be.revertedWith('TrueFiVault: only beneficiary')
     })
 
-    xit('delegates claimRewards from beneficiary', async () => {
+    it('delegates claimRewards from beneficiary', async () => {
       await stkTru.mock.claimRewards.withArgs(tru.address).returns()
       await trueFiVault.connect(beneficiary).claimRewards()
       expect('claimRewards').to.be.calledOnContractWith(stkTru, [tru.address])
@@ -213,7 +213,7 @@ describe('TrueFiVault', () => {
       await expect(trueFiVault.connect(owner).claimRestake()).to.be.revertedWith('TrueFiVault: only beneficiary')
     })
 
-    xit('delegates claimRestake from beneficiary', async () => {
+    it('delegates claimRestake from beneficiary', async () => {
       await stkTru.mock.claimRestake.returns()
       await trueFiVault.connect(beneficiary).claimRestake()
       expect('claimRestake').to.be.calledOnContract(stkTru)

--- a/test/truefi/TrueFiPool.test.ts
+++ b/test/truefi/TrueFiPool.test.ts
@@ -317,7 +317,7 @@ describe('TrueFiPool', () => {
       await pool.join(parseEth(1e7))
     })
 
-    xit('deposits given amount to curve', async () => {
+    it('deposits given amount to curve', async () => {
       await pool.flush(parseEth(100), 123)
       expect('add_liquidity').to.be.calledOnContractWith(curvePool, [[0, 0, 0, parseEth(100)], 123])
     })
@@ -331,7 +331,7 @@ describe('TrueFiPool', () => {
       await expect(pool.flush(parseEth(1e7 + 1), 0)).to.be.revertedWith('TrueFiPool: Insufficient currency balance')
     })
 
-    xit('deposits liquidity tokens in curve gauge', async () => {
+    it('deposits liquidity tokens in curve gauge', async () => {
       await expect('deposit').to.be.calledOnContractWith(mockCurveGauge, [parseEth(100)])
     })
 
@@ -352,7 +352,7 @@ describe('TrueFiPool', () => {
       await token.mint(curvePool.address, parseEth(1000))
     })
 
-    xit('withdraws given amount from curve', async () => {
+    it('withdraws given amount from curve', async () => {
       await pool.pull(parseEth(100), 123)
       expect('remove_liquidity_one_coin').to.be.calledOnContractWith(curvePool, [parseEth(100), 3, 123, false])
     })
@@ -573,7 +573,7 @@ describe('TrueFiPool', () => {
       expect(await curveToken.allowance(pool.address, curvePool.address)).to.equal(0)
     })
 
-    xit('calls remove_liquidity_one_coin with correct arguments', async () => {
+    it('calls remove_liquidity_one_coin with correct arguments', async () => {
       await curvePool.set_withdraw_price(parseEth(2))
       const amount = parseEth(5e6)
       await pool.flush(amount, 0)

--- a/test/truefi/TrueLender.test.ts
+++ b/test/truefi/TrueLender.test.ts
@@ -375,18 +375,18 @@ describe('TrueLender', () => {
         await mockPool.mock.balanceOf.returns(fee)
       })
 
-      xit('borrows tokens from pool', async () => {
+      it('borrows tokens from pool', async () => {
         await lender.fund(mockLoanToken.address)
         expect('borrow').to.be.calledOnContractWith(mockPool, [amount, fee])
       })
 
-      xit('calls approve and pays fee', async () => {
+      it('calls approve and pays fee', async () => {
         await lender.fund(mockLoanToken.address)
         expect('approve').to.be.calledOnContractWith(mockPool, [mockStakingPool.address, fee])
         expect('payFee').to.be.calledOnContract(mockStakingPool)
       })
 
-      xit('calls fund function', async () => {
+      it('calls fund function', async () => {
         await lender.fund(mockLoanToken.address)
         expect('fund').to.be.calledOnContractWith(mockLoanToken, [])
       })
@@ -487,13 +487,13 @@ describe('TrueLender', () => {
         .to.be.revertedWith('TrueLender: This loan has not been funded by the lender')
     })
 
-    xit('redeems funds from loan token', async () => {
+    it('redeems funds from loan token', async () => {
       await lender.fund(mockLoanToken.address)
       await lender.reclaim(mockLoanToken.address)
       await expect('redeem').to.be.calledOnContractWith(mockLoanToken, [availableLoanTokens])
     })
 
-    xit('repays funds from the pool', async () => {
+    it('repays funds from the pool', async () => {
       await lender.fund(mockLoanToken.address)
       await lender.reclaim(mockLoanToken.address)
       await expect('repay').to.be.calledOnContract(mockPool)
@@ -649,7 +649,7 @@ describe('TrueLender', () => {
       await lender.setPool(owner.address)
     })
 
-    xit('sends all loan tokens in the same proportion as numerator/denominator', async () => {
+    it('sends all loan tokens in the same proportion as numerator/denominator', async () => {
       await lender.distribute(otherWallet.address, 2, 5)
       for (let i = 0; i < 5; i++) {
         expect('transfer').to.be.calledOnContractWith(loanTokens[i], [otherWallet.address, parseEth(((i + 1) * 10).toString()).mul(2).div(5)])

--- a/test/truefi/keepers/TrueLenderReclaimer.test.ts
+++ b/test/truefi/keepers/TrueLenderReclaimer.test.ts
@@ -87,7 +87,7 @@ describe('TrueLenderReclaimer', () => {
         .to.be.revertedWith('TrueLenderReclaimer: Only LoanTokens can be settled')
     })
 
-    xit('settles fully repaid Withdrawn loans', async () => {
+    it('settles fully repaid Withdrawn loans', async () => {
       await withdrawnLoanToken.mock.isRepaid.returns(true)
       await withdrawnLoanToken.mock.settle.returns()
       await reclaimer.settleAll()
@@ -132,7 +132,7 @@ describe('TrueLenderReclaimer', () => {
         .to.be.revertedWith('TrueLenderReclaimer: Only LoanTokens can be reclaimed')
     })
 
-    xit('reclaims Settled loans', async () => {
+    it('reclaims Settled loans', async () => {
       await settledLoanToken.mock.status.returns(3) // ILoanToken.Status.Settled
       await mockLender.mock.reclaim.returns()
       await reclaimer.reclaimAll()

--- a/test/truefi2/TrueFiPool2.test.ts
+++ b/test/truefi2/TrueFiPool2.test.ts
@@ -226,7 +226,7 @@ describe('TrueFiPool2', () => {
       expect(await pool.liquidationTokenValue()).to.eq(0)
     })
 
-    xit('converts TRU to pool token value using oracle and returns value - 2%', async () => {
+    it('converts TRU to pool token value using oracle and returns value - 2%', async () => {
       await liquidationToken.mint(pool.address, 1000)
       const mockOracle = await deployMockContract(owner, ITrueFiPoolOracleJson.abi)
       await mockOracle.mock.truToToken.returns(500)
@@ -657,7 +657,7 @@ describe('TrueFiPool2', () => {
       await rater.mock.getResults.returns(0, 0, parseTRU(15e6))
     })
 
-    xit('only lender can be caller', async () => {
+    it('only lender can be caller', async () => {
       await expect(pool.connect(owner.address).borrow(0))
         .to.be.revertedWith('TrueFiPool: Caller is not the lender')
       const loan = await deployContract(
@@ -725,7 +725,7 @@ describe('TrueFiPool2', () => {
       await loan.settle()
     })
 
-    xit('only lender can be caller', async () => {
+    it('only lender can be caller', async () => {
       await expect(pool.connect(owner).repay(0))
         .to.be.revertedWith('TrueFiPool: Caller is not the lender')
       await lender.reclaim(loan.address, '0x')

--- a/test/truefi2/strategies/CurveYearnStrategy.test.ts
+++ b/test/truefi2/strategies/CurveYearnStrategy.test.ts
@@ -62,12 +62,12 @@ describe('CurveYearnStrategy', () => {
       await curvePool.set_withdraw_price(parseEth(2))
     })
 
-    xit('calls add_liquidity with correct amounts and minAmount as 95% of theoretical', async () => {
+    it('calls add_liquidity with correct amounts and minAmount as 95% of theoretical', async () => {
       await strategy.connect(pool).deposit(amount)
       expect('add_liquidity').to.be.calledOnContractWith(curvePool, [[0, 0, 0, amount], amount.div(2).mul(95).div(100)])
     })
 
-    xit('puts received tokens into gauge', async () => {
+    it('puts received tokens into gauge', async () => {
       await strategy.connect(pool).deposit(amount)
       expect('deposit').to.be.calledOnContractWith(mockCurveGauge, [amount.div(2)])
     })
@@ -96,7 +96,7 @@ describe('CurveYearnStrategy', () => {
       expect(await token.balanceOf(pool.address)).to.be.gte(amount.div(2))
     })
 
-    xit('withdraws from cure a bit more then theoretical value because of Curve\'s errors', async () => {
+    it('withdraws from cure a bit more then theoretical value because of Curve\'s errors', async () => {
       await strategy.connect(pool).withdraw(amount.div(2))
       const curveLpAmount = amount
         .div(2) // minAmount
@@ -105,7 +105,7 @@ describe('CurveYearnStrategy', () => {
       expect('remove_liquidity_one_coin').to.be.calledOnContractWith(curvePool, [curveLpAmount, 3, amount.div(2), false])
     })
 
-    xit('if curve LP amount is less than 0.5% below balance, withdraws all available balance', async () => {
+    it('if curve LP amount is less than 0.5% below balance, withdraws all available balance', async () => {
       await strategy.connect(pool).withdraw(amount.sub(2))
       const curveLpAmount = amount.div(2)
       expect('remove_liquidity_one_coin').to.be.calledOnContractWith(curvePool, [curveLpAmount, 3, amount.sub(2), false])

--- a/test/utils/beforeEachWithFixture.ts
+++ b/test/utils/beforeEachWithFixture.ts
@@ -1,14 +1,16 @@
 import { waffle } from 'hardhat'
+import { proxyProvider } from 'utils/hardhatCallHistoryProvider'
 import type { MockProvider } from 'ethereum-waffle'
-import { Wallet } from 'ethers'
+import type { Wallet } from 'ethers'
 
 export type Fixture<T> = (wallets: Wallet[], provider: MockProvider) => Promise<T>;
 
 export const loadFixture = waffle.createFixtureLoader(
-  waffle.provider.getWallets(),
-  waffle.provider,
+  proxyProvider.getWallets(),
+  proxyProvider,
 )
 
 export function beforeEachWithFixture (fixture: Fixture<void>) {
+  proxyProvider.clearCallHistory()
   beforeEach(() => loadFixture(fixture))
 }

--- a/test/utils/hardhatCallHistoryProvider.ts
+++ b/test/utils/hardhatCallHistoryProvider.ts
@@ -1,0 +1,36 @@
+import { waffle } from 'hardhat'
+import { utils } from 'ethers'
+
+let callHistory = []
+let subscribed = false
+
+const init = (waffle.provider as any)._hardhatNetwork.provider._wrapped._wrapped._wrapped._wrapped._init
+;(waffle.provider as any)._hardhatNetwork.provider._wrapped._wrapped._wrapped._wrapped._init = async function () {
+  await init.apply(this)
+  if (!subscribed) {
+    (waffle.provider as any)._hardhatNetwork.provider._wrapped._wrapped._wrapped._wrapped._node._vmTracer._vm.on('beforeMessage', (message) => {
+      if (message.to) {
+        callHistory.push({
+          address: utils.getAddress(message.to.toString()),
+          data: `0x${message.data.toString('hex')}`,
+        })
+      }
+    })
+    subscribed = true
+  }
+}
+
+const proxyProvider = new Proxy(waffle.provider, {
+  get (target: any, name) {
+    if (name === 'callHistory') {
+      return callHistory
+    }
+    return target[name]
+  },
+})
+
+proxyProvider.clearCallHistory = () => {
+  callHistory = []
+}
+
+export { proxyProvider }

--- a/test/utils/hardhatCallHistoryProvider.ts
+++ b/test/utils/hardhatCallHistoryProvider.ts
@@ -1,13 +1,12 @@
 import { waffle } from 'hardhat'
 import { utils } from 'ethers'
 
-let callHistory = []
-let subscribed = false
+const callHistory = []
 
 const init = (waffle.provider as any)._hardhatNetwork.provider._wrapped._wrapped._wrapped._wrapped._init
 ;(waffle.provider as any)._hardhatNetwork.provider._wrapped._wrapped._wrapped._wrapped._init = async function () {
   await init.apply(this)
-  if (!subscribed) {
+  if ((waffle.provider as any)._hardhatNetwork.provider._wrapped._wrapped._wrapped._wrapped._node._vmTracer._vm.listenerCount('beforeMessage') < 2) {
     (waffle.provider as any)._hardhatNetwork.provider._wrapped._wrapped._wrapped._wrapped._node._vmTracer._vm.on('beforeMessage', (message) => {
       if (message.to) {
         callHistory.push({
@@ -16,7 +15,6 @@ const init = (waffle.provider as any)._hardhatNetwork.provider._wrapped._wrapped
         })
       }
     })
-    subscribed = true
   }
 }
 
@@ -30,7 +28,7 @@ const proxyProvider = new Proxy(waffle.provider, {
 })
 
 proxyProvider.clearCallHistory = () => {
-  callHistory = []
+  callHistory.length = 0
 }
 
 export { proxyProvider }


### PR DESCRIPTION
This strongly depends on the internals of the Hardhat provider and might break again after any update so not sure if we actually want to merge this, but seems to fix the problem for now