### PR TITLE
Remove minMintAmount argument from TrueFiPool flush

### DIFF
--- a/contracts/truefi/TrueFiPool.sol
+++ b/contracts/truefi/TrueFiPool.sol
@@ -549,10 +549,7 @@ contract TrueFiPool is ITrueFiPool, IPauseableContract, ERC20, ReentrancyGuard, 
         emit Flushed(currencyAmount);
     }
 
-    function _curvePoolDeposit(uint256 currencyAmount)
-        internal
-        exchangeProtector(calcTokenAmount(currencyAmount), _curvePool.token())
-    {
+    function _curvePoolDeposit(uint256 currencyAmount) private {
         uint256[N_TOKENS] memory amounts = [0, 0, 0, currencyAmount];
 
         token.safeApprove(address(_curvePool), currencyAmount);

--- a/test/integration/poolExchanges.test.ts
+++ b/test/integration/poolExchanges.test.ts
@@ -9,7 +9,6 @@ describe('Pool Curve integration', () => {
   it('deposit TUSD to Curve', async () => {
     const pool = await upgradeSuite(TrueFiPool__factory, '0xa1e72267084192Db7387c8CC1328fadE470e4149', [])
     const tusdBalance = await pool.currencyBalance()
-    const minAmount = (await pool.calcTokenAmount(tusdBalance)).mul(99).div(100)
-    await expect(pool.flush(tusdBalance, minAmount)).to.be.not.reverted
+    await expect(pool.flush(tusdBalance)).to.be.not.reverted
   })
 })

--- a/test/truefi/TrueFiPool.test.ts
+++ b/test/truefi/TrueFiPool.test.ts
@@ -148,7 +148,7 @@ describe('TrueFiPool', () => {
       await timeTravel(provider, dayInSeconds * 182.5)
       const loan2 = await new LoanToken__factory(owner).deploy(token.address, borrower.address, lender.address, lender.address, parseEth(1e6), dayInSeconds * 365, 1000)
       await lender.connect(borrower).fund(loan2.address)
-      await pool.flush(parseEth(5e6), 0)
+      await pool.flush(parseEth(5e6))
       await curvePool.set_withdraw_price(parseEth(2))
       expectScaledCloseTo(await pool.poolValue(), parseEth(4e6).add(parseEth(105e4).add(parseEth(1e7))).add(calcBorrowerFee(parseEth(2e6))))
       await mockCrv.mint(pool.address, parseEth(1e5))
@@ -337,17 +337,17 @@ describe('TrueFiPool', () => {
     })
 
     it('deposits given amount to curve', async () => {
-      await pool.flush(parseEth(100), 123)
+      await pool.flush(parseEth(100))
       expect('add_liquidity').to.be.calledOnContractWith(curvePool, [[0, 0, 0, parseEth(100)], 123])
     })
 
     it('can be called by funds manager', async () => {
       await pool.setFundsManager(borrower.address)
-      await expect(pool.flush(parseEth(100), 123)).to.be.not.reverted
+      await expect(pool.flush(parseEth(100))).to.be.not.reverted
     })
 
     it('reverts if flushing more than tUSD balance', async () => {
-      await expect(pool.flush(parseEth(1e7 + 1), 0)).to.be.revertedWith('TrueFiPool: Insufficient currency balance')
+      await expect(pool.flush(parseEth(1e7 + 1))).to.be.revertedWith('TrueFiPool: Insufficient currency balance')
     })
 
     it('deposits liquidity tokens in curve gauge', async () => {
@@ -355,12 +355,12 @@ describe('TrueFiPool', () => {
     })
 
     it('curvePool allowance is 0 after flushing', async () => {
-      await pool.flush(parseEth(100), 123)
+      await pool.flush(parseEth(100))
       expect(await token.allowance(pool.address, curvePool.address)).to.eq(0)
     })
 
     it('curveGauge allowance remains (Mock)', async () => {
-      await pool.flush(parseEth(100), 123)
+      await pool.flush(parseEth(100))
       expect(await curveToken.allowance(pool.address, mockCurveGauge.address)).to.eq(parseEth(100))
     })
   })
@@ -406,7 +406,7 @@ describe('TrueFiPool', () => {
       )
       await token.approve(pool2.address, includeFee(parseEth(1e7)))
       await pool2.join(includeFee(parseEth(1e7)))
-      await pool2.flush(parseEth(5e6), 0)
+      await pool2.flush(parseEth(5e6))
     })
 
     it('reverts if borrower is not a lender', async () => {
@@ -577,14 +577,14 @@ describe('TrueFiPool', () => {
     })
 
     it('half funds are in curve: transfers TUSD without penalty and leaves curve with 0 allowance', async () => {
-      await pool.flush(parseEth(5e6), 0)
+      await pool.flush(parseEth(5e6))
       await pool.liquidExit(parseEth(6e6))
       expect(await token.balanceOf(owner.address)).to.equal(parseEth(6e6))
       expect(await curveToken.allowance(pool.address, curvePool.address)).to.equal(0)
     })
 
     it('half funds are in curve and curve earns: transfers TUSD without penalty and leaves curve with 0 allowance', async () => {
-      await pool.flush(parseEth(5e6), 0)
+      await pool.flush(parseEth(5e6))
       await curvePool.set_withdraw_price(parseEth(2))
       await pool.liquidExit(parseEth(6e6))
       expect(await token.balanceOf(owner.address)).to.equal(parseEth(9e6))
@@ -594,7 +594,7 @@ describe('TrueFiPool', () => {
     it('calls remove_liquidity_one_coin with correct arguments', async () => {
       await curvePool.set_withdraw_price(parseEth(2))
       const amount = parseEth(5e6)
-      await pool.flush(amount, 0)
+      await pool.flush(amount)
       provider.clearCallHistory()
       await pool.liquidExit(parseEth(6e6))
 

--- a/test/truefi/TrueFiPool.test.ts
+++ b/test/truefi/TrueFiPool.test.ts
@@ -338,7 +338,7 @@ describe('TrueFiPool', () => {
 
     it('deposits given amount to curve', async () => {
       await pool.flush(parseEth(100))
-      expect('add_liquidity').to.be.calledOnContractWith(curvePool, [[0, 0, 0, parseEth(100)], 123])
+      expect('add_liquidity').to.be.calledOnContractWith(curvePool, [[0, 0, 0, parseEth(100)], parseEth(99.9)])
     })
 
     it('can be called by funds manager', async () => {


### PR DESCRIPTION
This aligns TrueFiPool's slippage protections with TrueFiPool2 + CurveYearnStrategy, and makes automating CRV flushes with a keeper much simpler.

Compare `TrueFiPool.flush()` against `TrueFiPool2.flush()`:
https://github.com/trusttoken/smart-contracts/blob/c94ad4e2cc5aa2f4c3050d79eb75585065e287ba/contracts/truefi2/TrueFiPool2.sol#L488

Compare `TrueFiPool._curvePoolDeposit()` against `CurveYearnStrategy.deposit()`:
https://github.com/trusttoken/smart-contracts/blob/c94ad4e2cc5aa2f4c3050d79eb75585065e287ba/contracts/truefi2/strategies/CurveYearnStrategy.sol#L107