### PR TITLE
Phase 2 audit requested changes

### DIFF
--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -358,7 +358,7 @@ contract GovernorAlpha is UpgradeableClaimable {
         require(state(proposalId) == ProposalState.Active, "GovernorAlpha::_castVote: voting is closed");
         Proposal storage proposal = proposals[proposalId];
         Receipt storage receipt = proposal.receipts[voter];
-        require(receipt.hasVoted == false, "GovernorAlpha::_castVote: voter already voted");
+        require(!receipt.hasVoted, "GovernorAlpha::_castVote: voter already voted");
         uint96 votes = countVotes(voter, proposal.startBlock);
 
         if (support) {

--- a/contracts/governance/StkTruToken.sol
+++ b/contracts/governance/StkTruToken.sol
@@ -24,8 +24,8 @@ import {IPauseableContract} from "../governance/interface/IPauseableContract.sol
 contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, ReentrancyGuard {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
-    uint256 constant PRECISION = 1e30;
-    uint256 constant MIN_DISTRIBUTED_AMOUNT = 100e8;
+    uint256 public constant PRECISION = 1e30;
+    uint256 public constant MIN_DISTRIBUTED_AMOUNT = 100e8;
 
     struct FarmRewards {
         // track overall cumulative rewards
@@ -57,7 +57,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
 
     uint256 public stakeSupply;
 
-    mapping(address => uint256) cooldowns;
+    mapping(address => uint256) private cooldowns;
     uint256 public cooldownTime;
     uint256 public unstakePeriodDuration;
 

--- a/contracts/governance/StkTruToken.sol
+++ b/contracts/governance/StkTruToken.sol
@@ -24,8 +24,8 @@ import {IPauseableContract} from "../governance/interface/IPauseableContract.sol
 contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, ReentrancyGuard {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
-    uint256 public constant PRECISION = 1e30;
-    uint256 public constant MIN_DISTRIBUTED_AMOUNT = 100e8;
+    uint256 private constant PRECISION = 1e30;
+    uint256 private constant MIN_DISTRIBUTED_AMOUNT = 100e8;
 
     struct FarmRewards {
         // track overall cumulative rewards

--- a/contracts/governance/StkTruToken.sol
+++ b/contracts/governance/StkTruToken.sol
@@ -4,6 +4,7 @@ pragma solidity 0.6.10;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
 import {VoteToken} from "./VoteToken.sol";
 import {ITrueDistributor} from "../truefi/interface/ITrueDistributor.sol";
@@ -22,6 +23,7 @@ import {IPauseableContract} from "../governance/interface/IPauseableContract.sol
  */
 contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, ReentrancyGuard {
     using SafeMath for uint256;
+    using SafeERC20 for IERC20;
     uint256 constant PRECISION = 1e30;
     uint256 constant MIN_DISTRIBUTED_AMOUNT = 100e8;
 
@@ -261,7 +263,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
      */
     function stake(uint256 amount) external distribute update(msg.sender) joiningNotPaused {
         _stakeWithoutTransfer(amount);
-        require(tru.transferFrom(msg.sender, address(this), amount));
+        tru.safeTransferFrom(msg.sender, address(this), amount);
     }
 
     /**
@@ -285,7 +287,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
         _burn(msg.sender, amount);
         stakeSupply = stakeSupply.sub(amountToTransfer);
 
-        tru.transfer(msg.sender, amountToTransfer);
+        tru.safeTransfer(msg.sender, amountToTransfer);
 
         emit Unstake(msg.sender, amount);
     }
@@ -306,7 +308,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
      */
     function withdraw(uint256 amount) external onlyLiquidator {
         stakeSupply = stakeSupply.sub(amount);
-        tru.transfer(liquidator, amount);
+        tru.safeTransfer(liquidator, amount);
 
         emit Withdraw(amount);
     }
@@ -331,7 +333,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
         require(endTime < type(uint64).max, "StkTruToken: time overflow");
         require(amount < type(uint96).max, "StkTruToken: amount overflow");
 
-        require(tfusd.transferFrom(msg.sender, address(this), amount));
+        tfusd.safeTransferFrom(msg.sender, address(this), amount);
         undistributedTfusdRewards = undistributedTfusdRewards.add(amount.div(2));
         scheduledRewards.push(ScheduledTfUsdRewards({amount: uint96(amount.div(2)), timestamp: uint64(endTime)}));
 
@@ -367,7 +369,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
         uint256 amount = _claimWithoutTransfer(tru).add(extraStakeAmount);
         _stakeWithoutTransfer(amount);
         if (extraStakeAmount > 0) {
-            require(tru.transferFrom(msg.sender, address(this), extraStakeAmount));
+            tru.safeTransferFrom(msg.sender, address(this), extraStakeAmount);
         }
     }
 
@@ -480,7 +482,7 @@ contract StkTruToken is VoteToken, StkClaimableContract, IPauseableContract, Ree
     function _claim(IERC20 token) internal {
         uint256 rewardToClaim = _claimWithoutTransfer(token);
         if (rewardToClaim > 0) {
-            require(token.transfer(msg.sender, rewardToClaim));
+            token.safeTransfer(msg.sender, rewardToClaim);
         }
     }
 

--- a/contracts/truefi2/LoanToken2.sol
+++ b/contracts/truefi2/LoanToken2.sol
@@ -431,7 +431,7 @@ contract LoanToken2 is ILoanToken2, ERC20 {
 
     /**
      * @dev Calculate interest that will be paid by this loan for an amount (returned funds included)
-     * amount + ((amount * apy * term) / (365 days / precision))
+     * amount + ((amount * apy * term) / 365 days / precision)
      * @param _amount amount
      * @return uint256 Amount of interest paid for _amount
      */

--- a/contracts/truefi2/LoanToken2.sol
+++ b/contracts/truefi2/LoanToken2.sol
@@ -34,7 +34,7 @@ contract LoanToken2 is ILoanToken2, ERC20 {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
-    uint128 public constant lastMinutePaybackDuration = 1 days;
+    uint128 public constant LAST_MINUTE_PAYBACK_DURATION = 1 days;
 
     address public override borrower;
     address public liquidator;
@@ -319,7 +319,7 @@ contract LoanToken2 is ILoanToken2, ERC20 {
      */
     function enterDefault() external override onlyOngoing {
         require(!isRepaid(), "LoanToken2: cannot default a repaid loan");
-        require(start.add(term).add(lastMinutePaybackDuration) <= block.timestamp, "LoanToken2: Loan cannot be defaulted yet");
+        require(start.add(term).add(LAST_MINUTE_PAYBACK_DURATION) <= block.timestamp, "LoanToken2: Loan cannot be defaulted yet");
         status = Status.Defaulted;
         emit Defaulted(_balance());
     }

--- a/contracts/truefi2/LoanToken2.sol
+++ b/contracts/truefi2/LoanToken2.sol
@@ -35,11 +35,14 @@ contract LoanToken2 is ILoanToken2, ERC20 {
     using SafeERC20 for IERC20;
 
     uint128 public constant LAST_MINUTE_PAYBACK_DURATION = 1 days;
+    uint256 public constant APY_PRECISION = 10000;
 
     address public override borrower;
     address public liquidator;
     uint256 public override amount;
     uint256 public override term;
+
+    // apy precision: 10000 = 100%
     uint256 public override apy;
 
     uint256 public override start;
@@ -265,7 +268,7 @@ contract LoanToken2 is ILoanToken2, ERC20 {
         }
 
         // assume year is 365 days
-        uint256 interest = amount.mul(apy).mul(passed).div(365 days).div(10000);
+        uint256 interest = amount.mul(apy).mul(passed).div(365 days).div(APY_PRECISION);
 
         return amount.add(interest).mul(_balance).div(debt);
     }
@@ -436,7 +439,7 @@ contract LoanToken2 is ILoanToken2, ERC20 {
      * @return uint256 Amount of interest paid for _amount
      */
     function interest(uint256 _amount) internal view returns (uint256) {
-        return _amount.add(_amount.mul(apy).mul(term).div(365 days).div(10000));
+        return _amount.add(_amount.mul(apy).mul(term).div(365 days).div(APY_PRECISION));
     }
 
     /**

--- a/contracts/truefi2/LoanToken2.sol
+++ b/contracts/truefi2/LoanToken2.sol
@@ -35,7 +35,7 @@ contract LoanToken2 is ILoanToken2, ERC20 {
     using SafeERC20 for IERC20;
 
     uint128 public constant LAST_MINUTE_PAYBACK_DURATION = 1 days;
-    uint256 public constant APY_PRECISION = 10000;
+    uint256 private constant APY_PRECISION = 10000;
 
     address public override borrower;
     address public liquidator;

--- a/contracts/truefi2/PoolFactory.sol
+++ b/contracts/truefi2/PoolFactory.sol
@@ -145,6 +145,7 @@ contract PoolFactory is IPoolFactory, Claimable {
     }
 
     function setTrueLender(ITrueLender2 _trueLender2) external onlyOwner {
+        require(address(_trueLender2) != address(0), "PoolFactory: TrueLender address cannot be set to 0");
         trueLender2 = _trueLender2;
         emit TrueLenderChanged(trueLender2);
     }

--- a/contracts/truefi2/TrueFiPool2.sol
+++ b/contracts/truefi2/TrueFiPool2.sol
@@ -555,10 +555,10 @@ contract TrueFiPool2 is ITrueFiPool2, ERC20, Claimable {
      * @return amount minted from this transaction
      */
     function mint(uint256 depositedAmount) internal returns (uint256) {
-        uint256 mintedAmount = depositedAmount;
-        if (mintedAmount == 0) {
-            return mintedAmount;
+        if (depositedAmount == 0) {
+            return depositedAmount;
         }
+        uint256 mintedAmount = depositedAmount;
 
         // first staker mints same amount deposited
         if (totalSupply() > 0) {

--- a/contracts/truefi2/TrueFiPool2.sol
+++ b/contracts/truefi2/TrueFiPool2.sol
@@ -34,7 +34,7 @@ contract TrueFiPool2 is ITrueFiPool2, ERC20, Claimable {
     using SafeERC20 for IERC20;
     using OneInchExchange for I1Inch3;
 
-    uint256 public constant BASIS_PRECISION = 10000;
+    uint256 private constant BASIS_PRECISION = 10000;
 
     // ================ WARNING ==================
     // ===== THIS CONTRACT IS INITIALIZABLE ======

--- a/contracts/truefi2/TrueFiPool2.sol
+++ b/contracts/truefi2/TrueFiPool2.sol
@@ -527,6 +527,7 @@ contract TrueFiPool2 is ITrueFiPool2, ERC20, Claimable {
      * @dev Change oracle, can only be called by owner
      */
     function setOracle(ITrueFiPoolOracle newOracle) external onlyOwner {
+        require(address(newOracle) != address(0), "TrueFiPool: Oracle address cannot be set to 0");
         oracle = newOracle;
         emit OracleChanged(newOracle);
     }

--- a/contracts/truefi2/TrueFiPool2.sol
+++ b/contracts/truefi2/TrueFiPool2.sol
@@ -323,6 +323,7 @@ contract TrueFiPool2 is ITrueFiPool2, ERC20, Claimable {
      * @param newBeneficiary new beneficiary
      */
     function setBeneficiary(address newBeneficiary) external onlyOwner {
+        require(newBeneficiary != address(0), "TrueFiPool: Beneficiary address cannot be set to 0");
         beneficiary = newBeneficiary;
         emit BeneficiaryChanged(newBeneficiary);
     }

--- a/contracts/truefi2/TrueFiPool2.sol
+++ b/contracts/truefi2/TrueFiPool2.sol
@@ -527,7 +527,6 @@ contract TrueFiPool2 is ITrueFiPool2, ERC20, Claimable {
      * @dev Change oracle, can only be called by owner
      */
     function setOracle(ITrueFiPoolOracle newOracle) external onlyOwner {
-        require(address(newOracle) != address(0), "TrueFiPool: Oracle address cannot be set to 0");
         oracle = newOracle;
         emit OracleChanged(newOracle);
     }

--- a/contracts/truefi2/TrueLender2.sol
+++ b/contracts/truefi2/TrueLender2.sol
@@ -38,7 +38,7 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
     // REMOVAL OR REORDER OF VARIABLES WILL RESULT
     // ========= IN STORAGE CORRUPTION ===========
 
-    mapping(ITrueFiPool2 => ILoanToken2[]) poolLoans;
+    mapping(ITrueFiPool2 => ILoanToken2[]) public poolLoans;
 
     // maximum amount of loans lender can handle at once
     uint256 public maxLoans;

--- a/contracts/truefi2/TrueLender2.sol
+++ b/contracts/truefi2/TrueLender2.sol
@@ -311,14 +311,14 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
         ILoanToken2 loanToken,
         ITrueFiPool2 pool,
         bytes calldata data
-    ) internal returns (uint256 fundsReclaimed) {
+    ) internal returns (uint256) {
         // call redeem function on LoanToken
         uint256 balanceBefore = pool.token().balanceOf(address(this));
         loanToken.redeem(loanToken.balanceOf(address(this)));
         uint256 balanceAfter = pool.token().balanceOf(address(this));
 
         // gets reclaimed amount and pays back to pool
-        fundsReclaimed = balanceAfter.sub(balanceBefore);
+        uint256 fundsReclaimed = balanceAfter.sub(balanceBefore);
 
         uint256 feeAmount = 0;
         if (address(feeToken) != address(0)) {
@@ -333,6 +333,7 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
             // join pool and reward stakers
             _transferFeeToStakers();
         }
+        return fundsReclaimed;
     }
 
     /// @dev Swap `token` for `feeToken` on 1inch
@@ -340,8 +341,8 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
         IERC20 token,
         ILoanToken2 loanToken,
         bytes calldata data
-    ) internal returns (uint256 feeAmount) {
-        feeAmount = loanToken.debt().sub(loanToken.amount()).mul(fee).div(BASIS_RATIO);
+    ) internal returns (uint256) {
+        uint256 feeAmount = loanToken.debt().sub(loanToken.amount()).mul(fee).div(BASIS_RATIO);
         if (token == feeToken) {
             return feeAmount;
         }
@@ -358,6 +359,8 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
         require(swap.dstReceiver == address(this), "TrueLender: Receiver is not lender");
         require(swap.amount == feeAmount, "TrueLender: Incorrect fee swap amount");
         require(swap.flags & ONE_INCH_PARTIAL_FILL_FLAG == 0, "TrueLender: Partial fill is not allowed");
+
+        return feeAmount;
     }
 
     /// @dev Deposit feeToken to pool and transfer LP tokens to the stakers

--- a/contracts/truefi2/TrueMultiFarm.sol
+++ b/contracts/truefi2/TrueMultiFarm.sol
@@ -21,7 +21,7 @@ import {ITrueMultiFarm} from "./interface/ITrueMultiFarm.sol";
 contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
-    uint256 constant PRECISION = 1e30;
+    uint256 private constant PRECISION = 1e30;
 
     struct Stakes {
         // total amount of a particular token staked

--- a/contracts/truefi2/strategies/CurveYearnStrategy.sol
+++ b/contracts/truefi2/strategies/CurveYearnStrategy.sol
@@ -26,9 +26,9 @@ contract CurveYearnStrategy is UpgradeableClaimable, ITrueStrategy {
     using OneInchExchange for I1Inch3;
 
     // Number of tokens in Curve yPool
-    uint8 constant N_TOKENS = 4;
+    uint8 public constant N_TOKENS = 4;
     // Max slippage during uniswap sell
-    uint256 constant MAX_PRICE_SLIPPAGE = 300; // 3%
+    uint256 public constant MAX_PRICE_SLIPPAGE = 300; // 3%
 
     // ================ WARNING ==================
     // ===== THIS CONTRACT IS INITIALIZABLE ======

--- a/test/truefi2/PoolFactory.test.ts
+++ b/test/truefi2/PoolFactory.test.ts
@@ -16,6 +16,7 @@ import {
 import { solidity } from 'ethereum-waffle'
 import { Wallet } from 'ethers'
 import { beforeEachWithFixture } from 'utils/beforeEachWithFixture'
+import { AddressZero } from '@ethersproject/constants'
 
 use(solidity)
 
@@ -250,6 +251,11 @@ describe('PoolFactory', () => {
         .to.be.revertedWith('Ownable: caller is not the owner')
       await expect(factory.connect(owner).setTrueLender(trueLenderInstance2.address))
         .not.to.be.reverted
+    })
+
+    it('reverts when set to 0', async () => {
+      await expect(factory.setTrueLender(AddressZero))
+        .to.be.revertedWith('PoolFactory: TrueLender address cannot be set to 0')
     })
 
     it('sets new true lender contract', async () => {

--- a/test/truefi2/TrueFiPool2.test.ts
+++ b/test/truefi2/TrueFiPool2.test.ts
@@ -315,11 +315,6 @@ describe('TrueFiPool2', () => {
       await expect(pool.connect(borrower).setOracle(oracle))
         .to.be.revertedWith('Ownable: caller is not the owner')
     })
-
-    it('cannot be set to 0', async () => {
-      await expect(pool.setOracle(AddressZero))
-        .to.be.revertedWith('TrueFiPool: Oracle address cannot be set to 0')
-    })
   })
 
   describe('setBeneficiary', () => {

--- a/test/truefi2/TrueFiPool2.test.ts
+++ b/test/truefi2/TrueFiPool2.test.ts
@@ -323,7 +323,13 @@ describe('TrueFiPool2', () => {
     })
 
     it('reverts when called not by owner', async () => {
-      await expect(pool.connect(borrower).setBeneficiary(owner.address)).to.be.revertedWith('Ownable: caller is not the owner')
+      await expect(pool.connect(borrower).setBeneficiary(owner.address))
+        .to.be.revertedWith('Ownable: caller is not the owner')
+    })
+
+    it('cannot be set to 0', async () => {
+      await expect(pool.setBeneficiary(AddressZero))
+        .to.be.revertedWith('TrueFiPool: Beneficiary address cannot be set to 0')
     })
   })
 

--- a/test/truefi2/TrueFiPool2.test.ts
+++ b/test/truefi2/TrueFiPool2.test.ts
@@ -312,7 +312,13 @@ describe('TrueFiPool2', () => {
     })
 
     it('reverts when called not by owner', async () => {
-      await expect(pool.connect(borrower).setOracle(oracle)).to.be.revertedWith('Ownable: caller is not the owner')
+      await expect(pool.connect(borrower).setOracle(oracle))
+        .to.be.revertedWith('Ownable: caller is not the owner')
+    })
+
+    it('cannot be set to 0', async () => {
+      await expect(pool.setOracle(AddressZero))
+        .to.be.revertedWith('TrueFiPool: Oracle address cannot be set to 0')
     })
   })
 


### PR DESCRIPTION
**This PR addresses listed CertiK audit pre-report issues. Each commit represents a single issue with its ID, in order to ease picking changes if necessary.**

1. GAA-01 - not obligatory, but increases code quality by a bit.
2. STT-01 - good catch. Since we already use `SafeERC20` in other contracts, it might be good to use it everywhere for consistency.
3. STT-02 - explicitly setting variables visibility specifiers.
4. STT-03 [SKIPPED] - declaration of a new variable and return would add some extra code. This is a fairly simple function and it should remain compact.
5. STT-04 [SKIPPED] - STT-01 already solves the problem
6. LT2-01 - for consistency all constants should be in upper snake case notation.
7. LT2-02 - comment might have been a little misleading. Dividing by `(365 days / precision)` does not equal dividing by `365 days` and then `precision.`
8. LT2-03 - setting `apy` precision as constant, increases project consistency and code readability.
9. LT2-04 [SKIPPED] - `interest` function calculates loan interest that will be paid after the term passes. However with `value` method, we want to calculate loan’s value at a given time (meaning calculate interest only for a time that has passed).
10. PFY-01 - ensuring that `trueLender` in `PoolFactory` cannot be set to 0 address.
11. TFP-01 [SKIPPED] - might need future investigation if a hard fork of ethereum influences `tx.origin` in an undesirable way. For now it remains a good method to prevent join-exit _flash loan_ attacks.
12. TFP-02 - minor gas saving by allocating removing allocation if check has not passed.
13. TFP-03 - similarly to LT2-03 but for `TrueFiPool2,` increase project consistency and code readability by adding frequently use constants.
14. TFP-04 - similarly to PFY-01, ensuring that beneficiary address cannot be set to 0.
15. TFP-05 [SKIPPED][TO BE CLARIFIED]
16. TFP-06 [SKIPPED] - there might be a case when we want to set oracle's address to 0.
17. TL2-01 [SKIPPED] - present functionality might actually come handy. Currently setting `maxLoans` for less than previously, does not break anything. In fact it ensures that once running loans number decreases, new limit would apply.
18. TL2-02 [OUTDATED] - this issue was resolved while the audit was being conducted.
19. TL2-03 - explicitly setting variables visibility specifiers.
20. TL2-04 - `loans` not changed being a compact function. `redeemAndRepay` and `swapFee` changed to have explicitly named `return`. 
21. CYS-01 - explicitly setting constants visibility specifiers.
