### PR TITLE
Deploy tfUSDC distributor + farm to ropsten

### DIFF
--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -66,6 +66,8 @@ deploy({}, (_, config) => {
   const poolFactory_impl = contract(PoolFactory)
   const liquidator2_impl = contract(Liquidator2)
   const loanFactory2_impl = contract(LoanFactory2)
+  const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
 
   // New contract proxies
   const trueLender2 = proxy(trueLender2_impl, () => {})
@@ -91,10 +93,10 @@ deploy({}, (_, config) => {
   runIf(trueLender2.feePool().equals(AddressZero), () => {
     trueLender2.setFeePool(usdc_TrueFiPool2)
   })
-  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor), 'initialize',
+  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, 'initialize',
     [deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, usdc_TrueFiPool2],
   )
-  const usdc_TrueFiPool2_TrueFarm = proxy(contract('usdc_TrueFiPool2_TrueFarm', TrueFarm), () => {})
+  const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
   runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
     usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
   })

--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -1,6 +1,7 @@
 import { contract, createProxy, deploy, runIf } from 'ethereum-mars'
 import {
   ImplementationReference,
+  LinearTrueDistributor,
   Liquidator2,
   LoanFactory2, Mock1InchV3,
   TestUSDCToken,
@@ -10,22 +11,32 @@ import {
   TestTrueFiPool,
   TestTrustToken,
   TimeOwnedUpgradeabilityProxy,
+  TrueFarm,
   TrueFiPool,
   TrueFiPool2,
   TrueLender2,
   TrueRatingAgencyV2,
   TrustToken,
 } from '../build/artifacts'
+import { utils } from 'ethers'
 import { AddressZero } from '@ethersproject/constants'
+
+const DAY = 60 * 60 * 24
 
 // TODO set this properly for testnets or deploy a mock
 const ONE_INCH_EXCHANGE = '0x11111112542d85b3ef69ae05771c2dccff4faa26'
 const deployParams = {
   mainnet: {
     USDC: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    DISTRIBUTION_DURATION: 180 * DAY,
+    DISTRIBUTION_START: Date.parse('04/24/2021') / 1000,
+    STAKE_DISTRIBUTION_AMOUNT: utils.parseUnits('10', 8),
   },
   testnet: {
     LOAN_INTEREST_FEE: 500,
+    DISTRIBUTION_DURATION: 180 * DAY,
+    DISTRIBUTION_START: Date.parse('04/24/2021') / 1000,
+    STAKE_DISTRIBUTION_AMOUNT: utils.parseUnits('10', 8),
   },
 }
 
@@ -33,6 +44,7 @@ deploy({}, (_, config) => {
   const proxy = createProxy(OwnedUpgradeabilityProxy)
   const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
   const isMainnet = config.network === 'mainnet'
+  const NETWORK = isMainnet ? 'mainnet' : 'testnet'
 
   // Existing contracts
   const trustToken = isMainnet
@@ -72,6 +84,16 @@ deploy({}, (_, config) => {
   const usdc_TrueFiPool2 = poolFactory.pool(usdc)
   runIf(trueLender2.feePool().equals(AddressZero), () => {
     trueLender2.setFeePool(usdc_TrueFiPool2)
+  })
+  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor), 'initialize',
+    [deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, usdc_TrueFiPool2],
+  )
+  const usdc_TrueFiPool2_TrueFarm = proxy(contract('usdc_TrueFiPool2_TrueFarm', TrueFarm), () => {})
+  runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
+    usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
+  })
+  runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+    usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'tfUSDC')
   })
   if (!isMainnet) {
     trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)

--- a/deployments.json
+++ b/deployments.json
@@ -189,6 +189,22 @@
     "mock1InchV3": {
       "txHash": "0x7fc6f15137e192c4d2c2b8d24db2ed39775c5dadfa1430b08bec082a5e251435",
       "address": "0x8bb4DEA3e4D1BA6d4e28F151F1CbcB841a314dCe"
+    },
+    "usdc_TrueFiPool2_LinearTrueDistributor": {
+      "txHash": "0x2ad9eb9ab31fd8ca0448a1f447fd12461bd4bd960f2c65568a384bc4f2bca9ee",
+      "address": "0x8CAf88f3463000E50fFec881805e29A628c87D04"
+    },
+    "usdc_TrueFiPool2_LinearTrueDistributor_proxy": {
+      "txHash": "0x39efe349d5f76740b2d4740f96179faa950de8c989dc16c0447dbeb318846e5f",
+      "address": "0xB3fa96579cCc4769DeEa5B08fCFbC56A34996480"
+    },
+    "usdc_TrueFiPool2_TrueFarm": {
+      "txHash": "0x15feee9fc0add36164b1a294f6f7df74d05348401c52a639e0243bdb439c5c38",
+      "address": "0xc3c32872920103900525F1e7F323De52610e572e"
+    },
+    "usdc_TrueFiPool2_TrueFarm_proxy": {
+      "txHash": "0xa50ffd39cca1bfdd42078164d51c6e1539fae370ad1d956d28213f0983190b90",
+      "address": "0x3b375F0426cc592D2991Dc43B3b90F691cD900Ff"
     }
   },
   "mainnet": {


### PR DESCRIPTION
I based this PR on the existing tfTUSD distributor (LinearTrueDistributor) and farm (TrueFarm), copying over the same test constructor values (which will of course need to be modified before deploying to mainnet).