### PR TITLE
Deploy credit oracle to ropsten and mainnet

### DIFF
--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -47,87 +47,87 @@ const deployParams = {
 
 deploy({}, (_, config) => {
   const proxy = createProxy(OwnedUpgradeabilityProxy)
-  // const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
-  // const isMainnet = config.network === 'mainnet'
-  // const NETWORK = isMainnet ? 'mainnet' : 'testnet'
+  const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
+  const isMainnet = config.network === 'mainnet'
+  const NETWORK = isMainnet ? 'mainnet' : 'testnet'
 
-  // // Existing contracts
-  // const trustToken = isMainnet
-  //   ? timeProxy(contract(TrustToken), () => {})
-  //   : timeProxy(contract(TestTrustToken), () => {})
-  // const stkTruToken = proxy(contract(StkTruToken), () => {})
-  // const trueFiPool = isMainnet
-  //   ? proxy(contract(TrueFiPool), () => {})
-  //   : proxy(contract(TestTrueFiPool), () => {})
-  // const usdc = isMainnet
-  //   ? deployParams['mainnet'].USDC
-  //   : contract(TestUSDCToken)
-  // const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
+  // Existing contracts
+  const trustToken = isMainnet
+    ? timeProxy(contract(TrustToken), () => {})
+    : timeProxy(contract(TestTrustToken), () => {})
+  const stkTruToken = proxy(contract(StkTruToken), () => {})
+  const trueFiPool = isMainnet
+    ? proxy(contract(TrueFiPool), () => {})
+    : proxy(contract(TestTrueFiPool), () => {})
+  const usdc = isMainnet
+    ? deployParams['mainnet'].USDC
+    : contract(TestUSDCToken)
+  const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
 
-  // // New contract impls
-  // const trueLender2_impl = contract(TrueLender2)
-  // const poolFactory_impl = contract(PoolFactory)
-  // const liquidator2_impl = contract(Liquidator2)
-  // const loanFactory2_impl = contract(LoanFactory2)
-  // const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  // const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
+  // New contract impls
+  const trueLender2_impl = contract(TrueLender2)
+  const poolFactory_impl = contract(PoolFactory)
+  const liquidator2_impl = contract(Liquidator2)
+  const loanFactory2_impl = contract(LoanFactory2)
+  const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
   const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
 
-  // // New contract proxies
-  // const trueLender2 = proxy(trueLender2_impl, () => {})
-  // const poolFactory = proxy(poolFactory_impl, () => {})
-  // const liquidator2 = proxy(liquidator2_impl, () => {})
-  // const loanFactory2 = proxy(loanFactory2_impl, () => {})
-  // const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  // const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
+  // New contract proxies
+  const trueLender2 = proxy(trueLender2_impl, () => {})
+  const poolFactory = proxy(poolFactory_impl, () => {})
+  const liquidator2 = proxy(liquidator2_impl, () => {})
+  const loanFactory2 = proxy(loanFactory2_impl, () => {})
+  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
   const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
 
-  // // New bare contracts
-  // const trueFiPool2 = contract(TrueFiPool2)
-  // const implementationReference = contract(ImplementationReference, [trueFiPool2])
-  // const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
-  // const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
+  // New bare contracts
+  const trueFiPool2 = contract(TrueFiPool2)
+  const implementationReference = contract(ImplementationReference, [trueFiPool2])
+  const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
+  const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
 
-  // // Contract initialization
-  // runIf(poolFactory.isInitialized().not(), () => {
-  //   poolFactory.initialize(implementationReference, trustToken, trueLender2)
-  // })
-  // runIf(trueLender2.isInitialized().not(), () => {
-  //   trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch)
-  // })
-  // runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
-  //   trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
-  // })
-  // runIf(loanFactory2.isInitialized().not(), () => {
-  //   loanFactory2.initialize(poolFactory, trueLender2, liquidator2)
-  // })
-  // runIf(liquidator2.isInitialized().not(), () => {
-  //   liquidator2.initialize(stkTruToken, trustToken, loanFactory2)
-  // })
-  // runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
-  //   poolFactory.whitelist(usdc, true)
-  //   poolFactory.createPool(usdc)
-  // })
-  // const usdc_TrueFiPool2 = poolFactory.pool(usdc)
-  // runIf(trueLender2.feePool().equals(AddressZero), () => {
-  //   trueLender2.setFeePool(usdc_TrueFiPool2)
-  // })
-  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-  //   usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  // })
-  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
-  //   usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
-  // })
-  // runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-  //   usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
-  // })
+  // Contract initialization
+  runIf(poolFactory.isInitialized().not(), () => {
+    poolFactory.initialize(implementationReference, trustToken, trueLender2)
+  })
+  runIf(trueLender2.isInitialized().not(), () => {
+    trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch)
+  })
+  runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
+    trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
+  })
+  runIf(loanFactory2.isInitialized().not(), () => {
+    loanFactory2.initialize(poolFactory, trueLender2, liquidator2)
+  })
+  runIf(liquidator2.isInitialized().not(), () => {
+    liquidator2.initialize(stkTruToken, trustToken, loanFactory2)
+  })
+  runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
+    poolFactory.whitelist(usdc, true)
+    poolFactory.createPool(usdc)
+  })
+  const usdc_TrueFiPool2 = poolFactory.pool(usdc)
+  runIf(trueLender2.feePool().equals(AddressZero), () => {
+    trueLender2.setFeePool(usdc_TrueFiPool2)
+  })
+  runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+    usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  })
+  runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
+    usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
+  })
+  runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+    usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
+  })
   runIf(trueFiCreditOracle.isInitialized().not(), () => {
     trueFiCreditOracle.initialize()
   })
