### PR TITLE
Move TVL calculation from TrueCreditAgency to TrueRateAdjuster

### DIFF
--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -256,24 +256,6 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
     }
 
     /**
-     * @dev Calculate total TVL in USD
-     * @param decimals Precision to return
-     * @return TVL for all pools with lines of credit
-     */
-    function totalTVL(uint8 decimals) public view returns (uint256) {
-        uint256 tvl = 0;
-        uint256 resultPrecision = uint256(10)**decimals;
-
-        // loop through pools and sum tvl accounting for precision
-        for (uint8 i = 0; i < pools.length; i++) {
-            tvl = tvl.add(
-                pools[i].poolValue().mul(resultPrecision).div(uint256(10)**(ITrueFiPool2WithDecimals(address(pools[i])).decimals()))
-            );
-        }
-        return tvl;
-    }
-
-    /**
      * @dev Get total amount borrowed for `borrower` from lines of credit in USD
      * @param borrower Borrower to get amount borrowed for
      * @param decimals Precision to use when calculating total borrowed
@@ -307,7 +289,6 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
                 pool,
                 creditOracle.score(borrower),
                 creditOracle.maxBorrowerLimit(borrower),
-                totalTVL(poolDecimals),
                 totalBorrowed(borrower, poolDecimals)
             );
     }

--- a/contracts/truefi2/TrueRateAdjuster.sol
+++ b/contracts/truefi2/TrueRateAdjuster.sol
@@ -133,7 +133,7 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
     /**
      * @dev Add `pool` to TVL calculation
      */
