### PR TITLE
Fix tether loan funding

### DIFF
--- a/contracts/governance/TrueFiVault.sol
+++ b/contracts/governance/TrueFiVault.sol
@@ -119,7 +119,7 @@ contract TrueFiVault is UpgradeableClaimable {
      * @param amount Amount of TRU to stake
      */
     function stake(uint256 amount) external onlyBeneficiary {
-        tru.approve(address(stkTru), amount);
+        tru.safeApprove(address(stkTru), amount);
         stkTru.stake(amount);
     }
 

--- a/contracts/truefi/TrueFiPool.sol
+++ b/contracts/truefi/TrueFiPool.sol
@@ -579,7 +579,7 @@ contract TrueFiPool is ITrueFiPool, IPauseableContract, ERC20, ReentrancyGuard, 
 
         // stake yCurve tokens in gauge
         uint256 yBalance = _curvePool.token().balanceOf(address(this));
-        _curvePool.token().approve(address(_curveGauge), yBalance);
+        _curvePool.token().safeApprove(address(_curveGauge), yBalance);
         _curveGauge.deposit(yBalance);
 
         emit Flushed(currencyAmount);
@@ -591,7 +591,7 @@ contract TrueFiPool is ITrueFiPool, IPauseableContract, ERC20, ReentrancyGuard, 
     {
         uint256[N_TOKENS] memory amounts = [0, 0, 0, currencyAmount];
 
-        token.approve(address(_curvePool), currencyAmount);
+        token.safeApprove(address(_curvePool), currencyAmount);
         _curvePool.add_liquidity(amounts, minMintAmount);
     }
 
@@ -607,7 +607,7 @@ contract TrueFiPool is ITrueFiPool, IPauseableContract, ERC20, ReentrancyGuard, 
         ensureEnoughTokensAreAvailable(yAmount);
 
         // remove TUSD from curve
-        _curvePool.token().approve(address(_curvePool), yAmount);
+        _curvePool.token().safeApprove(address(_curvePool), yAmount);
         _curvePool.remove_liquidity_one_coin(yAmount, TUSD_INDEX, minCurrencyAmount, false);
 
         emit Pulled(yAmount);
@@ -638,7 +638,7 @@ contract TrueFiPool is ITrueFiPool, IPauseableContract, ERC20, ReentrancyGuard, 
         // pull tokens from gauge
         ensureEnoughTokensAreAvailable(roughCurveTokenAmount);
         // remove TUSD from curve
-        _curvePool.token().approve(address(_curvePool), roughCurveTokenAmount);
+        _curvePool.token().safeApprove(address(_curvePool), roughCurveTokenAmount);
         uint256 minAmount = roughCurveTokenAmount.mul(_curvePool.curve().get_virtual_price()).mul(999).div(1000).div(1 ether);
         _curvePool.remove_liquidity_one_coin(roughCurveTokenAmount, TUSD_INDEX, minAmount, false);
     }
@@ -675,7 +675,7 @@ contract TrueFiPool is ITrueFiPool, IPauseableContract, ERC20, ReentrancyGuard, 
         uint256 amountOutMin,
         address[] calldata path
     ) public exchangeProtector(_crvOracle.crvToUsd(amountIn), token) {
-        _minter.token().approve(address(_uniRouter), amountIn);
+        _minter.token().safeApprove(address(_uniRouter), amountIn);
         _uniRouter.swapExactTokensForTokens(amountIn, amountOutMin, path, address(this), block.timestamp + 1 hours);
     }
 
@@ -695,7 +695,7 @@ contract TrueFiPool is ITrueFiPool, IPauseableContract, ERC20, ReentrancyGuard, 
         uint256 amountOutMin,
         address[] calldata path
     ) public exchangeProtector(oracle.truToToken(amountIn), token) {
-        _stakeToken.approve(address(_uniRouter), amountIn);
+        _stakeToken.safeApprove(address(_uniRouter), amountIn);
         _uniRouter.swapExactTokensForTokens(amountIn, amountOutMin, path, address(this), block.timestamp + 1 hours);
     }
 

--- a/contracts/truefi/TrueFiPool.sol
+++ b/contracts/truefi/TrueFiPool.sol
@@ -4,6 +4,7 @@ pragma solidity 0.6.10;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
 import {ERC20} from "../common/UpgradeableERC20.sol";
 import {Ownable} from "../common/UpgradeableOwnable.sol";
