### PR TITLE
Set ImplementationReference in PoolFactory

### DIFF
--- a/contracts/truefi2/PoolFactory.sol
+++ b/contracts/truefi2/PoolFactory.sol
@@ -69,6 +69,12 @@ contract PoolFactory is IPoolFactory, Claimable {
     event TrueLenderChanged(ITrueLender2 trueLender2);
 
     /**
+     * @dev Event to show poolImplementationReference was changed
+     * @param implementationReference new ImplementationReference
+     */
+    event PoolImplementationReferenceChanged(ImplementationReference implementationReference);
+
+    /**
      * @dev Throws if token already has an existing corresponding pool
      * @param token Token to be checked for existing pool
      */
@@ -148,5 +154,11 @@ contract PoolFactory is IPoolFactory, Claimable {
         require(address(_trueLender2) != address(0), "PoolFactory: TrueLender address cannot be set to 0");
         trueLender2 = _trueLender2;
         emit TrueLenderChanged(trueLender2);
+    }
+
+    function setImplementationReference(ImplementationReference _implementationReference) external onlyOwner {
+        require(address(_implementationReference) != address(0), "PoolFactory: ImplementationReference cannot be set to 0");
+        poolImplementationReference = _implementationReference;
+        emit PoolImplementationReferenceChanged(poolImplementationReference);
     }
 }

--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -54,6 +54,9 @@ deploy({}, (_, config) => {
   const poolFactory = proxy(contract(PoolFactory), 'initialize',
     [implementationReference, trustToken, trueLender2],
   )
+  runIf(poolFactory.poolImplementationReference().equals(implementationReference).not(), () => {
+    poolFactory.setImplementationReference(implementationReference)
+  })
   const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
   runIf(trueLender2.isInitialized().not(), () => {
     trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch)


### PR DESCRIPTION
ImplementationReference contract code has been updated and redeployed, but PoolFactory (proxy) can't be reinitialized with this new ImplementationReference so we're still stuck with the old ImplementationReference in PoolFactory.

This change checks for changes in ImplementationReference in the deploy script and updates it in PoolFactory.