### PR TITLE
Update legacy tfTUSD name/symbol to "Legacy TrueFi TrueUSD"/"Legacy tfTUSD"

### DIFF
--- a/contracts/truefi/TrueFiPool.sol
+++ b/contracts/truefi/TrueFiPool.sol
@@ -225,6 +225,10 @@ contract TrueFiPool is ITrueFiPool, IPauseableContract, ERC20, ReentrancyGuard, 
         loansValueCache = 0;
     }
 
+    function updateNameAndSymbolToLegacy() public {
+        updateNameAndSymbol("Legacy TrueFi TrueUSD", "Legacy tfTUSD");
+    }
+
     /// @dev support borrow function from pool V2
     function borrow(uint256 amount) external {
         borrow(amount, 0);


### PR DESCRIPTION
We'll need to call this from a function because name() and symbol() are inherited from UpgradeableERC20, which we don't want to change.