-  // if (!isMainnet) {
-  //   trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
-  // }
-  // runIf(poolFactory.isPool(trueFiPool).not(), () => {
-  //   poolFactory.addLegacyPool(trueFiPool)
-  // })
+  if (!isMainnet) {
+    trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
+  }
+  runIf(poolFactory.isPool(trueFiPool).not(), () => {
+    poolFactory.addLegacyPool(trueFiPool)
+  })
 })

--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -47,87 +47,87 @@ const deployParams = {
 
 deploy({}, (_, config) => {
   const proxy = createProxy(OwnedUpgradeabilityProxy)
-  const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
-  const isMainnet = config.network === 'mainnet'
-  const NETWORK = isMainnet ? 'mainnet' : 'testnet'
+  // const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
+  // const isMainnet = config.network === 'mainnet'
+  // const NETWORK = isMainnet ? 'mainnet' : 'testnet'
 
-  // Existing contracts
-  const trustToken = isMainnet
-    ? timeProxy(contract(TrustToken), () => {})
-    : timeProxy(contract(TestTrustToken), () => {})
-  const stkTruToken = proxy(contract(StkTruToken), () => {})
-  const trueFiPool = isMainnet
-    ? proxy(contract(TrueFiPool), () => {})
-    : proxy(contract(TestTrueFiPool), () => {})
-  const usdc = isMainnet
-    ? deployParams['mainnet'].USDC
-    : contract(TestUSDCToken)
-  const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
+  // // Existing contracts
+  // const trustToken = isMainnet
+  //   ? timeProxy(contract(TrustToken), () => {})
+  //   : timeProxy(contract(TestTrustToken), () => {})
+  // const stkTruToken = proxy(contract(StkTruToken), () => {})
+  // const trueFiPool = isMainnet
+  //   ? proxy(contract(TrueFiPool), () => {})
+  //   : proxy(contract(TestTrueFiPool), () => {})
+  // const usdc = isMainnet
+  //   ? deployParams['mainnet'].USDC
+  //   : contract(TestUSDCToken)
+  // const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
 
-  // New contract impls
-  const trueLender2_impl = contract(TrueLender2)
-  const poolFactory_impl = contract(PoolFactory)
-  const liquidator2_impl = contract(Liquidator2)
-  const loanFactory2_impl = contract(LoanFactory2)
-  const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
+  // // New contract impls
+  // const trueLender2_impl = contract(TrueLender2)
+  // const poolFactory_impl = contract(PoolFactory)
+  // const liquidator2_impl = contract(Liquidator2)
+  // const loanFactory2_impl = contract(LoanFactory2)
+  // const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  // const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
   const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
 
-  // New contract proxies
-  const trueLender2 = proxy(trueLender2_impl, () => {})
-  const poolFactory = proxy(poolFactory_impl, () => {})
-  const liquidator2 = proxy(liquidator2_impl, () => {})
-  const loanFactory2 = proxy(loanFactory2_impl, () => {})
-  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
+  // // New contract proxies
+  // const trueLender2 = proxy(trueLender2_impl, () => {})
+  // const poolFactory = proxy(poolFactory_impl, () => {})
+  // const liquidator2 = proxy(liquidator2_impl, () => {})
+  // const loanFactory2 = proxy(loanFactory2_impl, () => {})
+  // const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  // const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
   const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
 
-  // New bare contracts
-  const trueFiPool2 = contract(TrueFiPool2)
-  const implementationReference = contract(ImplementationReference, [trueFiPool2])
-  const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
-  const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
+  // // New bare contracts
+  // const trueFiPool2 = contract(TrueFiPool2)
+  // const implementationReference = contract(ImplementationReference, [trueFiPool2])
+  // const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
+  // const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
 
-  // Contract initialization
-  runIf(poolFactory.isInitialized().not(), () => {
-    poolFactory.initialize(implementationReference, trustToken, trueLender2)
-  })
-  runIf(trueLender2.isInitialized().not(), () => {
-    trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch)
-  })
-  runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
-    trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
-  })
-  runIf(loanFactory2.isInitialized().not(), () => {
-    loanFactory2.initialize(poolFactory, trueLender2, liquidator2)
-  })
-  runIf(liquidator2.isInitialized().not(), () => {
-    liquidator2.initialize(stkTruToken, trustToken, loanFactory2)
-  })
-  runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
-    poolFactory.whitelist(usdc, true)
-    poolFactory.createPool(usdc)
-  })
-  const usdc_TrueFiPool2 = poolFactory.pool(usdc)
-  runIf(trueLender2.feePool().equals(AddressZero), () => {
-    trueLender2.setFeePool(usdc_TrueFiPool2)
-  })
-  runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-    usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  })
-  runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
-    usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
-  })
-  runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-    usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
-  })
+  // // Contract initialization
+  // runIf(poolFactory.isInitialized().not(), () => {
+  //   poolFactory.initialize(implementationReference, trustToken, trueLender2)
+  // })
+  // runIf(trueLender2.isInitialized().not(), () => {
+  //   trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch)
+  // })
+  // runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
+  //   trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
+  // })
+  // runIf(loanFactory2.isInitialized().not(), () => {
+  //   loanFactory2.initialize(poolFactory, trueLender2, liquidator2)
+  // })
+  // runIf(liquidator2.isInitialized().not(), () => {
+  //   liquidator2.initialize(stkTruToken, trustToken, loanFactory2)
+  // })
+  // runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
+  //   poolFactory.whitelist(usdc, true)
+  //   poolFactory.createPool(usdc)
+  // })
+  // const usdc_TrueFiPool2 = poolFactory.pool(usdc)
+  // runIf(trueLender2.feePool().equals(AddressZero), () => {
+  //   trueLender2.setFeePool(usdc_TrueFiPool2)
+  // })
+  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+  //   usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  // })
+  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
+  //   usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
+  // })
+  // runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+  //   usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
+  // })
   runIf(trueFiCreditOracle.isInitialized().not(), () => {
     trueFiCreditOracle.initialize()
   })
