### PR TITLE
Fix error message in LinearTrueDistributor

### DIFF
--- a/contracts/truefi/distributors/LinearTrueDistributor.sol
+++ b/contracts/truefi/distributors/LinearTrueDistributor.sol
@@ -89,7 +89,7 @@ contract LinearTrueDistributor is ITrueDistributor, Ownable {
      * @param newFarm New farm for distribution
      */
     function setFarm(address newFarm) external onlyOwner {
-        require(newFarm != address(0), "Farm address can't be the zero address");
+        require(newFarm != address(0), "LinearTrueDistributor: Farm address can't be the zero address");
         distribute();
         farm = newFarm;
         emit FarmChanged(newFarm);

--- a/test/truefi/distributors/LinearTrueDistributor.test.ts
+++ b/test/truefi/distributors/LinearTrueDistributor.test.ts
@@ -54,7 +54,7 @@ describe('LinearTrueDistributor', () => {
     })
 
     it('reverts if new address is zero', async () => {
-      await expect(distributor.setFarm(ZERO_ADDRESS)).to.be.revertedWith('Farm address can\'t be the zero address')
+      await expect(distributor.setFarm(ZERO_ADDRESS)).to.be.revertedWith('LinearTrueDistributor: Farm address can\'t be the zero address')
     })
 
     it('emits event when farm is set', async () => {


### PR DESCRIPTION
In PR #798 there was added an additional `require`. The error message was not set properly according to our convention. This PR introduces the fix.