### PR TITLE
Fix Ropsten tfUSDT farm + distributor proxies

### DIFF
--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -58,83 +58,83 @@ deploy({}, (_, config) => {
   const trustToken = isMainnet
     ? timeProxy(contract(TrustToken), () => {})
     : timeProxy(contract(TestTrustToken), () => {})
-  // const stkTruToken = proxy(contract(StkTruToken), () => {})
-  // const trueFiPool = isMainnet
-  //   ? proxy(contract(TrueFiPool), () => {})
-  //   : proxy(contract(TestTrueFiPool), () => {})
-  // const usdc = isMainnet
-  //   ? deployParams['mainnet'].USDC
-  //   : contract(TestUSDCToken)
+  const stkTruToken = proxy(contract(StkTruToken), () => {})
+  const trueFiPool = isMainnet
+    ? proxy(contract(TrueFiPool), () => {})
+    : proxy(contract(TestTrueFiPool), () => {})
+  const usdc = isMainnet
+    ? deployParams['mainnet'].USDC
+    : contract(TestUSDCToken)
   const usdt = isMainnet
     ? deployParams['mainnet'].USDT
     : contract(TestUSDTToken)
-  // const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
+  const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
 
   // New contract impls
-  // const trueLender2_impl = contract(TrueLender2)
+  const trueLender2_impl = contract(TrueLender2)
   const poolFactory_impl = contract(PoolFactory)
-  // const liquidator2_impl = contract(Liquidator2)
-  // const loanFactory2_impl = contract(LoanFactory2)
-  // const safu_impl = contract(SAFU)
-  // const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  // const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
+  const liquidator2_impl = contract(Liquidator2)
+  const loanFactory2_impl = contract(LoanFactory2)
+  const safu_impl = contract(SAFU)
+  const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
   const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
   const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
-  // const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
+  const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
 
   // New contract proxies
-  // const trueLender2 = proxy(trueLender2_impl, () => {})
+  const trueLender2 = proxy(trueLender2_impl, () => {})
   const poolFactory = proxy(poolFactory_impl, () => {})
-  // const liquidator2 = proxy(liquidator2_impl, () => {})
-  // const loanFactory2 = proxy(loanFactory2_impl, () => {})
-  // const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  // const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
+  const liquidator2 = proxy(liquidator2_impl, () => {})
+  const loanFactory2 = proxy(loanFactory2_impl, () => {})
+  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
   const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
   const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
-  // const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
-  // const safu = proxy(safu_impl, () => {})
-  // // New bare contracts
-  // const trueFiPool2 = contract(TrueFiPool2)
-  // const implementationReference = contract(ImplementationReference, [trueFiPool2])
-  // const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
-  // const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
+  const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
+  const safu = proxy(safu_impl, () => {})
+  // New bare contracts
+  const trueFiPool2 = contract(TrueFiPool2)
+  const implementationReference = contract(ImplementationReference, [trueFiPool2])
+  const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
+  const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
 
   // Contract initialization
-  // runIf(safu.isInitialized().not(), () => {
-  //   safu.initialize(loanFactory2, liquidator2)
-  // })
-  // runIf(poolFactory.isInitialized().not(), () => {
-  //   poolFactory.initialize(implementationReference, trustToken, trueLender2, safu)
-  // })
-  // runIf(trueLender2.isInitialized().not(), () => {
-  //   trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch)
-  // })
-  // runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
-  //   trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
-  // })
-  // runIf(loanFactory2.isInitialized().not(), () => {
-  //   loanFactory2.initialize(poolFactory, trueLender2, liquidator2)
-  // })
-  // runIf(liquidator2.isInitialized().not(), () => {
-  //   liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
-  // })
-  // runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
-  //   poolFactory.whitelist(usdc, true)
-  //   poolFactory.createPool(usdc)
-  // })
-  // const usdc_TrueFiPool2 = poolFactory.pool(usdc)
-  // runIf(trueLender2.feePool().equals(AddressZero), () => {
-  //   trueLender2.setFeePool(usdc_TrueFiPool2)
-  // })
-  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-  //   usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  // })
-  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
-  //   usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
-  // })
-  // runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-  //   usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
-  // })
+  runIf(safu.isInitialized().not(), () => {
+    safu.initialize(loanFactory2, liquidator2)
+  })
+  runIf(poolFactory.isInitialized().not(), () => {
+    poolFactory.initialize(implementationReference, trustToken, trueLender2, safu)
+  })
+  runIf(trueLender2.isInitialized().not(), () => {
+    trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch)
+  })
+  runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
+    trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
+  })
+  runIf(loanFactory2.isInitialized().not(), () => {
+    loanFactory2.initialize(poolFactory, trueLender2, liquidator2)
+  })
+  runIf(liquidator2.isInitialized().not(), () => {
+    liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
+  })
+  runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
+    poolFactory.whitelist(usdc, true)
+    poolFactory.createPool(usdc)
+  })
+  const usdc_TrueFiPool2 = poolFactory.pool(usdc)
+  runIf(trueLender2.feePool().equals(AddressZero), () => {
+    trueLender2.setFeePool(usdc_TrueFiPool2)
+  })
+  runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+    usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  })
+  runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
+    usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
+  })
+  runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+    usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
+  })
   runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
     poolFactory.whitelist(usdt, true)
     poolFactory.createPool(usdt)
