### PR TITLE
Introduce Pauser contract

### DIFF
--- a/contracts/governance/Pauser.sol
+++ b/contracts/governance/Pauser.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+import {UpgradeableClaimable} from "../common/UpgradeableClaimable.sol";
+import {ITimelock} from "./interface/ITimelock.sol";
+import {IVoteToken} from "./interface/IVoteToken.sol";
+
+contract Pauser is UpgradeableClaimable {
+    // ================ WARNING ==================
+    // ===== THIS CONTRACT IS INITIALIZABLE ======
+    // === STORAGE VARIABLES ARE DECLARED BELOW ==
+    // REMOVAL OR REORDER OF VARIABLES WILL RESULT
+    // ========= IN STORAGE CORRUPTION ===========
+
+    // @notice The duration of voting on emergency pause
+    uint256 public votingPeriod;
+
+    // @notice The address of the TrustToken Protocol Timelock
+    ITimelock public timelock;
+
+    // @notice The address of the TrustToken governance token
+    IVoteToken public trustToken;
+
+    // @notice The address of the stkTRU voting token
+    IVoteToken public stkTRU;
+
+    // @notice The total number of requests
+    uint256 public requestCount;
+
+    // @notice The official record of all requests ever proposed
+    mapping(uint256 => PauseRequest) public requests;
+
+    // ======= STORAGE DECLARATION END ============
+
+    // @notice The name of this contract
+    string public constant name = "TrueFi Pauser";
+
+    struct PauseRequest {
+        // @notice Unique id for looking up a request
+        uint256 id;
+        // @notice Creator of the request
+        address requester;
+        // @notice The timestamp that the request will be available for execution, set once the vote succeeds
+        uint256 eta;
+        // @notice the ordered list of target addresses of contracts to be paused
+        address[] targets;
+        // @notice The ordered list of function signatures to be called by the
+        // different types of proxies might require different types of pause functions
+        string[] signatures;
+        // @notice The block at which voting begins: holders must delegate their votes prior to this block
+        uint256 startBlock;
+        // @notice The block at which voting ends: votes must be cast prior to this block
+        uint256 endBlock;
+        // @notice Current number of votes in favor of this request
+        uint256 forVotes;
+        // @notice Flag marking whether the request has been canceled
+        bool canceled;
+        // @notice Flag marking whether the request has been executed
+        bool executed;
+        // @notice Receipts of ballots for the entire set of voters
+        mapping(address => bool) receipts;
+    }
+
+    // @notice Ballot receipt record for a voter
+    struct Receipt {
+        // @notice Whether or not a vote has been cast
+        bool hasVoted;
+        // @notice The number of votes the voter had, which were cast
+        uint96 votes;
+    }
+
+    // @notice Possible states that a request may be in
+    enum RequestState {Pending, Active, Canceled, Succeeded, Expired, Executed}
+
+    // @notice The number of votes in support of a request required in order for a quorum to be reached and for a vote to succeed
+    function quorumVotes() public pure returns (uint256) {
+        return 50000000e8;
+    } // 50,000,000 Tru
+
+    // @notice The number of votes required in order for a voter to become a requester
+    function requestThreshold() public pure returns (uint256) {
+        return 100000e8;
+    } // 100,000 TRU
+
+    // @notice The maximum number of actions that can be included in a request
+    function requestMaxOperations() public pure returns (uint256) {
+        return 10;
+    } // 10 actions
+
+    /**
+     * @dev Initialize sets initial contract variables
+     */
+    function initialize(
+        ITimelock _timelock,
+        IVoteToken _trustToken,
+        IVoteToken _stkTRU,
+        uint256 _votingPeriod
+    ) external {
+        UpgradeableClaimable.initialize(msg.sender);
+        timelock = _timelock;
+        trustToken = _trustToken;
+        stkTRU = _stkTRU;
+        votingPeriod = _votingPeriod;
+    }
+
+    /**
+     * @dev Get the request state for the specified request
+     * @param requestId ID of a request in which to get its state
+     * @return Enumerated type of RequestState
+     */
+    function state(uint256 requestId) public view returns (RequestState) {
+        require(requestCount >= requestId && requestId > 0, "Pauser: invalid request id");
+        PauseRequest storage request = requests[requestId];
+        if (request.canceled) {
+            return RequestState.Canceled;
+        } else if (block.number <= request.startBlock) {
+            return RequestState.Pending;
+        } else if (block.number <= request.endBlock) {
+            return RequestState.Active;
+        } else if (request.eta == 0) {
+            return RequestState.Succeeded;
+        } else if (request.executed) {
+            return RequestState.Executed;
+        } else if (block.timestamp >= add256(request.eta, timelock.GRACE_PERIOD())) {
+            return RequestState.Expired;
+        }
+    }
+
+    /**
+     * @dev safe addition function for uint256
+     */
+    function add256(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "addition overflow");
+        return c;
+    }
+
+    /**
+     * @dev Count the total PriorVotes from TRU and stkTRU
+     * @param account The address to check the total votes
+     * @param blockNumber The block number at which the getPriorVotes() check
+     * @return The sum of PriorVotes from TRU and stkTRU
+     */
+    function countVotes(address account, uint256 blockNumber) public view returns (uint96) {
+        uint96 truVote = trustToken.getPriorVotes(account, blockNumber);
+        uint96 stkTRUVote = stkTRU.getPriorVotes(account, blockNumber);
+        uint96 totalVote = add96(truVote, stkTRUVote, "GovernorAlpha: countVotes addition overflow");
+        return totalVote;
+    }
+
+    /**
+     * @dev safe96 add function
+     * @return a + b
+     */
+    function add96(
+        uint96 a,
+        uint96 b,
+        string memory errorMessage
+    ) internal pure returns (uint96) {
+        uint96 c = a + b;
+        require(c >= a, errorMessage);
+        return c;
+    }
+
+    /**
+     * @dev safe subtraction function for uint256
+     */
+    function sub256(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b <= a, "subtraction underflow");
+        return a - b;
+    }
+}