@@ -33,6 +34,7 @@ import {PoolExtensions} from "../truefi2/PoolExtensions.sol";
  */
 contract TrueFiPool is ITrueFiPool, IPauseableContract, ERC20, ReentrancyGuard, Ownable {
     using SafeMath for uint256;
+    using SafeERC20 for IERC20;
 
     // ================ WARNING ==================
     // ===== THIS CONTRACT IS INITIALIZABLE ======

--- a/contracts/truefi/TrueLender.sol
+++ b/contracts/truefi/TrueLender.sol
@@ -38,7 +38,6 @@ import {IStakingPool} from "./interface/IStakingPool.sol";
 contract TrueLender is ITrueLender, Ownable {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
-    using SafeERC20 for ITrueFiPool;
 
     // ================ WARNING ==================
     // ===== THIS CONTRACT IS INITIALIZABLE ======
@@ -334,7 +333,7 @@ contract TrueLender is ITrueLender, Ownable {
         currencyToken.safeApprove(address(loanToken), receivedAmount);
         loanToken.fund();
 
-        pool.safeApprove(address(stakingPool), pool.balanceOf(address(this)));
+        pool.approve(address(stakingPool), pool.balanceOf(address(this)));
         stakingPool.payFee(pool.balanceOf(address(this)), block.timestamp.add(term));
 
         emit Funded(address(loanToken), receivedAmount);

--- a/contracts/truefi/TrueLender.sol
+++ b/contracts/truefi/TrueLender.sol
@@ -3,6 +3,7 @@ pragma solidity 0.6.10;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
 import {Ownable} from "../common/UpgradeableOwnable.sol";
 import {ILoanToken} from "./interface/ILoanToken.sol";
@@ -36,6 +37,8 @@ import {IStakingPool} from "./interface/IStakingPool.sol";
  */
 contract TrueLender is ITrueLender, Ownable {
     using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+    using SafeERC20 for ITrueFiPool;
 
     // ================ WARNING ==================
     // ===== THIS CONTRACT IS INITIALIZABLE ======

--- a/contracts/truefi/TrueLender.sol
+++ b/contracts/truefi/TrueLender.sol
@@ -187,7 +187,7 @@ contract TrueLender is ITrueLender, Ownable {
 
         pool = _pool;
         currencyToken = _pool.currencyToken();
-        currencyToken.approve(address(_pool), uint256(-1));
+        currencyToken.safeApprove(address(_pool), uint256(-1));
         ratingAgency = _ratingAgency;
         stakingPool = _stakingPool;
 
@@ -328,10 +328,10 @@ contract TrueLender is ITrueLender, Ownable {
 
         _loans.push(loanToken);
         pool.borrow(amount, amount.sub(receivedAmount));
-        currencyToken.approve(address(loanToken), receivedAmount);
+        currencyToken.safeApprove(address(loanToken), receivedAmount);
         loanToken.fund();
 
-        pool.approve(address(stakingPool), pool.balanceOf(address(this)));
+        pool.safeApprove(address(stakingPool), pool.balanceOf(address(this)));
         stakingPool.payFee(pool.balanceOf(address(this)), block.timestamp.add(term));
 
         emit Funded(address(loanToken), receivedAmount);

--- a/contracts/truefi/mocks/PoolArbitrageTest.sol
+++ b/contracts/truefi/mocks/PoolArbitrageTest.sol
@@ -7,7 +7,7 @@ contract PoolArbitrageTest {
     function joinExit(ITrueFiPool pool) external {
         IERC20 token = pool.currencyToken();
         uint256 balance = token.balanceOf(address(this));
-        token.approve(address(pool), balance);
+        token.safeApprove(address(pool), balance);
         pool.join(balance);
         pool.exit(pool.balanceOf(address(this)));
     }

--- a/contracts/truefi/mocks/PoolArbitrageTest.sol
+++ b/contracts/truefi/mocks/PoolArbitrageTest.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.6.10;
 
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
 import {ITrueFiPool, IERC20} from "../interface/ITrueFiPool.sol";
 
 contract PoolArbitrageTest {
+    using SafeERC20 for IERC20;
+
     function joinExit(ITrueFiPool pool) external {
         IERC20 token = pool.currencyToken();
         uint256 balance = token.balanceOf(address(this));

--- a/contracts/truefi2/TrueFiPool2.sol
+++ b/contracts/truefi2/TrueFiPool2.sol
@@ -35,6 +35,7 @@ import {PoolExtensions} from "./PoolExtensions.sol";
 contract TrueFiPool2 is ITrueFiPool2, IPauseableContract, ERC20, UpgradeableClaimable {
     using SafeMath for uint256;
     using SafeERC20 for ERC20;
+    using SafeERC20 for IERC20;
     using OneInchExchange for I1Inch3;
 
     uint256 private constant BASIS_PRECISION = 10000;

--- a/contracts/truefi2/TrueLender2.sol
+++ b/contracts/truefi2/TrueLender2.sol
@@ -258,7 +258,7 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
 
         poolLoans[pool].push(loanToken);
         pool.borrow(amount);
-        pool.token().approve(address(loanToken), amount);
+        pool.token().safeApprove(address(loanToken), amount);
         loanToken.fund();
 
         emit Funded(address(pool), address(loanToken), amount);
@@ -333,7 +333,7 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
             feeAmount = _swapFee(pool, loanToken, data);
         }
 
-        pool.token().approve(address(pool), fundsReclaimed.sub(feeAmount));
+        pool.token().safeApprove(address(pool), fundsReclaimed.sub(feeAmount));
         pool.repay(fundsReclaimed.sub(feeAmount));
 
         if (address(feeToken) != address(0)) {
@@ -381,7 +381,7 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
         if (amount == 0) {
             return;
         }
-        feeToken.approve(address(feePool), amount);
+        feeToken.safeApprove(address(feePool), amount);
         feePool.join(amount);
         feePool.transfer(address(stakingPool), feePool.balanceOf(address(this)));
     }

--- a/contracts/truefi2/TrueLender2.sol
+++ b/contracts/truefi2/TrueLender2.sol
@@ -4,7 +4,9 @@ pragma experimental ABIEncoderV2;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
+import {ERC20} from "../common/UpgradeableERC20.sol";
 import {UpgradeableClaimable} from "../common/UpgradeableClaimable.sol";
 import {OneInchExchange} from "./libraries/OneInchExchange.sol";
 
@@ -24,6 +26,8 @@ import {IERC20WithDecimals} from "./interface/IERC20WithDecimals.sol";
  */
 contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
     using SafeMath for uint256;
+    using SafeERC20 for ERC20;
+    using SafeERC20 for IERC20WithDecimals;
     using OneInchExchange for I1Inch3;
 
     // basis point for ratio

--- a/contracts/truefi2/libraries/OneInchExchange.sol
+++ b/contracts/truefi2/libraries/OneInchExchange.sol
@@ -45,7 +45,7 @@ library OneInchExchange {
             description.dstReceiver = address(this);
         }
 
-        IERC20(description.srcToken).approve(address(_1inchExchange), description.amount);
+        IERC20(description.srcToken).safeApprove(address(_1inchExchange), description.amount);
 
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, ) = address(_1inchExchange).call(data);

--- a/contracts/truefi2/libraries/OneInchExchange.sol
+++ b/contracts/truefi2/libraries/OneInchExchange.sol
@@ -4,6 +4,7 @@ pragma experimental ABIEncoderV2;
 
 import {I1Inch3} from "../interface/I1Inch3.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
 interface IUniRouter {
     function token0() external view returns (address);
@@ -12,6 +13,8 @@ interface IUniRouter {
 }
 
 library OneInchExchange {
+    using SafeERC20 for IERC20;
+
     uint256 constant ADDRESS_MASK = 0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff;
     uint256 constant REVERSE_MASK = 0x8000000000000000000000000000000000000000000000000000000000000000;
 

--- a/contracts/truefi2/mocks/Pool2ArbitrageTest.sol
+++ b/contracts/truefi2/mocks/Pool2ArbitrageTest.sol
@@ -7,7 +7,7 @@ contract Pool2ArbitrageTest {
     function joinExit(TrueFiPool2 pool) external {
         IERC20 token = pool.token();
         uint256 balance = token.balanceOf(address(this));
-        token.approve(address(pool), balance);
+        token.safeApprove(address(pool), balance);
         pool.join(balance);
         pool.exit(pool.balanceOf(address(this)));
     }

--- a/contracts/truefi2/mocks/Pool2ArbitrageTest.sol
+++ b/contracts/truefi2/mocks/Pool2ArbitrageTest.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.6.10;
 
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
 import {TrueFiPool2, IERC20} from "../TrueFiPool2.sol";
 
 contract Pool2ArbitrageTest {
+    using SafeERC20 for IERC20;
+
     function joinExit(TrueFiPool2 pool) external {
         IERC20 token = pool.token();
         uint256 balance = token.balanceOf(address(this));

--- a/contracts/truefi2/strategies/CurveYearnStrategy.sol
+++ b/contracts/truefi2/strategies/CurveYearnStrategy.sol
@@ -22,6 +22,7 @@ import {IERC20WithDecimals} from "../interface/IERC20WithDecimals.sol";
  */
 contract CurveYearnStrategy is UpgradeableClaimable, ITrueStrategy {
     using SafeMath for uint256;
+    using SafeERC20 for IERC20;
     using SafeERC20 for IERC20WithDecimals;
     using OneInchExchange for I1Inch3;
 

--- a/contracts/truefi2/strategies/CurveYearnStrategy.sol
+++ b/contracts/truefi2/strategies/CurveYearnStrategy.sol
@@ -116,7 +116,7 @@ contract CurveYearnStrategy is UpgradeableClaimable, ITrueStrategy {
 
         // stake yCurve tokens in gauge
         uint256 yBalance = curvePool.token().balanceOf(address(this));
-        curvePool.token().approve(address(curveGauge), yBalance);
+        curvePool.token().safeApprove(address(curveGauge), yBalance);
         curveGauge.deposit(yBalance);
 
         emit Deposited(amount, yBalance);
@@ -138,7 +138,7 @@ contract CurveYearnStrategy is UpgradeableClaimable, ITrueStrategy {
         // pull tokens from gauge
         withdrawFromGaugeIfNecessary(conservativeCurveTokenAmount);
         // remove TUSD from curve
-        curvePool.token().approve(address(curvePool), conservativeCurveTokenAmount);
+        curvePool.token().safeApprove(address(curvePool), conservativeCurveTokenAmount);
         curvePool.remove_liquidity_one_coin(conservativeCurveTokenAmount, tokenIndex, minAmount, false);
         transferAllToPool();
 
@@ -152,7 +152,7 @@ contract CurveYearnStrategy is UpgradeableClaimable, ITrueStrategy {
     function withdrawAll() external override onlyPool {
         curveGauge.withdraw(curveGauge.balanceOf(address(this)));
         uint256 yBalance = yTokenBalance();
-        curvePool.token().approve(address(curvePool), yBalance);
+        curvePool.token().safeApprove(address(curvePool), yBalance);
         curvePool.remove_liquidity_one_coin(yBalance, tokenIndex, 0, false);
         transferAllToPool();
 

--- a/test/integration/TrueLender2.test.ts
+++ b/test/integration/TrueLender2.test.ts
@@ -2,6 +2,7 @@ import { forkChain } from './suite'
 import { setupDeploy } from 'scripts/utils'
 import {
   MockUsdStableCoinOracle__factory,
+  Erc20Mock,
   Erc20Mock__factory,
   ImplementationReference__factory,
   TrueFiPool2,
@@ -15,7 +16,6 @@ import {
   LoanFactory2__factory,
   LoanToken2,
   LoanToken2__factory,
-  Erc20Mock,
 } from 'contracts'
 import { DAY, parseEth, parseTRU } from 'utils'
 import fetch from 'node-fetch'
@@ -52,7 +52,7 @@ describe('TrueLender2', () => {
   let stkTru: Wallet
   let tusd: Erc20Mock
   let usdc: Erc20Mock
-  let usdt: ERC20Mock
+  let usdt: Erc20Mock
   let loan: LoanToken2
 
   beforeEach(async () => {

--- a/test/integration/TrueLender2.test.ts
+++ b/test/integration/TrueLender2.test.ts
@@ -116,14 +116,14 @@ describe('TrueLender2', () => {
   })
 
   it('funds tether loan tokens', async () => {
-    const tx = await loanFactory.createLoanToken(usdtLoanPool.address, parseEth(100000), 1000, DAY * 365)
+    const tx = await loanFactory.createLoanToken(usdtLoanPool.address, 10_000_000, 1000, DAY * 365)
     const creationEvent = (await tx.wait()).events[0]
     const { contractAddress } = creationEvent.args
 
     loan = LoanToken2__factory.connect(contractAddress, owner)
 
-    await usdt.connect(usdtHolder).approve(usdtLoanPool.address, parseEth(100000))
-    await usdtLoanPool.connect(usdtHolder).join(parseEth(100000))
+    await usdt.connect(usdtHolder).approve(usdtLoanPool.address, 10_000_000)
+    await usdtLoanPool.connect(usdtHolder).join(10_000_000)
 
     await expect(lender.fund(loan.address)).not.to.be.reverted
   })


### PR DESCRIPTION
USDT's approve() function doesn't comply with the ERC20 spec since it reverts on failure and doesn't return a boolean for success/failure.

TrueLender2 currently calls the low-level ERC20 approve() instead of SafeERC20's safeApprove(), so it fails due to ABI incompatibility with USDT.

---

This PR adds a failing integration test to demonstrate the bug, and then fixes the test by globally replacing ERC20 approve() calls with SafeERC20 safeApprove() calls.