### PR TITLE
discount tru price from legacy truefi pool

### DIFF
--- a/contracts/truefi/TrueFiPool.sol
+++ b/contracts/truefi/TrueFiPool.sol
@@ -356,7 +356,7 @@ contract TrueFiPool is ITrueFiPool, IPauseableContract, ERC20, ReentrancyGuard, 
      */
     function poolValue() public view returns (uint256) {
         // this assumes defaulted loans are worth their full value
-        return liquidValue().add(loansValue()).add(truValue()).add(crvValue());
+        return liquidValue().add(loansValue()).add(crvValue());
     }
 
     /**

--- a/test/truefi/TrueFiPool.test.ts
+++ b/test/truefi/TrueFiPool.test.ts
@@ -135,7 +135,7 @@ describe('TrueFiPool', () => {
       expectScaledCloseTo(await pool.poolValue(), parseEth(9e6).add(parseEth(105e4)).add(calcBorrowerFee(parseEth(2e6))))
     })
 
-    it('loan tokens + tusd + curve liquidity + tru tokens', async () => {
+    it('loan tokens + tusd + curve liquidity', async () => {
       await token.approve(pool.address, includeFee(parseEth(1e7)))
       await pool.join(includeFee(parseEth(1e7)))
       const loan1 = await new LoanToken__factory(owner).deploy(token.address, borrower.address, lender.address, lender.address, parseEth(1e6), dayInSeconds * 365, 1000)
@@ -149,10 +149,10 @@ describe('TrueFiPool', () => {
       expectScaledCloseTo(await pool.poolValue(), parseEth(4e6).add(parseEth(105e4).add(parseEth(1e7))).add(calcBorrowerFee(parseEth(2e6))))
       await trustToken.mint(pool.address, parseTRU(4e5))
       expect(await pool.truValue()).to.equal(parseEth(98000)) // 100000 - 2%
-      expectScaledCloseTo(await pool.poolValue(), parseEth(4e6).add(parseEth(105e4).add(parseEth(1e7)).add(parseEth(98000))).add(calcBorrowerFee(parseEth(2e6))))
+      expectScaledCloseTo(await pool.poolValue(), parseEth(4e6).add(parseEth(105e4).add(parseEth(1e7))).add(calcBorrowerFee(parseEth(2e6))))
       await mockCrv.mint(pool.address, parseEth(1e5))
       expect(await pool.crvValue()).to.equal(parseEth(4.9e4)) // 50000 - 2%
-      expectScaledCloseTo(await pool.poolValue(), parseEth(4e6).add(parseEth(105e4).add(parseEth(1e7)).add(parseEth(98000))).add(parseEth(4.9e4)).add(calcBorrowerFee(parseEth(2e6))))
+      expectScaledCloseTo(await pool.poolValue(), parseEth(4e6).add(parseEth(105e4).add(parseEth(1e7))).add(parseEth(4.9e4)).add(calcBorrowerFee(parseEth(2e6))))
     })
   })
 


### PR DESCRIPTION
We want to be conservative when estimating the price of the legacy pool, so I removed the TRU value from the pool calculations. Pricing & managing liquidated TRU will be handled in the next minor upgrade to TrueFi. For now we are skipping the tests that calculate this as well.