--- a/contracts/governance/Pauser.sol
+++ b/contracts/governance/Pauser.sol
@@ -160,22 +160,22 @@ contract Pauser is UpgradeableClaimable {
     function makeRequest(address[] memory targets, PausingMethod[] memory methods) public returns (uint256) {
         require(
             countVotes(msg.sender, sub256(block.number, 1)) > requestThreshold(),
-            "Pauser::request: requester votes below request threshold"
+            "Pauser::makeRequest: requester votes below request threshold"
         );
-        require(targets.length == methods.length, "Pauser::request: request function information arity mismatch");
-        require(targets.length != 0, "Pauser::request: must provide actions");
-        require(targets.length <= requestMaxOperations(), "Pauser::request: too many actions");
+        require(targets.length == methods.length, "Pauser::makeRequest: request function information arity mismatch");
+        require(targets.length != 0, "Pauser::makeRequest: must provide actions");
+        require(targets.length <= requestMaxOperations(), "Pauser::makeRequest: too many actions");
 
         uint256 latestRequestId = latestRequestIds[msg.sender];
         if (latestRequestId != 0) {
             RequestState proposersLatestRequestState = state(latestRequestId);
             require(
                 proposersLatestRequestState != RequestState.Active,
-                "GovernorAlpha::propose: one live request per proposer, found an already active request"
+                "Pauser::makeRequest: one live request per proposer, found an already active request"
             );
             require(
                 proposersLatestRequestState != RequestState.Pending,
-                "GovernorAlpha::propose: one live request per proposer, found an already pending request"
+                "Pauser::makeRequest: one live request per proposer, found an already pending request"
             );
         }
 

--- a/contracts/governance/Pauser.sol
+++ b/contracts/governance/Pauser.sol
@@ -45,6 +45,8 @@ contract Pauser is UpgradeableClaimable {
     // @notice The name of this contract
     string public constant name = "TrueFi Pauser";
 
+    // @notice Time in seconds, which corresponds to a period of time,
+    // that a request is available for execution after successful voting
     uint256 public constant EXECUTION_PERIOD = 1 days;
 
     struct PauseRequest {

--- a/contracts/governance/Pauser.sol
+++ b/contracts/governance/Pauser.sol
@@ -52,8 +52,6 @@ contract Pauser is UpgradeableClaimable {
         uint256 id;
         // @notice Creator of the request
         address requester;
-        // @notice The timestamp that the request will be available for execution
-        uint256 eta;
         // @notice the ordered list of target addresses of contracts to be paused
         address[] targets;
         // @notice The ordered list of functions to be called
@@ -144,7 +142,7 @@ contract Pauser is UpgradeableClaimable {
         PauseRequest storage request = requests[requestId];
         if (request.executed) {
             return RequestState.Executed;
-        } else if (block.timestamp >= add256(request.eta, request.endTime)) {
+        } else if (block.timestamp >= add256(EXECUTION_PERIOD, request.endTime)) {
             return RequestState.Expired;
         } else if (request.votes >= quorumVotes()) {
             return RequestState.Succeeded;
@@ -186,7 +184,6 @@ contract Pauser is UpgradeableClaimable {
         PauseRequest memory newRequest = PauseRequest({
             id: requestCount,
             requester: msg.sender,
-            eta: EXECUTION_PERIOD,
             targets: targets,
             methods: methods,
             startBlock: startBlock,

--- a/contracts/governance/Timelock.sol
+++ b/contracts/governance/Timelock.sol
@@ -11,7 +11,7 @@ pragma solidity ^0.6.10;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import {UpgradeableClaimable} from "../common/UpgradeableClaimable.sol";
-import {OwnedUpgradeabilityProxy} from "../proxy/OwnedUpgradeabilityProxy.sol";
+import {IOwnedUpgradeabilityProxy} from "../proxy/interface/IOwnedUpgradeabilityProxy.sol";
 import {ImplementationReference} from "../proxy/ImplementationReference.sol";
 import {IPauseableContract} from "../common/interface/IPauseableContract.sol";
 
@@ -44,7 +44,7 @@ contract Timelock is UpgradeableClaimable {
     event NewPauser(address indexed newPauser);
     event NewPendingAdmin(address indexed newPendingAdmin);
     event NewDelay(uint indexed newDelay);
-    event EmergencyPauseProxy(OwnedUpgradeabilityProxy proxy);
+    event EmergencyPauseProxy(IOwnedUpgradeabilityProxy proxy);
     event EmergencyPauseReference(ImplementationReference implementationReference);
     event PauseStatusChanged(address pauseContract, bool status);
     event CancelTransaction(bytes32 indexed txHash, address indexed target, uint value, string signature,  bytes data, uint eta);
@@ -91,7 +91,7 @@ contract Timelock is UpgradeableClaimable {
      * Upgrades a proxy to the zero address in order to emergency pause
      * @param proxy Proxy to upgrade to zero address
      */
-    function emergencyPauseProxy(OwnedUpgradeabilityProxy proxy) external {
+    function emergencyPauseProxy(IOwnedUpgradeabilityProxy proxy) external {
         require(msg.sender == address(this) || msg.sender == pauser, "Timelock::emergencyPauseProxy: Call must come from Timelock or pauser.");
         require(address(proxy) != address(this), "Timelock::emergencyPauseProxy: Cannot pause Timelock.");
         require(address(proxy) != address(admin), "Timelock:emergencyPauseProxy: Cannot pause admin.");

--- a/contracts/governance/interface/ITimelock.sol
+++ b/contracts/governance/interface/ITimelock.sol
@@ -2,6 +2,10 @@
 
 pragma solidity ^0.6.10;
 
+import {IOwnedUpgradeabilityProxy} from "../../proxy/interface/IOwnedUpgradeabilityProxy.sol";
+import {ImplementationReference} from "../../proxy/ImplementationReference.sol";
+import {IPauseableContract} from "../../common/interface/IPauseableContract.sol";
+
 interface ITimelock {
     function delay() external view returns (uint256);
 
@@ -34,4 +38,10 @@ interface ITimelock {
         bytes calldata data,
         uint256 eta
     ) external payable returns (bytes memory);
+
+    function emergencyPauseProxy(IOwnedUpgradeabilityProxy proxy) external;
+
+    function emergencyPauseReference(ImplementationReference implementationReference) external;
+
+    function setPauseStatus(IPauseableContract pauseContract, bool status) external;
 }

--- a/test/governance/Pauser.test.ts
+++ b/test/governance/Pauser.test.ts
@@ -1,0 +1,52 @@
+import { Timelock, TrustToken, Pauser, Timelock__factory, TrustToken__factory, Pauser__factory, OwnedUpgradeabilityProxy } from "contracts";
+import { expect, use } from "chai";
+import { solidity } from "ethereum-waffle";
+import { providers, Wallet } from "ethers";
+import { beforeEachWithFixture, DAY, parseTRU } from "utils";
+import { deployContract } from 'scripts/utils/deployContract'
+
+use(solidity)
+
+describe('Pauser', () => {
+  let owner: Wallet, holder1: Wallet, holder2: Wallet, holder3: Wallet
+  let timelock: Timelock
+  let trustToken: TrustToken
+  let stkTru: TrustToken
+  let pauser: Pauser
+  let provider: providers.JsonRpcProvider
+
+  beforeEachWithFixture(async (wallets, _provider) => {
+    [owner, holder1, holder2] = wallets
+    provider = _provider
+
+    timelock = await deployContract(owner, Timelock__factory)
+    trustToken = await deployContract(owner, TrustToken__factory)
+    stkTru = await deployContract(owner, TrustToken__factory)
+    pauser = await deployContract(owner, Pauser__factory)
+
+    await timelock.initialize(owner.address, 200000)
+    await trustToken.initialize()
+    await stkTru.initialize()
+    await pauser.initialize(timelock.address, trustToken.address, stkTru.address, DAY)
+
+    await timelock.setPauser(pauser.address)
+  })
+
+  describe('initializer', () => {
+    it('sets timelock address', async () => {
+      expect(await pauser.timelock()).to.eq(timelock.address)
+    })
+
+    it('sets trust token address', async () => {
+      expect(await pauser.trustToken()).to.eq(trustToken.address)
+    })
+
+    it('sets staked tru address', async () => {
+      expect(await pauser.stkTRU()).to.eq(stkTru.address)
+    })
+
+    it('sets voting period', async () => {
+      expect(await pauser.votingPeriod()).to.eq(DAY)
+    })
+  })
+})

--- a/test/governance/Pauser.test.ts
+++ b/test/governance/Pauser.test.ts
@@ -1,16 +1,17 @@
-import { Timelock, TrustToken, Pauser, Timelock__factory, TrustToken__factory, Pauser__factory, OwnedUpgradeabilityProxy, OwnedProxyWithReference, ImplementationReference, MockPauseableContract, OwnedUpgradeabilityProxy__factory, OwnedProxyWithReference__factory, ImplementationReference__factory, MockPauseableContract__factory } from "contracts";
-import { expect, use } from "chai";
-import { solidity } from "ethereum-waffle";
-import { providers, Wallet } from "ethers";
-import { beforeEachWithFixture, DAY, parseTRU } from "utils";
+import { Timelock, TrustToken, Pauser, Timelock__factory, TrustToken__factory, Pauser__factory, OwnedUpgradeabilityProxy, OwnedProxyWithReference, ImplementationReference, MockPauseableContract, OwnedUpgradeabilityProxy__factory, OwnedProxyWithReference__factory, ImplementationReference__factory, MockPauseableContract__factory } from 'contracts'
+import { expect, use } from 'chai'
+import { solidity } from 'ethereum-waffle'
+import { BigNumber, providers, Wallet } from 'ethers'
+import { beforeEachWithFixture, DAY, parseTRU, timeTravel } from 'utils'
+import { AddressZero } from '@ethersproject/constants'
 import { deployContract } from 'scripts/utils/deployContract'
 
 use(solidity)
 
 describe('Pauser', () => {
   enum RequestState {
-    Pending, Active, Succeeded, Expired, Executed
-  } 
+    Active, Succeeded, Defeated, Expired, Executed
+  }
   enum PausingMethod { Status, Proxy, Reference }
 
   let owner: Wallet, holder1: Wallet, holder2: Wallet, holder3: Wallet
@@ -27,17 +28,22 @@ describe('Pauser', () => {
   let target: string[]
   let methods: PausingMethod[]
 
+  const votesAmount = parseTRU(50e6)
+
   beforeEachWithFixture(async (wallets, _provider) => {
     [owner, holder1, holder2, holder3] = wallets
     provider = _provider
+    await provider.send('hardhat_reset', [])
+
+    const randomAddress = Wallet.createRandom().address
 
     timelock = await deployContract(owner, Timelock__factory)
     trustToken = await deployContract(owner, TrustToken__factory)
     stkTru = await deployContract(owner, TrustToken__factory)
     pauser = await deployContract(owner, Pauser__factory)
     standardProxy = await deployContract(owner, OwnedUpgradeabilityProxy__factory)
-    reference = await deployContract(owner, ImplementationReference__factory, [owner.address])
-    referenceProxy = await deployContract(owner, OwnedProxyWithReference__factory, [owner.address, reference.address])
+    reference = await deployContract(owner, ImplementationReference__factory, [randomAddress])
+    referenceProxy = await deployContract(owner, OwnedProxyWithReference__factory, [timelock.address, reference.address])
     pauseable = await deployContract(owner, MockPauseableContract__factory)
 
     await timelock.initialize(owner.address, 200000)
@@ -45,12 +51,28 @@ describe('Pauser', () => {
     await stkTru.initialize()
     await pauser.initialize(timelock.address, trustToken.address, stkTru.address, DAY)
 
-    await stkTru.mint(holder1.address, parseTRU(25e5))
+    await stkTru.mint(holder1.address, votesAmount.div(2))
     await stkTru.connect(holder1).delegate(holder1.address)
+
+    await stkTru.mint(holder2.address, votesAmount.div(2))
+    await stkTru.connect(holder2).delegate(holder2.address)
+
+    await trustToken.mint(holder3.address, votesAmount.div(2))
+    await trustToken.connect(holder3).delegate(holder3.address)
 
     await timelock.setPauser(pauser.address)
 
-    target = [standardProxy.address, referenceProxy.address, pauseable.address]
+    await standardProxy.upgradeTo(randomAddress)
+    await standardProxy.transferProxyOwnership(timelock.address)
+    await reference.transferOwnership(timelock.address)
+    const block = await provider.getBlock('latest')
+    await timelock.queueTransaction(standardProxy.address, 0, 'claimProxyOwnership()', '0x', block.timestamp + 200100)
+    await timelock.queueTransaction(reference.address, 0, 'claimOwnership()', '0x', block.timestamp + 200100)
+    await timeTravel(standardProxy.provider as any, 200200)
+    await timelock.executeTransaction(standardProxy.address, 0, 'claimProxyOwnership()', '0x', block.timestamp + 200100)
+    await timelock.executeTransaction(reference.address, 0, 'claimOwnership()', '0x', block.timestamp + 200100)
+
+    target = [standardProxy.address, reference.address, pauseable.address]
     methods = [PausingMethod.Proxy, PausingMethod.Reference, PausingMethod.Status]
   })
 
@@ -81,8 +103,8 @@ describe('Pauser', () => {
     })
 
     describe('reverts if', () => {
-      it('requester has not enough votes', async () => {
-        await expect(pauser.connect(holder2).makeRequest([], []))
+      it('requester does not have enough votes', async () => {
+        await expect(pauser.connect(owner).makeRequest([], []))
           .to.be.revertedWith('Pauser::makeRequest: requester votes below request threshold')
       })
 
@@ -106,13 +128,193 @@ describe('Pauser', () => {
     })
 
     it('creates request with correct parameters', async () => {
-      const timestamp = (await provider.getBlock(await provider.getBlockNumber())).timestamp
-      await pauser.connect(holder1).makeRequest(target, methods)
+      const tx = await (await pauser.connect(holder1).makeRequest(target, methods)).wait()
+      const timestamp = (await provider.getBlock(tx.blockNumber)).timestamp
       const id = await pauser.latestRequestIds(holder1.address)
       const request = await pauser.requests(id)
-      expect(request.startTime).to.be.gt(timestamp)
-      expect(request.endTime.sub(request.startTime)).to.equal(DAY)
+      expect(request.startBlock).to.equal(tx.blockNumber)
+      expect(request.endTime).to.equal(timestamp + DAY)
       expect(request.requester).to.equal(holder1.address)
+    })
+  })
+
+  describe('castVote', () => {
+    beforeEach(async () => {
+      await trustToken.mint(owner.address, votesAmount)
+      await trustToken.delegate(owner.address)
+      await pauser.connect(holder1).makeRequest(target, methods)
+      await pauser.connect(holder1).castVote(1)
+    })
+
+    describe('after initialHolder casts vote', () => {
+      it('request state becomes active', async () => {
+        expect(await pauser.state(1)).to.eq(RequestState.Active)
+      })
+
+      describe('returns the right number of votes', () => {
+        it('single voter', async () => {
+          expect((await pauser.requests(1)).votes).to.eq(votesAmount.div(2))
+        })
+
+        it('multiple voters', async () => {
+          await pauser.castVote(1)
+          expect((await pauser.requests(1)).votes).to.eq(votesAmount.mul(3).div(2))
+        })
+      })
+
+      it('cant vote again', async () => {
+        await expect(pauser.connect(holder1).castVote(1))
+          .to.be.revertedWith('Pauser::_castVote: voter already voted')
+      })
+
+      it('cant vote after voting is over', async () => {
+        await timeTravel(provider, DAY)
+        await expect(pauser.castVote(1))
+          .to.be.revertedWith('Pauser::_castVote: voting is closed')
+      })
+    })
+  })
+
+  describe('execute', () => {
+    const newRequestId = 1
+    beforeEach(async () => {
+      await pauser.connect(holder1).makeRequest(target, methods)
+    })
+
+    describe('reverts if', () => {
+      it('not enough votes - active', async () => {
+        await pauser.connect(holder1).castVote(newRequestId)
+        await expect(pauser.connect(owner).execute(newRequestId))
+          .to.be.revertedWith('Pauser::execute: request can only be executed if it is succeeded')
+        expect(await pauser.state(newRequestId)).to.eq(RequestState.Active)
+      })
+
+      it('not enough votes - not active', async () => {
+        await pauser.connect(holder1).castVote(newRequestId)
+        await timeTravel(provider, DAY)
+        await expect(pauser.connect(owner).execute(newRequestId))
+          .to.be.revertedWith('Pauser::execute: request can only be executed if it is succeeded')
+        expect(await pauser.state(newRequestId)).to.eq(RequestState.Defeated)
+      })
+
+      it('request expired', async () => {
+        await pauser.connect(holder1).castVote(newRequestId)
+        await pauser.connect(holder2).castVote(newRequestId)
+        await timeTravel(provider, 2 * DAY)
+        await expect(pauser.connect(owner).execute(newRequestId))
+          .to.be.revertedWith('Pauser::execute: request can only be executed if it is succeeded')
+        expect(await pauser.state(newRequestId)).to.eq(RequestState.Expired)
+      })
+
+      it('request already executed', async () => {
+        await pauser.connect(holder1).castVote(newRequestId)
+        await pauser.connect(holder2).castVote(newRequestId)
+        await pauser.execute(newRequestId)
+        await expect(pauser.connect(owner).execute(newRequestId))
+          .to.be.revertedWith('Pauser::execute: request can only be executed if it is succeeded')
+        expect(await pauser.state(newRequestId)).to.eq(RequestState.Executed)
+      })
+    })
+
+    describe('executes', () => {
+      it('one vote token used', async () => {
+        await pauser.connect(holder1).castVote(newRequestId)
+        await pauser.connect(holder2).castVote(newRequestId)
+        await expect(pauser.connect(owner).execute(newRequestId))
+          .not.to.be.reverted
+      })
+
+      it('mixed vote token used', async () => {
+        await pauser.connect(holder1).castVote(newRequestId)
+        await pauser.connect(holder3).castVote(newRequestId)
+        await expect(pauser.connect(owner).execute(newRequestId))
+          .not.to.be.reverted
+      })
+    })
+
+    describe('pauses requested contracts', () => {
+      beforeEach(async () => {
+        await pauser.connect(holder1).castVote(newRequestId)
+        await pauser.connect(holder2).castVote(newRequestId)
+        await pauser.execute(newRequestId)
+      })
+
+      it('pauses regular proxy', async () => {
+        expect(await standardProxy.implementation()).to.eq(AddressZero)
+      })
+
+      it('pauses reference proxy', async () => {
+        expect(await referenceProxy.implementation()).to.eq(AddressZero)
+      })
+
+      it('pauses pausable contract', async () => {
+        expect(await pauseable.pauseStatus()).to.eq(true)
+      })
+    })
+  })
+
+  describe('getActions', async () => {
+    it('gets no actions from request that doesn\'t exist', async () => {
+      const tx = await pauser.getActions(42)
+      for (const k in tx) {
+        expect(tx[k]).to.eql([])
+      }
+    })
+
+    it('gets actions from existing proposal', async () => {
+      await pauser.connect(holder1).makeRequest(target, methods)
+      const tx = await pauser.getActions(1)
+      expect(tx[0]).to.eql(target)
+      expect(tx[1]).to.eql(methods)
+    })
+  })
+
+  describe('getReceipt', async () => {
+    interface Receipt {
+      hasVoted: boolean,
+      votes: BigNumber,
+    }
+
+    describe('gets default receipt if', async () => {
+      it('provided requestId is invalid', async () => {
+        const tx = await pauser.getReceipt(42, AddressZero)
+        const { hasVoted, votes }: Receipt = tx
+        expect(hasVoted).to.be.false
+        expect(votes.toNumber()).to.be.eq(0)
+      })
+
+      it('provided voter address is invalid', async () => {
+        await pauser.connect(holder1).makeRequest(target, methods)
+        const tx = await pauser.getReceipt(42, AddressZero)
+        const { hasVoted, votes }: Receipt = tx
+        expect(hasVoted).to.be.false
+        expect(votes.toNumber()).to.be.eq(0)
+      })
+    })
+
+    describe('gets a receipt when', async () => {
+      beforeEach(async () => {
+        await trustToken.mint(owner.address, votesAmount.mul(2))
+        await trustToken.delegate(owner.address)
+        await pauser.connect(holder1).makeRequest(target, methods)
+        await timeTravel(provider, 1)
+      })
+
+      it('holder votes with TRU', async () => {
+        await pauser.connect(holder1).castVote(1)
+        const tx = await pauser.getReceipt(1, holder1.address)
+        const { hasVoted, votes }: Receipt = tx
+        expect(hasVoted).to.be.true
+        expect(votes.toNumber()).to.be.eq(votesAmount.div(2))
+      })
+
+      it('holder votes with stkTRU', async () => {
+        await pauser.connect(holder3).castVote(1)
+        const tx = await pauser.getReceipt(1, holder3.address)
+        const { hasVoted, votes }: Receipt = tx
+        expect(hasVoted).to.be.true
+        expect(votes).to.be.eq(votesAmount.div(2))
+      })
     })
   })
 })

--- a/test/governance/Pauser.test.ts
+++ b/test/governance/Pauser.test.ts
@@ -83,25 +83,25 @@ describe('Pauser', () => {
     describe('reverts if', () => {
       it('requester has not enough votes', async () => {
         await expect(pauser.connect(holder2).makeRequest([], []))
-          .to.be.revertedWith('Pauser::request: requester votes below request threshold')
+          .to.be.revertedWith('Pauser::makeRequest: requester votes below request threshold')
       })
 
       it('targets length does not match methods length', async () => {
         await expect(pauser.connect(holder1).makeRequest([standardProxy.address, referenceProxy.address], [PausingMethod.Proxy]))
-          .to.be.revertedWith('Pauser::request: request function information arity mismatch')
+          .to.be.revertedWith('Pauser::makeRequest: request function information arity mismatch')
 
         await expect(pauser.connect(holder1).makeRequest([standardProxy.address], [PausingMethod.Proxy, PausingMethod.Reference]))
-          .to.be.revertedWith('Pauser::request: request function information arity mismatch')
+          .to.be.revertedWith('Pauser::makeRequest: request function information arity mismatch')
       })
 
       it('no actions provided', async () => {
         await expect(pauser.connect(holder1).makeRequest([], []))
-          .to.be.revertedWith('Pauser::request: must provide actions')
+          .to.be.revertedWith('Pauser::makeRequest: must provide actions')
       })
 
       it('too many actions provided', async () => {
         await expect(pauser.connect(holder1).makeRequest(Array(11).fill(standardProxy.address), Array(11).fill(PausingMethod.Proxy)))
-          .to.be.revertedWith('Pauser::request: too many actions')
+          .to.be.revertedWith('Pauser::makeRequest: too many actions')
       })
     })
 

--- a/test/governance/Pauser.test.ts
+++ b/test/governance/Pauser.test.ts
@@ -1,4 +1,4 @@
-import { Timelock, TrustToken, Pauser, Timelock__factory, TrustToken__factory, Pauser__factory, OwnedUpgradeabilityProxy } from "contracts";
+import { Timelock, TrustToken, Pauser, Timelock__factory, TrustToken__factory, Pauser__factory, OwnedUpgradeabilityProxy, OwnedProxyWithReference, ImplementationReference, MockPauseableContract, OwnedUpgradeabilityProxy__factory, OwnedProxyWithReference__factory, ImplementationReference__factory, MockPauseableContract__factory } from "contracts";
 import { expect, use } from "chai";
 import { solidity } from "ethereum-waffle";
 import { providers, Wallet } from "ethers";
@@ -8,28 +8,50 @@ import { deployContract } from 'scripts/utils/deployContract'
 use(solidity)
 
 describe('Pauser', () => {
+  enum RequestState {
+    Pending, Active, Succeeded, Expired, Executed
+  } 
+  enum PausingMethod { Status, Proxy, Reference }
+
   let owner: Wallet, holder1: Wallet, holder2: Wallet, holder3: Wallet
   let timelock: Timelock
   let trustToken: TrustToken
   let stkTru: TrustToken
   let pauser: Pauser
+  let standardProxy: OwnedUpgradeabilityProxy
+  let referenceProxy: OwnedProxyWithReference
+  let reference: ImplementationReference
+  let pauseable: MockPauseableContract
   let provider: providers.JsonRpcProvider
 
+  let target: string[]
+  let methods: PausingMethod[]
+
   beforeEachWithFixture(async (wallets, _provider) => {
-    [owner, holder1, holder2] = wallets
+    [owner, holder1, holder2, holder3] = wallets
     provider = _provider
 
     timelock = await deployContract(owner, Timelock__factory)
     trustToken = await deployContract(owner, TrustToken__factory)
     stkTru = await deployContract(owner, TrustToken__factory)
     pauser = await deployContract(owner, Pauser__factory)
+    standardProxy = await deployContract(owner, OwnedUpgradeabilityProxy__factory)
+    reference = await deployContract(owner, ImplementationReference__factory, [owner.address])
+    referenceProxy = await deployContract(owner, OwnedProxyWithReference__factory, [owner.address, reference.address])
+    pauseable = await deployContract(owner, MockPauseableContract__factory)
 
     await timelock.initialize(owner.address, 200000)
     await trustToken.initialize()
     await stkTru.initialize()
     await pauser.initialize(timelock.address, trustToken.address, stkTru.address, DAY)
 
+    await stkTru.mint(holder1.address, parseTRU(25e5))
+    await stkTru.connect(holder1).delegate(holder1.address)
+
     await timelock.setPauser(pauser.address)
+
+    target = [standardProxy.address, referenceProxy.address, pauseable.address]
+    methods = [PausingMethod.Proxy, PausingMethod.Reference, PausingMethod.Status]
   })
 
   describe('initializer', () => {
@@ -47,6 +69,50 @@ describe('Pauser', () => {
 
     it('sets voting period', async () => {
       expect(await pauser.votingPeriod()).to.eq(DAY)
+    })
+  })
+
+  describe('makeRequest', () => {
+    describe('get request ID', () => {
+      it('returns id equals to 1', async () => {
+        await pauser.connect(holder1).makeRequest(target, methods)
+        expect(await pauser.latestRequestIds(holder1.address)).to.eq(1)
+      })
+    })
+
+    describe('reverts if', () => {
+      it('requester has not enough votes', async () => {
+        await expect(pauser.connect(holder2).makeRequest([], []))
+          .to.be.revertedWith('Pauser::request: requester votes below request threshold')
+      })
+
+      it('targets length does not match methods length', async () => {
+        await expect(pauser.connect(holder1).makeRequest([standardProxy.address, referenceProxy.address], [PausingMethod.Proxy]))
+          .to.be.revertedWith('Pauser::request: request function information arity mismatch')
+
+        await expect(pauser.connect(holder1).makeRequest([standardProxy.address], [PausingMethod.Proxy, PausingMethod.Reference]))
+          .to.be.revertedWith('Pauser::request: request function information arity mismatch')
+      })
+
+      it('no actions provided', async () => {
+        await expect(pauser.connect(holder1).makeRequest([], []))
+          .to.be.revertedWith('Pauser::request: must provide actions')
+      })
+
+      it('too many actions provided', async () => {
+        await expect(pauser.connect(holder1).makeRequest(Array(11).fill(standardProxy.address), Array(11).fill(PausingMethod.Proxy)))
+          .to.be.revertedWith('Pauser::request: too many actions')
+      })
+    })
+
+    it('creates request with correct parameters', async () => {
+      const timestamp = (await provider.getBlock(await provider.getBlockNumber())).timestamp
+      await pauser.connect(holder1).makeRequest(target, methods)
+      const id = await pauser.latestRequestIds(holder1.address)
+      const request = await pauser.requests(id)
+      expect(request.startTime).to.be.gt(timestamp)
+      expect(request.endTime.sub(request.startTime)).to.equal(DAY)
+      expect(request.requester).to.equal(holder1.address)
     })
   })
 })


### PR DESCRIPTION
This is actually really similar to our already developed Governance contract.
It is meant to allow for pausing owned by Timelock contracts, when such a pause request accumulates at least 50M TRU/stkTRU votes.