### PR TITLE
Exclude Curve and 1Inch tests from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: yarn test:integration
+      - run: yarn test:integration --config .mocharc.integration-ci.js
 
 workflows:
   version: 2

--- a/.mocharc.integration-ci.js
+++ b/.mocharc.integration-ci.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  ...require('./.mocharc.integration.json'),
+  grep: /(1Inch|Curve)/i,
+  invert: true
+}


### PR DESCRIPTION
Integration tests checking interactions with foreign protocols have been failing randomly, especially during high price volatility periods. After this PR it will be our responsibility to run the integration tests when we perform any changes regarding swap/deposit logic