### PR TITLE
Ignore reentrancy detector in claim function

### DIFF
--- a/contracts/truefi/TrueRatingAgencyV2.sol
+++ b/contracts/truefi/TrueRatingAgencyV2.sol
@@ -379,7 +379,6 @@ contract TrueRatingAgencyV2 is ITrueRatingAgencyV2, Ownable {
      * R = Total Reward = (interest * chi * rewardFactor)
      * @param id Loan ID
      */
-    // slither-disable-next-line reentrancy-no-eth
     modifier calculateTotalReward(address id) {
         if (loans[id].reward == 0) {
             uint256 interest = ILoanToken2(id).profit();

--- a/contracts/truefi/TrueRatingAgencyV2.sol
+++ b/contracts/truefi/TrueRatingAgencyV2.sol
@@ -426,6 +426,7 @@ contract TrueRatingAgencyV2 is ITrueRatingAgencyV2, Ownable {
      * @param id Loan ID
      * @param rater Rater account
      */
+    // slither-disable-next-line reentrancy-eth
     function claim(address id, address rater) external override onlyFundedLoans(id) calculateTotalReward(id) {
         uint256 claimableRewards = claimable(id, rater);
 


### PR DESCRIPTION
Slither was warning us, that a low level call is performed before writing some state variables. It happens because of _SafeERC20_ `_callOptionalReturn` function. It is used for the _safeTransfer_, _safeApprove_ etc. _Calldata_ is explicitly encoded in those functions, therefore it cannot be manipulated.

My proposition is to simply ignore the warning. It would be really nice, if someone else could have a quick look at it, to double check whether im correct. 