@@ -149,13 +149,13 @@ deploy({}, (_, config) => {
   runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
     usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
   })
-  // runIf(trueFiCreditOracle.isInitialized().not(), () => {
-  //   trueFiCreditOracle.initialize()
-  // })
-  // if (!isMainnet) {
-  //   trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
-  // }
-  // runIf(poolFactory.isPool(trueFiPool).not(), () => {
-  //   poolFactory.addLegacyPool(trueFiPool)
-  // })
+  runIf(trueFiCreditOracle.isInitialized().not(), () => {
+    trueFiCreditOracle.initialize()
+  })
+  if (!isMainnet) {
+    trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
+  }
+  runIf(poolFactory.isPool(trueFiPool).not(), () => {
+    poolFactory.addLegacyPool(trueFiPool)
+  })
 })

--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -58,83 +58,83 @@ deploy({}, (_, config) => {
   const trustToken = isMainnet
     ? timeProxy(contract(TrustToken), () => {})
     : timeProxy(contract(TestTrustToken), () => {})
-  const stkTruToken = proxy(contract(StkTruToken), () => {})
-  const trueFiPool = isMainnet
-    ? proxy(contract(TrueFiPool), () => {})
-    : proxy(contract(TestTrueFiPool), () => {})
-  const usdc = isMainnet
-    ? deployParams['mainnet'].USDC
-    : contract(TestUSDCToken)
+  // const stkTruToken = proxy(contract(StkTruToken), () => {})
+  // const trueFiPool = isMainnet
+  //   ? proxy(contract(TrueFiPool), () => {})
+  //   : proxy(contract(TestTrueFiPool), () => {})
+  // const usdc = isMainnet
+  //   ? deployParams['mainnet'].USDC
+  //   : contract(TestUSDCToken)
   const usdt = isMainnet
     ? deployParams['mainnet'].USDT
     : contract(TestUSDTToken)
-  const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
+  // const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
 
   // New contract impls
-  const trueLender2_impl = contract(TrueLender2)
+  // const trueLender2_impl = contract(TrueLender2)
   const poolFactory_impl = contract(PoolFactory)
-  const liquidator2_impl = contract(Liquidator2)
-  const loanFactory2_impl = contract(LoanFactory2)
-  const safu_impl = contract(SAFU)
-  const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
+  // const liquidator2_impl = contract(Liquidator2)
+  // const loanFactory2_impl = contract(LoanFactory2)
+  // const safu_impl = contract(SAFU)
+  // const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  // const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
   const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
   const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
-  const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
+  // const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
 
   // New contract proxies
-  const trueLender2 = proxy(trueLender2_impl, () => {})
+  // const trueLender2 = proxy(trueLender2_impl, () => {})
   const poolFactory = proxy(poolFactory_impl, () => {})
-  const liquidator2 = proxy(liquidator2_impl, () => {})
-  const loanFactory2 = proxy(loanFactory2_impl, () => {})
-  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
+  // const liquidator2 = proxy(liquidator2_impl, () => {})
+  // const loanFactory2 = proxy(loanFactory2_impl, () => {})
+  // const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  // const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
   const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
   const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
-  const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
-  const safu = proxy(safu_impl, () => {})
-  // New bare contracts
-  const trueFiPool2 = contract(TrueFiPool2)
-  const implementationReference = contract(ImplementationReference, [trueFiPool2])
-  const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
-  const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
+  // const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
+  // const safu = proxy(safu_impl, () => {})
+  // // New bare contracts
+  // const trueFiPool2 = contract(TrueFiPool2)
+  // const implementationReference = contract(ImplementationReference, [trueFiPool2])
+  // const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
+  // const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
 
   // Contract initialization
-  runIf(safu.isInitialized().not(), () => {
-    safu.initialize(loanFactory2, liquidator2)
-  })
-  runIf(poolFactory.isInitialized().not(), () => {
-    poolFactory.initialize(implementationReference, trustToken, trueLender2, safu)
-  })
-  runIf(trueLender2.isInitialized().not(), () => {
-    trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch)
-  })
-  runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
-    trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
-  })
-  runIf(loanFactory2.isInitialized().not(), () => {
-    loanFactory2.initialize(poolFactory, trueLender2, liquidator2)
-  })
-  runIf(liquidator2.isInitialized().not(), () => {
-    liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
-  })
-  runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
-    poolFactory.whitelist(usdc, true)
-    poolFactory.createPool(usdc)
-  })
-  const usdc_TrueFiPool2 = poolFactory.pool(usdc)
-  runIf(trueLender2.feePool().equals(AddressZero), () => {
-    trueLender2.setFeePool(usdc_TrueFiPool2)
-  })
-  runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-    usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  })
-  runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
-    usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
-  })
-  runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-    usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
-  })
+  // runIf(safu.isInitialized().not(), () => {
+  //   safu.initialize(loanFactory2, liquidator2)
+  // })
+  // runIf(poolFactory.isInitialized().not(), () => {
+  //   poolFactory.initialize(implementationReference, trustToken, trueLender2, safu)
+  // })
+  // runIf(trueLender2.isInitialized().not(), () => {
+  //   trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch)
+  // })
+  // runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
+  //   trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
+  // })
+  // runIf(loanFactory2.isInitialized().not(), () => {
+  //   loanFactory2.initialize(poolFactory, trueLender2, liquidator2)
+  // })
+  // runIf(liquidator2.isInitialized().not(), () => {
+  //   liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
+  // })
+  // runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
+  //   poolFactory.whitelist(usdc, true)
+  //   poolFactory.createPool(usdc)
+  // })
+  // const usdc_TrueFiPool2 = poolFactory.pool(usdc)
+  // runIf(trueLender2.feePool().equals(AddressZero), () => {
+  //   trueLender2.setFeePool(usdc_TrueFiPool2)
+  // })
+  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+  //   usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  // })
+  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
+  //   usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
+  // })
+  // runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+  //   usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
+  // })
   runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
     poolFactory.whitelist(usdt, true)
     poolFactory.createPool(usdt)