-  if (!isMainnet) {
-    trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
-  }
-  runIf(poolFactory.isPool(trueFiPool).not(), () => {
-    poolFactory.addLegacyPool(trueFiPool)
-  })
+  // if (!isMainnet) {
+  //   trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
+  // }
+  // runIf(poolFactory.isPool(trueFiPool).not(), () => {
+  //   poolFactory.addLegacyPool(trueFiPool)
+  // })
 })

--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -12,6 +12,7 @@ import {
   TestTrustToken,
   TimeOwnedUpgradeabilityProxy,
   TrueFarm,
+  TrueFiCreditOracle,
   TrueFiPool,
   TrueFiPool2,
   TrueLender2,
@@ -70,6 +71,7 @@ deploy({}, (_, config) => {
   const loanFactory2_impl = contract(LoanFactory2)
   const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
   const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
+  const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
 
   // New contract proxies
   const trueLender2 = proxy(trueLender2_impl, () => {})
@@ -78,6 +80,7 @@ deploy({}, (_, config) => {
   const loanFactory2 = proxy(loanFactory2_impl, () => {})
   const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
   const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
+  const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
 
   // New bare contracts
   const trueFiPool2 = contract(TrueFiPool2)
@@ -117,6 +120,9 @@ deploy({}, (_, config) => {
   })
   runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
     usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
+  })
+  runIf(trueFiCreditOracle.isInitialized().not(), () => {
+    trueFiCreditOracle.initialize()
   })
   if (!isMainnet) {
     trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)

--- a/deployments.json
+++ b/deployments.json
@@ -229,6 +229,14 @@
     "sushiTimelock": {
       "txHash": "0x136db0350b6942b6665c0fce22937906f2a6ccaeab68f9c5354cefa151712667",
       "address": "0x43c93F4A3CC43c4f4d5a2f29b8A646090A2b325f"
+    },
+    "trueFiCreditOracle": {
+      "txHash": "0x006914e44fdf135410e4ce56ac219a30adb38ff29676997afab3759b9746d7f8",
+      "address": "0x669Ef7fdebCA0100883C35a9EbdC28FcD983C63D"
+    },
+    "trueFiCreditOracle_proxy": {
+      "txHash": "0xc764b8c1db38b2e8c15d2ae032183d87caa1ce103cff95428ac3e0923650ebda",
+      "address": "0x9ff6ca759631E658444Ba85409a283f55C49bb93"
     }
   },
   "mainnet": {

--- a/deployments.json
+++ b/deployments.json
@@ -439,6 +439,14 @@
     "crvPriceOracle": {
       "txHash": "0x9f1f2a8be0574db1a0e5c2e96d861436b0112ef20c63991d4e50d235486a7d65",
       "address": "0x842D486a5d12b3729c89B0E8968C54f68eADba7c"
+    },
+    "trueFiCreditOracle": {
+      "txHash": "0xa235b90914ab19b605aa4362d4276368fa1c414607a1beb9e767e502315cf387",
+      "address": "0xf47d06C3E8734B3cc21eD3DD91dD7E100FDAeB06"
+    },
+    "trueFiCreditOracle_proxy": {
+      "txHash": "0xdd6e5f89621e4060cfce40a90b8a0d87e585805377892c827f9b69c3050dde2d",
+      "address": "0x73581551665680696946f568259977Da02e8712A"
     }
   }
 }


### PR DESCRIPTION
Commands run:
```
$ yarn deploy:truefi2 --network ropsten --verify
$ yarn deploy:truefi2 --verify
```

The second command was run after commit 624317c, which commented out everything irrelevant to deploying the credit oracle. The commenting out is reverted later in commit c0bf6cd.