-    function addPooltoTVL(ITrueFiPool2 pool) external onlyOwner {
+    function addPoolToTVL(ITrueFiPool2 pool) external onlyOwner {
         for (uint256 i = 0; i < tvlPools.length; i++) {
             require(tvlPools[i] != pool, "TrueRateAdjuster: Pool has already been added to TVL");
         }

--- a/contracts/truefi2/TrueRateAdjuster.sol
+++ b/contracts/truefi2/TrueRateAdjuster.sol
@@ -134,6 +134,9 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
      * @dev Add `pool` to TVL calculation
      */
     function addPooltoTVL(ITrueFiPool2 pool) external onlyOwner {
+        for (uint256 i = 0; i < tvlPools.length; i++) {
+            require(tvlPools[i] != pool, "TrueRateAdjuster: Pool has already been added to TVL");
+        }
         tvlPools.push(pool);
         emit AddPoolToTVL(pool);
     }

--- a/contracts/truefi2/TrueRateAdjuster.sol
+++ b/contracts/truefi2/TrueRateAdjuster.sol
@@ -89,8 +89,11 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
 
     // ======= STORAGE DECLARATION END ============
 
-    /// @dev emit `pool` and `isIncluded` when TVL pool inclusion status changes
-    event TVLPool(ITrueFiPool2 pool, bool isIncluded);
+    /// @dev emit `pool` when adding to TVL
+    event AddPoolToTVL(ITrueFiPool2 pool);
+
+    /// @dev emit `pool` when removing from TVL
+    event RemovePoolFromTVL(ITrueFiPool2 pool);
 
     /// @dev Emit `newRate` when risk premium changed
     event RiskPremiumChanged(uint256 newRate);
@@ -128,21 +131,25 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
     }
 
     /**
-     * @dev Set whether `pool` is included in TVL calculation
+     * @dev Add `pool` to TVL calculation
      */
-    function setTVLPool(ITrueFiPool2 pool, bool isIncluded) external onlyOwner {
-        if (isIncluded) {
-            tvlPools.push(pool);
-        } else {
-            for (uint256 i = 0; i < tvlPools.length; i++) {
-                if (tvlPools[i] == pool) {
-                    tvlPools[i] = tvlPools[tvlPools.length - 1];
-                    tvlPools.pop();
-                    break;
-                }
+    function addPooltoTVL(ITrueFiPool2 pool) external onlyOwner {
+        tvlPools.push(pool);
+        emit AddPoolToTVL(pool);
+    }
+
+    /**
+     * @dev Remove `pool` from TVL calculation
+     */
+    function removePoolFromTVL(ITrueFiPool2 pool) external onlyOwner {
+        for (uint256 i = 0; i < tvlPools.length; i++) {
+            if (tvlPools[i] == pool) {
+                tvlPools[i] = tvlPools[tvlPools.length - 1];
+                tvlPools.pop();
+                break;
             }
         }
-        emit TVLPool(pool, isIncluded);
+        emit RemovePoolFromTVL(pool);
     }
 
     /// @dev Set risk premium to `newRate`

--- a/contracts/truefi2/TrueRateAdjuster.sol
+++ b/contracts/truefi2/TrueRateAdjuster.sol
@@ -90,10 +90,10 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
     // ======= STORAGE DECLARATION END ============
 
     /// @dev emit `pool` when adding to TVL
-    event AddPoolToTVL(ITrueFiPool2 pool);
+    event PoolAddedToTVL(ITrueFiPool2 pool);
 
     /// @dev emit `pool` when removing from TVL
-    event RemovePoolFromTVL(ITrueFiPool2 pool);
+    event PoolRemovedFromTVL(ITrueFiPool2 pool);
 
     /// @dev Emit `newRate` when risk premium changed
     event RiskPremiumChanged(uint256 newRate);
@@ -138,7 +138,7 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
             require(tvlPools[i] != pool, "TrueRateAdjuster: Pool has already been added to TVL");
         }
         tvlPools.push(pool);
-        emit AddPoolToTVL(pool);
+        emit PoolAddedToTVL(pool);
     }
 
     /**
@@ -149,7 +149,7 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
             if (tvlPools[i] == pool) {
                 tvlPools[i] = tvlPools[tvlPools.length - 1];
                 tvlPools.pop();
-                emit RemovePoolFromTVL(pool);
+                emit PoolRemovedFromTVL(pool);
                 return;
             }
         }

--- a/contracts/truefi2/TrueRateAdjuster.sol
+++ b/contracts/truefi2/TrueRateAdjuster.sol
@@ -303,16 +303,16 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
      * @param decimals Precision to return
      * @return TVL for all pools
      */
-    function totalTVL(uint8 decimals) public view returns (uint256) {
-        uint256 tvl = 0;
+    function tvl(uint8 decimals) public view returns (uint256) {
+        uint256 _tvl = 0;
         uint256 resultPrecision = uint256(10)**decimals;
 
         // loop through pools and sum tvl accounting for precision
         for (uint256 i = 0; i < tvlPools.length; i++) {
             uint8 poolDecimals = ITrueFiPool2WithDecimals(address(tvlPools[i])).decimals();
-            tvl = tvl.add(tvlPools[i].poolValue().mul(resultPrecision).div(uint256(10)**poolDecimals));
+            _tvl = _tvl.add(tvlPools[i].poolValue().mul(resultPrecision).div(uint256(10)**poolDecimals));
         }
-        return tvl;
+        return _tvl;
     }
 
     /**
@@ -334,7 +334,7 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
         }
         uint8 poolDecimals = ITrueFiPool2WithDecimals(address(pool)).decimals();
         maxBorrowerLimit = maxBorrowerLimit.mul(uint256(10)**poolDecimals).div(1 ether);
-        uint256 maxTVLLimit = totalTVL(poolDecimals).mul(borrowLimitConfig.tvlLimitCoefficient).div(BASIS_POINTS);
+        uint256 maxTVLLimit = tvl(poolDecimals).mul(borrowLimitConfig.tvlLimitCoefficient).div(BASIS_POINTS);
         uint256 adjustment = borrowLimitAdjustment(score);
         uint256 creditLimit = min(maxBorrowerLimit, maxTVLLimit).mul(adjustment).div(BASIS_POINTS);
         uint256 poolBorrowMax = min(pool.poolValue().mul(borrowLimitConfig.poolValueLimitCoefficient).div(BASIS_POINTS), creditLimit);

--- a/contracts/truefi2/TrueRateAdjuster.sol
+++ b/contracts/truefi2/TrueRateAdjuster.sol
@@ -149,10 +149,11 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
             if (tvlPools[i] == pool) {
                 tvlPools[i] = tvlPools[tvlPools.length - 1];
                 tvlPools.pop();
-                break;
+                emit RemovePoolFromTVL(pool);
+                return;
             }
         }
-        emit RemovePoolFromTVL(pool);
+        revert("TrueRateAdjuster: Pool already removed from TVL");
     }
 
     /// @dev Set risk premium to `newRate`

--- a/contracts/truefi2/TrueRateAdjuster.sol
+++ b/contracts/truefi2/TrueRateAdjuster.sol
@@ -308,7 +308,7 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
         uint256 resultPrecision = uint256(10)**decimals;
 
         // loop through pools and sum tvl accounting for precision
-        for (uint8 i = 0; i < tvlPools.length; i++) {
+        for (uint256 i = 0; i < tvlPools.length; i++) {
             uint8 poolDecimals = ITrueFiPool2WithDecimals(address(tvlPools[i])).decimals();
             tvl = tvl.add(tvlPools[i].poolValue().mul(resultPrecision).div(uint256(10)**poolDecimals));
         }

--- a/contracts/truefi2/interface/ITrueRateAdjuster.sol
+++ b/contracts/truefi2/interface/ITrueRateAdjuster.sol
@@ -28,7 +28,6 @@ interface ITrueRateAdjuster {
         ITrueFiPool2 pool,
         uint8 score,
         uint256 maxBorrowerLimit,
-        uint256 totalTVL,
         uint256 totalBorrowed
     ) external view returns (uint256);
 }

--- a/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
@@ -235,7 +235,7 @@ describe('TrueCreditAgency', () => {
     })
   })
 
-  describe('totalTVL & totalBorrowed', () => {
+  describe('totalBorrowed & poolValue', () => {
     beforeEach(async () => {
       await usdcPool.setCreditAgency(creditAgency.address)
       await creditAgency.allowPool(usdcPool.address, true)
@@ -245,10 +245,6 @@ describe('TrueCreditAgency', () => {
       await usdcPool.join(parseUSDC(2e7))
     })
 
-    it('totalTVL returns sum of poolValues of all pools with 18 decimals precision', async () => {
-      expect(await creditAgency.totalTVL(18)).to.equal(parseEth(3e7))
-    })
-
     it('totalBorrowed returns total borrowed amount across all pools with 18 decimals precision', async () => {
       await creditAgency.allowBorrower(borrower.address, true)
       await creditAgency.connect(borrower).borrow(tusdPool.address, parseEth(100))
@@ -256,19 +252,19 @@ describe('TrueCreditAgency', () => {
       expect(await creditAgency.totalBorrowed(borrower.address, 18)).to.equal(parseEth(600))
     })
 
-    it('totalTVL remains unchanged after borrowing', async () => {
-      expect(await creditAgency.totalTVL(18)).to.equal(parseEth(3e7))
+    it('poolValue remains unchanged after borrowing', async () => {
+      expect(await tusdPool.poolValue()).to.equal(parseEth(1e7))
       await creditAgency.allowBorrower(borrower.address, true)
       await creditAgency.connect(borrower).borrow(tusdPool.address, parseEth(100))
-      expect(await creditAgency.totalTVL(18)).to.equal(parseEth(3e7))
+      expect(await tusdPool.poolValue()).to.equal(parseEth(1e7))
     })
 
-    it('totalTVL scales with credit interest', async () => {
-      expect(await creditAgency.totalTVL(18)).to.equal(parseEth(3e7))
+    it('poolValue scales with credit interest', async () => {
+      expect(await tusdPool.poolValue()).to.equal(parseEth(1e7))
       await creditAgency.allowBorrower(borrower.address, true)
       await creditAgency.connect(borrower).borrow(tusdPool.address, parseEth(100))
       await timeTravel(YEAR)
-      expectScaledCloseTo(await creditAgency.totalTVL(18), parseEth(3e7).add(parseEth(1)))
+      expectScaledCloseTo(await tusdPool.poolValue(), parseEth(1e7).add(parseEth(1)))
     })
   })
 

--- a/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
@@ -347,7 +347,7 @@ describe('TrueCreditAgency', () => {
 
     it('borrow amount is limited by total TVL', async () => {
       await usdcPool.liquidExit(parseUSDC(19e6))
-      const maxTVLLimit = (await rateAdjuster.totalTVL(18)).mul(15).div(100)
+      const maxTVLLimit = (await rateAdjuster.tvl(18)).mul(15).div(100)
       expect(await creditAgency.borrowLimit(tusdPool.address, borrower.address)).to.equal(maxTVLLimit.mul(8051).div(10000))
     })
 

--- a/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
@@ -347,7 +347,7 @@ describe('TrueCreditAgency', () => {
 
     it('borrow amount is limited by total TVL', async () => {
       await usdcPool.liquidExit(parseUSDC(19e6))
-      const maxTVLLimit = (await creditAgency.totalTVL(18)).mul(15).div(100)
+      const maxTVLLimit = (await rateAdjuster.totalTVL(18)).mul(15).div(100)
       expect(await creditAgency.borrowLimit(tusdPool.address, borrower.address)).to.equal(maxTVLLimit.mul(8051).div(10000))
     })
 

--- a/test/truefi2/lines-of-credit/TrueRateAdjuster.test.ts
+++ b/test/truefi2/lines-of-credit/TrueRateAdjuster.test.ts
@@ -350,8 +350,8 @@ describe('TrueRateAdjuster', () => {
       await mockPool.mock.poolValue.returns(parseEth(1e7))
       await mockPool2.mock.decimals.returns(6)
       await mockPool2.mock.poolValue.returns(parseUSDC(1e7))
-      await rateAdjuster.addPooltoTVL(mockPool.address)
-      await rateAdjuster.addPooltoTVL(mockPool2.address)
+      await rateAdjuster.addPoolToTVL(mockPool.address)
+      await rateAdjuster.addPoolToTVL(mockPool2.address)
     })
 
     it('borrow amount is limited by borrower limit', async () => {

--- a/test/truefi2/lines-of-credit/TrueRateAdjuster.test.ts
+++ b/test/truefi2/lines-of-credit/TrueRateAdjuster.test.ts
@@ -78,37 +78,35 @@ describe('TrueRateAdjuster', () => {
     const pool3 = '0x3333333333333333333333333333333333333333'
     const pool4 = '0x4444444444444444444444444444444444444444'
 
+    beforeEach(async () => {
+      await rateAdjuster.addPoolToTVL(pool1)
+      await rateAdjuster.addPoolToTVL(pool2)
+      await rateAdjuster.addPoolToTVL(pool4)
+    })
+
     it('reverts if caller is not the owner', async () => {
-      await expect(rateAdjuster.connect(borrower).addPoolToTVL(pool1))
+      await expect(rateAdjuster.connect(borrower).addPoolToTVL(pool3))
         .to.be.revertedWith('Ownable: caller is not the owner')
     })
 
     it('reverts if pool has already been added', async () => {
-      await rateAdjuster.addPoolToTVL(pool1)
-      await rateAdjuster.addPoolToTVL(pool2)
-      await rateAdjuster.addPoolToTVL(pool3)
-      await rateAdjuster.addPoolToTVL(pool4)
-
-      await expect(rateAdjuster.addPoolToTVL(pool3))
+      await expect(rateAdjuster.addPoolToTVL(pool2))
         .to.be.revertedWith('TrueRateAdjuster: Pool has already been added to TVL')
     })
 
     it('adds pools to array', async () => {
-      await rateAdjuster.addPoolToTVL(pool1)
-      await rateAdjuster.addPoolToTVL(pool2)
       await rateAdjuster.addPoolToTVL(pool3)
-      await rateAdjuster.addPoolToTVL(pool4)
 
       expect(await rateAdjuster.tvlPools(0)).eq(pool1)
       expect(await rateAdjuster.tvlPools(1)).eq(pool2)
-      expect(await rateAdjuster.tvlPools(2)).eq(pool3)
-      expect(await rateAdjuster.tvlPools(3)).eq(pool4)
+      expect(await rateAdjuster.tvlPools(2)).eq(pool4)
+      expect(await rateAdjuster.tvlPools(3)).eq(pool3)
     })
 
     it('emits event', async () => {
-      await expect(rateAdjuster.addPoolToTVL(pool1))
+      await expect(rateAdjuster.addPoolToTVL(pool3))
         .to.emit(rateAdjuster, 'PoolAddedToTVL')
-        .withArgs(pool1)
+        .withArgs(pool3)
     })
   })
 
@@ -118,40 +116,32 @@ describe('TrueRateAdjuster', () => {
     const pool3 = '0x3333333333333333333333333333333333333333'
     const pool4 = '0x4444444444444444444444444444444444444444'
 
+    beforeEach(async () => {
+      await rateAdjuster.addPoolToTVL(pool1)
+      await rateAdjuster.addPoolToTVL(pool2)
+      await rateAdjuster.addPoolToTVL(pool4)
+    })
+
     it('reverts if caller is not the owner', async () => {
-      await expect(rateAdjuster.connect(borrower).removePoolFromTVL(pool1))
+      await expect(rateAdjuster.connect(borrower).removePoolFromTVL(pool2))
         .to.be.revertedWith('Ownable: caller is not the owner')
     })
 
     it('reverts if pool not in array', async () => {
-      await rateAdjuster.addPoolToTVL(pool1)
-      await rateAdjuster.addPoolToTVL(pool2)
-      await rateAdjuster.addPoolToTVL(pool4)
-
       await expect(rateAdjuster.removePoolFromTVL(pool3)).to.be.revertedWith('TrueRateAdjuster: Pool already removed from TVL')
     })
 
     it('removes pool from array', async () => {
-      await rateAdjuster.addPoolToTVL(pool1)
-      await rateAdjuster.addPoolToTVL(pool2)
-      await rateAdjuster.addPoolToTVL(pool3)
-      await rateAdjuster.addPoolToTVL(pool4)
+      await rateAdjuster.removePoolFromTVL(pool2)
 
-      await rateAdjuster.removePoolFromTVL(pool3)
       expect(await rateAdjuster.tvlPools(0)).eq(pool1)
-      expect(await rateAdjuster.tvlPools(1)).eq(pool2)
-      expect(await rateAdjuster.tvlPools(2)).eq(pool4)
+      expect(await rateAdjuster.tvlPools(1)).eq(pool4)
     })
 
     it('emits event', async () => {
-      await rateAdjuster.addPoolToTVL(pool1)
-      await rateAdjuster.addPoolToTVL(pool2)
-      await rateAdjuster.addPoolToTVL(pool3)
-      await rateAdjuster.addPoolToTVL(pool4)
-
-      await expect(rateAdjuster.removePoolFromTVL(pool3))
+      await expect(rateAdjuster.removePoolFromTVL(pool2))
         .to.emit(rateAdjuster, 'PoolRemovedFromTVL')
-        .withArgs(pool3)
+        .withArgs(pool2)
     })
   })
 

--- a/test/truefi2/lines-of-credit/TrueRateAdjuster.test.ts
+++ b/test/truefi2/lines-of-credit/TrueRateAdjuster.test.ts
@@ -350,8 +350,8 @@ describe('TrueRateAdjuster', () => {
       await mockPool.mock.poolValue.returns(parseEth(1e7))
       await mockPool2.mock.decimals.returns(6)
       await mockPool2.mock.poolValue.returns(parseUSDC(1e7))
-      await rateAdjuster.setTVLPool(mockPool.address, true)
-      await rateAdjuster.setTVLPool(mockPool2.address, true)
+      await rateAdjuster.addPooltoTVL(mockPool.address)
+      await rateAdjuster.addPooltoTVL(mockPool2.address)
     })
 
     it('borrow amount is limited by borrower limit', async () => {

--- a/test/utils/setupTruefi2.ts
+++ b/test/utils/setupTruefi2.ts
@@ -89,8 +89,8 @@ export const setupTruefi2 = async (owner: Wallet, provider: MockProvider, custom
 
   await rateAdjuster.setBaseRateOracle(standardPool.address, standardBaseRateOracle.address)
   await rateAdjuster.setBaseRateOracle(feePool.address, feeBaseRateOracle.address)
-  await rateAdjuster.addPooltoTVL(standardPool.address)
-  await rateAdjuster.addPooltoTVL(feePool.address)
+  await rateAdjuster.addPoolToTVL(standardPool.address)
+  await rateAdjuster.addPoolToTVL(feePool.address)
 
   await mockRateAdjuster.mock.rate.returns(0)
   await mockRateAdjuster.mock.fixedTermLoanAdjustment.returns(0)

--- a/test/utils/setupTruefi2.ts
+++ b/test/utils/setupTruefi2.ts
@@ -89,6 +89,8 @@ export const setupTruefi2 = async (owner: Wallet, provider: MockProvider, custom
 
   await rateAdjuster.setBaseRateOracle(standardPool.address, standardBaseRateOracle.address)
   await rateAdjuster.setBaseRateOracle(feePool.address, feeBaseRateOracle.address)
+  await rateAdjuster.setTVLPool(standardPool.address, true)
+  await rateAdjuster.setTVLPool(feePool.address, true)
 
   await mockRateAdjuster.mock.rate.returns(0)
   await mockRateAdjuster.mock.fixedTermLoanAdjustment.returns(0)

--- a/test/utils/setupTruefi2.ts
+++ b/test/utils/setupTruefi2.ts
@@ -89,8 +89,8 @@ export const setupTruefi2 = async (owner: Wallet, provider: MockProvider, custom
 
   await rateAdjuster.setBaseRateOracle(standardPool.address, standardBaseRateOracle.address)
   await rateAdjuster.setBaseRateOracle(feePool.address, feeBaseRateOracle.address)
-  await rateAdjuster.setTVLPool(standardPool.address, true)
-  await rateAdjuster.setTVLPool(feePool.address, true)
+  await rateAdjuster.addPooltoTVL(standardPool.address)
+  await rateAdjuster.addPooltoTVL(feePool.address)
 
   await mockRateAdjuster.mock.rate.returns(0)
   await mockRateAdjuster.mock.fixedTermLoanAdjustment.returns(0)


### PR DESCRIPTION
If we move total TVL to TRA, then TrueLender2 should have access to all the info it requires to calculate `borrowLimit()` _without_ adding TrueCreditAgency as a dependency. Hopefully that resolves this discussion favorably: https://github.com/trusttoken/smart-contracts/pull/885#discussion_r693176256