### PR TITLE
allow transferring in extra TRU in claimRestake()

### DIFF
--- a/contracts/governance/StkTruToken.sol
+++ b/contracts/governance/StkTruToken.sol
@@ -359,12 +359,14 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
     }
 
     /**
-     * @dev Claim TRU rewards, then restake without transferring
-     * Allows account to save more gas by avoiding out-and-back transfers
+     * @dev Claim TRU rewards, transfer in extraStakeAmount, and
+     * stake both the rewards and the new amount.
+     * Allows account to save more gas by avoiding out-and-back transfers of rewards
      */
-    function claimRestake() external distribute update(msg.sender) {
-        uint256 amount = _claimWithoutTransfer(tru);
+    function claimRestake(uint256 extraStakeAmount) external distribute update(msg.sender) {
+        uint256 amount = _claimWithoutTransfer(tru) + extraStakeAmount;
         _stakeWithoutTransfer(amount);
+        require(tru.transferFrom(msg.sender, address(this), extraStakeAmount));
     }
 
     /**

--- a/contracts/governance/StkTruToken.sol
+++ b/contracts/governance/StkTruToken.sol
@@ -366,7 +366,9 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
     function claimRestake(uint256 extraStakeAmount) external distribute update(msg.sender) {
         uint256 amount = _claimWithoutTransfer(tru) + extraStakeAmount;
         _stakeWithoutTransfer(amount);
-        require(tru.transferFrom(msg.sender, address(this), extraStakeAmount));
+        if (extraStakeAmount > 0) {
+            require(tru.transferFrom(msg.sender, address(this), extraStakeAmount));
+        }
     }
 
     /**

--- a/contracts/governance/StkTruToken.sol
+++ b/contracts/governance/StkTruToken.sol
@@ -364,7 +364,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
      * Allows account to save more gas by avoiding out-and-back transfers of rewards
      */
     function claimRestake(uint256 extraStakeAmount) external distribute update(msg.sender) {
-        uint256 amount = _claimWithoutTransfer(tru) + extraStakeAmount;
+        uint256 amount = _claimWithoutTransfer(tru).add(extraStakeAmount);
         _stakeWithoutTransfer(amount);
         if (extraStakeAmount > 0) {
             require(tru.transferFrom(msg.sender, address(this), extraStakeAmount));

--- a/contracts/governance/TrueFiVault.sol
+++ b/contracts/governance/TrueFiVault.sol
@@ -122,6 +122,6 @@ contract TrueFiVault {
      * Allows account to save more gas by avoiding out-and-back transfers
      */
     function claimRestake() external onlyBeneficiary {
-        stkTru.claimRestake();
+        stkTru.claimRestake(0);
     }
 }


### PR DESCRIPTION
(Written while wearing my volunteer-community-member hat; no idea if folks actually want this feature.)

`claimRestake` is a great new feature for saving time and gas. But if you have any source of extra TRU you want to stake (e.g. from farming tfTUSD, or from just buying some), then `claimRestake` in its current form seems not to help - e.g. my current workflow is 1) `claim` rewards and then 2) `stake` rewards+extra (two transactions), and with `claimRestake` it would instead be 1) `claimRestake` rewards and then 2) `stake` extra (still two transactions, and I'd bet they're even *more* gas-expensive). With this PR, the old `claimRestake()` would now still be usable as `claimRestake(0)`, but the extra-TRU workflow could be done in a single transaction, actually saving time and gas, with `claimRestake(extraAmount)`.