### PR TITLE
Delete TrueFiCreditOracle public getters

### DIFF
--- a/contracts/truefi2/LoanFactory2.sol
+++ b/contracts/truefi2/LoanFactory2.sol
@@ -82,7 +82,7 @@ contract LoanFactory2 is ILoanFactory2, Initializable {
         address borrower,
         uint256 amount
     ) internal view returns (uint256) {
-        uint8 borrowerScore = creditOracle.getScore(borrower);
+        uint8 borrowerScore = creditOracle.score(borrower);
         return rateAdjuster.proFormaRate(pool, borrowerScore, amount);
     }
 

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -182,7 +182,7 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
 
     function _updateCreditScore(ITrueFiPool2 pool, address borrower) internal returns (uint8, uint8) {
         uint8 oldScore = creditScore[pool][borrower];
-        uint8 newScore = creditOracle.getScore(borrower);
+        uint8 newScore = creditOracle.score(borrower);
         creditScore[pool][borrower] = newScore;
         return (oldScore, newScore);
     }
@@ -227,12 +227,12 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
     }
 
     function borrowLimit(ITrueFiPool2 pool, address borrower) public view returns (uint256) {
-        uint256 score = uint256(creditOracle.getScore(borrower));
+        uint256 score = uint256(creditOracle.score(borrower));
         if (score < borrowLimitConfig.scoreFloor) {
             return 0;
         }
         uint8 poolDecimals = ITrueFiPool2WithDecimals(address(pool)).decimals();
-        uint256 maxBorrowerLimit = creditOracle.getMaxBorrowerLimit(borrower).mul(uint256(10)**poolDecimals).div(1 ether);
+        uint256 maxBorrowerLimit = creditOracle.maxBorrowerLimit(borrower).mul(uint256(10)**poolDecimals).div(1 ether);
         uint256 maxTVLLimit = totalTVL(poolDecimals).mul(borrowLimitConfig.tvlLimitCoefficient).div(10000);
         uint256 adjustment = borrowLimitAdjustment(score);
         uint256 creditLimit = min(maxBorrowerLimit, maxTVLLimit).mul(adjustment).div(10000);

--- a/contracts/truefi2/TrueFiCreditOracle.sol
+++ b/contracts/truefi2/TrueFiCreditOracle.sol
@@ -26,10 +26,10 @@ contract TrueFiCreditOracle is ITrueFiCreditOracle, UpgradeableClaimable {
     // ========= IN STORAGE CORRUPTION ===========
 
     // @dev Track credit scores for an account
-    mapping(address => uint8) score;
+    mapping(address => uint8) public override score;
 
     // @dev Track max borrowing limit for an account
-    mapping(address => uint256) maxBorrowerLimit;
+    mapping(address => uint256) public override maxBorrowerLimit;
 
     // @dev Manager role authorized to set credit scores
     address public manager;
@@ -90,15 +90,6 @@ contract TrueFiCreditOracle is ITrueFiCreditOracle, UpgradeableClaimable {
     }
 
     /**
-     * @dev Get score for `account`
-     * Scores are stored as uint8 allowing scores of 0-255
-     * @return Credit score for account
-     */
-    function getScore(address account) public override view returns (uint8) {
-        return score[account];
-    }
-
-    /**
      * @dev Set `newScore` value for `account`
      * Scores are stored as uint8 allowing scores of 0-255
      */
@@ -106,14 +97,6 @@ contract TrueFiCreditOracle is ITrueFiCreditOracle, UpgradeableClaimable {
         _setEligibleUntilTime(account, Math.max(eligibleUntilTime[account], block.timestamp.add(creditUpdatePeriod)));
         score[account] = newScore;
         emit ScoreChanged(account, newScore);
-    }
-
-    /**
-     * @dev Get max borrow limit for `account`
-     * Limit should be stored with 18 decimal precision
-     */
-    function getMaxBorrowerLimit(address account) public override view returns (uint256) {
-        return maxBorrowerLimit[account];
     }
 
     /**

--- a/contracts/truefi2/TrueLender2.sol
+++ b/contracts/truefi2/TrueLender2.sol
@@ -567,7 +567,7 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
 
     function isCredibleForTerm(uint256 term) internal view returns (bool) {
         if (term > longTermLoanThreshold) {
-            return creditOracle.getScore(msg.sender) >= longTermLoanScoreThreshold;
+            return creditOracle.score(msg.sender) >= longTermLoanScoreThreshold;
         }
         return true;
     }

--- a/contracts/truefi2/interface/ITrueFiCreditOracle.sol
+++ b/contracts/truefi2/interface/ITrueFiCreditOracle.sol
@@ -6,7 +6,7 @@ interface ITrueFiCreditOracle {
 
     function status(address account) external view returns (Status);
 
-    function getScore(address account) external view returns (uint8);
+    function score(address account) external view returns (uint8);
 
-    function getMaxBorrowerLimit(address account) external view returns (uint256);
+    function maxBorrowerLimit(address account) external view returns (uint256);
 }

--- a/test/truefi2/lines-of-credit/TrueFiCreditOracle.test.ts
+++ b/test/truefi2/lines-of-credit/TrueFiCreditOracle.test.ts
@@ -126,7 +126,7 @@ describe('TrueFiCreditOracle', () => {
 
     it('credit score is properly set', async () => {
       await oracle.connect(manager).setScore(borrower.address, 100)
-      expect(await oracle.getScore(borrower.address)).to.equal(100)
+      expect(await oracle.score(borrower.address)).to.equal(100)
     })
 
     it('updates eligible until time', async () => {
@@ -152,7 +152,7 @@ describe('TrueFiCreditOracle', () => {
 
     it('max borrower limit is properly set', async () => {
       await oracle.connect(manager).setMaxBorrowerLimit(borrower.address, 1_000_000)
-      expect(await oracle.getMaxBorrowerLimit(borrower.address)).to.equal(1_000_000)
+      expect(await oracle.maxBorrowerLimit(borrower.address)).to.equal(1_000_000)
     })
 
     it('updates eligible until time', async () => {


### PR DESCRIPTION
This was a minor annoyance that I pulled out of the backlog even though it doesn't really matter.

If we don't fix this API now, then we'll be locked in to maintaining the getters forever due to legacy contracts.