### PR TITLE
Delegate tf{token}.decimals() to underlying token.decimals()

### DIFF
--- a/contracts/common/UpgradeableERC20.sol
+++ b/contracts/common/UpgradeableERC20.sol
@@ -89,7 +89,7 @@ contract ERC20 is Initializable, Context, IERC20 {
      * no way affects any of the arithmetic of the contract, including
      * {IERC20-balanceOf} and {IERC20-transfer}.
      */
-    function decimals() public view returns (uint8) {
+    function decimals() public virtual view returns (uint8) {
         return _decimals;
     }
 

--- a/contracts/truefi2/TrueFiPool2.sol
+++ b/contracts/truefi2/TrueFiPool2.sol
@@ -229,6 +229,10 @@ contract TrueFiPool2 is ITrueFiPool2, IPauseableContract, ERC20, Claimable {
         emit PauseStatusChanged(status);
     }
 
+    /**
+     * @dev Number of decimals for user-facing representations.
+     * Delegates to the underlying pool token.
+     */
     function decimals() public override view returns (uint8) {
         return token.decimals();
     }

--- a/contracts/truefi2/TrueFiPool2.sol
+++ b/contracts/truefi2/TrueFiPool2.sol
@@ -32,7 +32,7 @@ import {OneInchExchange} from "./libraries/OneInchExchange.sol";
  */
 contract TrueFiPool2 is ITrueFiPool2, IPauseableContract, ERC20, Claimable {
     using SafeMath for uint256;
-    using SafeERC20 for IERC20;
+    using SafeERC20 for ERC20;
     using OneInchExchange for I1Inch3;
 
     uint256 private constant BASIS_PRECISION = 10000;
@@ -45,7 +45,7 @@ contract TrueFiPool2 is ITrueFiPool2, IPauseableContract, ERC20, Claimable {
 
     uint8 public constant VERSION = 0;
 
-    IERC20 public override token;
+    ERC20 public override token;
 
     ITrueStrategy public strategy;
     ITrueLender2 public lender;
@@ -227,6 +227,10 @@ contract TrueFiPool2 is ITrueFiPool2, IPauseableContract, ERC20, Claimable {
     function setPauseStatus(bool status) external override onlyOwner {
         pauseStatus = status;
         emit PauseStatusChanged(status);
+    }
+
+    function decimals() public override view returns (uint8) {
+        return token.decimals();
     }
 
     /**

--- a/contracts/truefi2/interface/ITrueFiPool2.sol
+++ b/contracts/truefi2/interface/ITrueFiPool2.sol
@@ -15,7 +15,7 @@ interface ITrueFiPool2 is IERC20 {
         address __owner
     ) external;
 
-    function token() external view returns (IERC20);
+    function token() external view returns (ERC20);
 
     function oracle() external view returns (ITrueFiPoolOracle);
 


### PR DESCRIPTION
This is a quick hack I came up with to check if delegating decimals() is feasible.

It looks like unit tests aren't affected, although this does force us to use ERC20 instead of IERC20 (which our initialize() function already forces us to do).