@@ -149,13 +149,13 @@ deploy({}, (_, config) => {
   runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
     usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
   })
-  runIf(trueFiCreditOracle.isInitialized().not(), () => {
-    trueFiCreditOracle.initialize()
-  })
-  if (!isMainnet) {
-    trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
-  }
-  runIf(poolFactory.isPool(trueFiPool).not(), () => {
-    poolFactory.addLegacyPool(trueFiPool)
-  })
+  // runIf(trueFiCreditOracle.isInitialized().not(), () => {
+  //   trueFiCreditOracle.initialize()
+  // })
+  // if (!isMainnet) {
+  //   trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
+  // }
+  // runIf(poolFactory.isPool(trueFiPool).not(), () => {
+  //   poolFactory.addLegacyPool(trueFiPool)
+  // })
 })

--- a/deployments.json
+++ b/deployments.json
@@ -250,6 +250,14 @@
       "txHash": "0xa50edf039a7282d5c68e5ce7d4eae499320131250c32700c5d565d0e6603d6e9",
       "address": "0x84CD64C65D48Ae9dDF8eF324A8c5dC571e5f3833"
     },
+    "usdt_TrueFiPool2_LinearTrueDistributor_proxy": {
+      "txHash": "0x04922cb49a012a427e93b9e7735c3a9e38abd467dc2594568983050526097263",
+      "address": "0xAeB550d2Fe2373C4EB81d3bE9BC7D33731EfA8eD"
+    },
+    "usdt_TrueFiPool2_TrueFarm_proxy": {
+      "txHash": "0xb74c9e20dd97be6902b6b8d4166fbd50ff7fa51e0333b2b94ae2c85876aa0f24",
+      "address": "0xEFE2709D623a19493A9F9AAf1Cf50029D30567fC"
+    },
     "sAFU_proxy": {
       "txHash": "0x2d415ad00f64fa2ffa1bb327df6d26861442d35aa2ecca8cc2d0b7dcc20244af",
       "address": "0xD8bCC7Bdf3D2E6F3F865f1060cf814C51f5F9C17"

--- a/deployments.json
+++ b/deployments.json
@@ -250,14 +250,6 @@
       "txHash": "0xa50edf039a7282d5c68e5ce7d4eae499320131250c32700c5d565d0e6603d6e9",
       "address": "0x84CD64C65D48Ae9dDF8eF324A8c5dC571e5f3833"
     },
-    "usdt_TrueFiPool2_LinearTrueDistributor_proxy": {
-      "txHash": "0xd353457b7badaa054fb606b4a502784efb6866aff38e534a22e9dd06c8d47f52",
-      "address": "0xb70A7B1B77cFA9be30E6dbD26cf4475FDD6fE968"
-    },
-    "usdt_TrueFiPool2_TrueFarm_proxy": {
-      "txHash": "0x1721244a7af159053dbbb98ae91d4de036ea806008a0a1ad902cb741aef163d6",
-      "address": "0x063f61442335b1ec7ec9CCfce690c57807DF5aa3"
-    },
     "sAFU_proxy": {
       "txHash": "0x2d415ad00f64fa2ffa1bb327df6d26861442d35aa2ecca8cc2d0b7dcc20244af",
       "address": "0xD8bCC7Bdf3D2E6F3F865f1060cf814C51f5F9C17"


### PR DESCRIPTION
When I ran `deploy:truefi2` on Ropsten yesterday, I forgot to add a call to `createPool(usdt)` in the deploy script until I'd already initialized the tfUSDT farm + distributor with an `AddressZero` tfUSDT pool. This left the farm + distributor in a broken state that would be easier to replace than fix on testnet.