### PR TITLE
Add PoolFactory deprecatePool() and removePool() functions

### DIFF
--- a/contracts/truefi2/PoolFactory.sol
+++ b/contracts/truefi2/PoolFactory.sol
@@ -146,6 +146,21 @@ contract PoolFactory is IPoolFactory, UpgradeableClaimable {
     }
 
     /**
+     * @dev Deprecate a pool from token lookups without removing it from the factory.
+     * Calling this function allows owner to create a replacement pool for the same token.
+     */
+    function deprecatePool(ITrueFiPool2 legacyPool) external onlyOwner {
+        pool[address(legacyPool.token())] = address(0);
+    }
+
+    /**
+     * @dev Remove a pool from the factory regardless of deprecation status.
+     */
+    function removePool(ITrueFiPool2 legacyPool) external onlyOwner {
+        isPool[address(legacyPool)] = false;
+    }
+
+    /**
      * @dev Create a new pool behind proxy. Update new pool's implementation.
      * Transfer ownership of created pool to Factory owner.
      * @param token Address of token which the pool will correspond to.


### PR DESCRIPTION
We have to upgrade PoolFactory to allow deprecation of legacy pools before we can call `createPool()` for TUSD. This is because `createPool()` reverts if the `onlyNotExistingPools()` check fails.

I searched through the repo for possible contract side effects and breakages of this PR. After deploying this change we'll have the following sequence of states:
1. Before legacy pool deprecation: No contract behavior changes.
2. After deprecation but before new pool creation: Other contracts in the repo only ever call `isPool(TUSD)`. This never touches the `pool` mapping and hence won't fail even on the legacy pool. End users who call `pool(token)` will temporarily get `address(0)`, but that doesn't break anything.
3. After new pool creation but before removal: Ditto with 1. End users who call `pool(token)` will get the new pool address.
4. After removal: `isPool(legacy TUSD)` will fail, so TrueLender2 and LoanFactory2 will refuse to create, fund, distribute, or transfer legacy tfTUSD loans.

2 and 3 should be called back-to-back when creating a new tfTUSD pool.

4 should ONLY be called after the last legacy tfTUSD loan has been repaid. Otherwise it could lock funds in legacy tfTUSD loans.