### PR TITLE
Make TrueFiVault UpgradeableClaimable

### DIFF
--- a/scripts/flatten.ts
+++ b/scripts/flatten.ts
@@ -28,9 +28,5 @@ const header = `/*
 */
 
 `
-export default async (contractName: string) => {
-  console.log(`${header}
-  ${await flattenSingleFile({ sourceDirectory: 'contracts' }, contractName)}`)
-  return `${header}
-  ${await flattenSingleFile({ sourceDirectory: 'contracts' }, contractName)}`
-}
+export default async (contractName: string) => `${header}
+${await flattenSingleFile({ sourceDirectory: 'contracts' }, contractName)}`

--- a/scripts/truefi_vault_deploy.ts
+++ b/scripts/truefi_vault_deploy.ts
@@ -13,7 +13,6 @@ import {
 const beneficiary = '' // Beneficiary
 const amount = '' // (8 Decimals)
 const start = '0' // Unix Time
-const finalOwner = '0x16cEa306506c387713C70b9C1205fd5aC997E78E' // Multisig
 const txnArgs = { gasLimit: 1_000_000, gasPrice: 20_000_000_000 }
 
 // mainnet
@@ -49,12 +48,8 @@ async function deployTrueFiVault () {
   // initialize and transfer
   await (await tru.approve(vault.address, amount)).wait()
   console.log(`Approved: ${amount} TRU`)
-  await (await vault.initialize(beneficiary, finalOwner, amount, start, truAddress, stkTruAddress, txnArgs)).wait()
+  await (await vault.initialize(beneficiary, amount, start, truAddress, stkTruAddress, txnArgs)).wait()
   console.log(`Locked: ${amount} TRU`)
-  if (network === 'mainnet') {
-    await (await vaultProxy.transferProxyOwnership(finalOwner)).wait()
-    console.log(`Transfereed Proxy Ownership to: ${finalOwner}`)
-  }
 }
 
 deployTrueFiVault().catch(console.error)

--- a/test/governance/TrueFiVault.test.ts
+++ b/test/governance/TrueFiVault.test.ts
@@ -55,7 +55,6 @@ describe('TrueFiVault', () => {
     await tru.approve(trueFiVault.address, TRU_AMOUNT.add(STKTRU_AMOUNT))
     await trueFiVault.initialize(
       beneficiary.address,
-      owner.address,
       TRU_AMOUNT.add(STKTRU_AMOUNT),
       vaultStart,
       tru.address,
@@ -80,7 +79,6 @@ describe('TrueFiVault', () => {
       const vaultStart = (await provider.getBlock('latest')).timestamp + DAY
       await vault.initialize(
         beneficiary.address,
-        owner.address,
         0,
         vaultStart,
         tru.address,
@@ -94,7 +92,6 @@ describe('TrueFiVault', () => {
       const now = (await provider.getBlock('latest')).timestamp
       await expect(vault.initialize(
         beneficiary.address,
-        owner.address,
         0,
         now - 10,
         tru.address,
@@ -103,7 +100,6 @@ describe('TrueFiVault', () => {
 
       await expect(vault.initialize(
         beneficiary.address,
-        owner.address,
         0,
         now * 2,
         tru.address,
@@ -194,8 +190,8 @@ describe('TrueFiVault', () => {
         // 1/6th of stake was slashed by half, our balance is 11/12 of initial
         expect(await trueFiVault.withdrawable(stkTru.address)).to.be.closeTo(start.mul(11).div(12).mul(2), 10000)
         await trueFiVault.connect(beneficiary).withdrawStkTru(await trueFiVault.withdrawable(stkTru.address))
-        expect(await trueFiVault.withdrawable(stkTru.address)).to.be.closeTo(Zero, 10000)
-        expect(await trueFiVault.withdrawable(tru.address)).to.be.closeTo(Zero, 10000)
+        expect(await trueFiVault.withdrawable(stkTru.address)).to.be.closeTo(Zero, 100000)
+        expect(await trueFiVault.withdrawable(tru.address)).to.be.closeTo(Zero, 100000)
         await timeTravel(provider, MONTH)
         expect(await trueFiVault.withdrawable(stkTru.address)).to.be.closeTo(VEST_EACH_MONTH.mul(11).div(12).mul(2), 20000000)
         await timeTravel(provider, MONTH)


### PR DESCRIPTION
Important: we must not use this as implementation for previously deployed vaults as it will break storage. I've decided not to create multiple versions because it's unlikely we will want to change old vaults' implementation and I wanted to avoid having Vault and Vault2 in the repo 