### PR TITLE
Deploy SAFU + Liquidator2 to mainnet

### DIFF
--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -52,114 +52,128 @@ const deployParams = {
 
 deploy({}, (_, config) => {
   const proxy = createProxy(OwnedUpgradeabilityProxy)
-  const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
-  const isMainnet = config.network === 'mainnet'
-  const NETWORK = isMainnet ? 'mainnet' : 'testnet'
+  // const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
+  // const isMainnet = config.network === 'mainnet'
+  // const NETWORK = isMainnet ? 'mainnet' : 'testnet'
 
-  // Existing contracts
-  const trustToken = isMainnet
-    ? timeProxy(contract(TrustToken), () => {})
-    : timeProxy(contract(TestTrustToken), () => {})
-  const stkTruToken = proxy(contract(StkTruToken), () => {})
-  const trueFiPool = isMainnet
-    ? proxy(contract(TrueFiPool), () => {})
-    : proxy(contract(TestTrueFiPool), () => {})
-  const usdc = isMainnet
-    ? deployParams['mainnet'].USDC
-    : contract(TestUSDCToken)
-  const usdt = isMainnet
-    ? deployParams['mainnet'].USDT
-    : contract(TestUSDTToken)
-  const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
+  // // Existing contracts
+  // const trustToken = isMainnet
+  //   ? timeProxy(contract(TrustToken), () => {})
+  //   : timeProxy(contract(TestTrustToken), () => {})
+  // const stkTruToken = proxy(contract(StkTruToken), () => {})
+  // const trueFiPool = isMainnet
+  //   ? proxy(contract(TrueFiPool), () => {})
+  //   : proxy(contract(TestTrueFiPool), () => {})
+  // const usdc = isMainnet
+  //   ? deployParams['mainnet'].USDC
+  //   : contract(TestUSDCToken)
+  // const usdt = isMainnet
+  //   ? deployParams['mainnet'].USDT
+  //   : contract(TestUSDTToken)
+  // const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
 
-  // New contract impls
-  const trueLender2_impl = contract(TrueLender2)
-  const poolFactory_impl = contract(PoolFactory)
-  const liquidator2_impl = contract(Liquidator2)
-  const loanFactory2_impl = contract(LoanFactory2)
+  // // New contract impls
+  // const trueLender2_impl = contract(TrueLender2)
+  // const poolFactory_impl = contract(PoolFactory)
+  // const liquidator2_impl = contract(Liquidator2)
+  // const loanFactory2_impl = contract(LoanFactory2)
   const safu_impl = contract(SAFU)
-  const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
-  const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
-  const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
+  // const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  // const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
+  // const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  // const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
+  // const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
 
-  // New contract proxies
-  const trueLender2 = proxy(trueLender2_impl, () => {})
-  const poolFactory = proxy(poolFactory_impl, () => {})
-  const liquidator2 = proxy(liquidator2_impl, () => {})
-  const loanFactory2 = proxy(loanFactory2_impl, () => {})
-  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
-  const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
-  const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
+  // // New contract proxies
+  // const trueLender2 = proxy(trueLender2_impl, () => {})
+  // const poolFactory = proxy(poolFactory_impl, () => {})
+  // const liquidator2 = proxy(liquidator2_impl, () => {})
+  // const loanFactory2 = proxy(loanFactory2_impl, () => {})
+  // const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  // const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
+  // const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  // const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
+  // const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
   const safu = proxy(safu_impl, () => {})
-  // New bare contracts
-  const trueFiPool2 = contract(TrueFiPool2)
-  const implementationReference = contract(ImplementationReference, [trueFiPool2])
-  const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
-  const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
-  const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
-  const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
+  // // New bare contracts
+  // const trueFiPool2 = contract(TrueFiPool2)
+  // const implementationReference = contract(ImplementationReference, [trueFiPool2])
+  // const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
+  // const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
+  // const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
+  // const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
 
-  // Contract initialization
+  // // Contract initialization
+  const MULTISIG = '0x16cEa306506c387713C70b9C1205fd5aC997E78E'
+  const LOAN_FACTORY_2 = '0x69d844fB5928d0e7Bc530cC6325A88e53d6685BC'
+  const LIQUIDATOR_2 = '0x7aC899754Dd042024bb168fd5c9a07420F444Bdf'
   runIf(safu.isInitialized().not(), () => {
-    safu.initialize(loanFactory2, liquidator2, oneInch)
+    safu.initialize(LOAN_FACTORY_2, LIQUIDATOR_2, ONE_INCH_EXCHANGE)
   })
-  runIf(poolFactory.isInitialized().not(), () => {
-    poolFactory.initialize(implementationReference, trueLender2, safu)
-  })
-  runIf(trueLender2.isInitialized().not(), () => {
-    trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle)
-  })
-  runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
-    trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
-  })
-  runIf(loanFactory2.isInitialized().not(), () => {
-    loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, AddressZero)
-  })
-  runIf(liquidator2.isInitialized().not(), () => {
-    liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
-  })
-  runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
-    poolFactory.allowToken(usdc, true)
-    poolFactory.createPool(usdc)
-  })
-  const usdc_TrueFiPool2 = poolFactory.pool(usdc)
-  runIf(trueLender2.feePool().equals(AddressZero), () => {
-    trueLender2.setFeePool(usdc_TrueFiPool2)
-  })
-  runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-    usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  })
-  runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
-    usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
-  })
-  runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-    usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
-  })
-  runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
-    poolFactory.allowToken(usdt, true)
-    poolFactory.createPool(usdt)
-  })
-  const usdt_TrueFiPool2 = poolFactory.pool(usdt)
-  runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-    usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  })
-  runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
-    usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
-  })
-  runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-    usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
-  })
-  runIf(trueFiCreditOracle.isInitialized().not(), () => {
-    trueFiCreditOracle.initialize()
-  })
-  if (!isMainnet) {
-    trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
-  }
-  runIf(poolFactory.isPool(trueFiPool).not(), () => {
-    poolFactory.addLegacyPool(trueFiPool)
-  })
+  safu.transferOwnership(MULTISIG)
+  // TODO manually call:
+  // safu.transferProxyOwnership(MULTISIG)
+
+  // TODO multisig call:
+  // safu.claimOwnership()
+  // safu.claimProxyOwnership()
+  // poolFactory.setSafuAddress(safu)
+  // legacytfTUSD.setSafuAddress(safu)
+  // tfTUSD.setSafuAddress(safu)
+  // tfUSDC.setSafuAddress(safu)
+  // tfUSDT.setSafuAddress(safu)
+
+
+  // runIf(trueLender2.isInitialized().not(), () => {
+  //   trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle)
+  // })
+  // runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
+  //   trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
+  // })
+  // runIf(loanFactory2.isInitialized().not(), () => {
+  //   loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, AddressZero)
+  // })
+  // runIf(liquidator2.isInitialized().not(), () => {
+  //   liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
+  // })
+  // runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
+  //   poolFactory.allowToken(usdc, true)
+  //   poolFactory.createPool(usdc)
+  // })
+  // const usdc_TrueFiPool2 = poolFactory.pool(usdc)
+  // runIf(trueLender2.feePool().equals(AddressZero), () => {
+  //   trueLender2.setFeePool(usdc_TrueFiPool2)
+  // })
+  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+  //   usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  // })
+  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
+  //   usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
+  // })
+  // runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+  //   usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
+  // })
+  // runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
+  //   poolFactory.allowToken(usdt, true)
+  //   poolFactory.createPool(usdt)
+  // })
+  // const usdt_TrueFiPool2 = poolFactory.pool(usdt)
+  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+  //   usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  // })
+  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
+  //   usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
+  // })
+  // runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+  //   usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
+  // })
+  // runIf(trueFiCreditOracle.isInitialized().not(), () => {
+  //   trueFiCreditOracle.initialize()
+  // })
+  // if (!isMainnet) {
+  //   trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
+  // }
+  // runIf(poolFactory.isPool(trueFiPool).not(), () => {
+  //   poolFactory.addLegacyPool(trueFiPool)
+  // })
 })

--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -51,115 +51,115 @@ const deployParams = {
 }
 
 deploy({}, (_, config) => {
-  // const proxy = createProxy(OwnedUpgradeabilityProxy)
-  // const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
-  // const isMainnet = config.network === 'mainnet'
-  // const NETWORK = isMainnet ? 'mainnet' : 'testnet'
+  const proxy = createProxy(OwnedUpgradeabilityProxy)
+  const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
+  const isMainnet = config.network === 'mainnet'
+  const NETWORK = isMainnet ? 'mainnet' : 'testnet'
 
-  // // Existing contracts
-  // const trustToken = isMainnet
-  //   ? timeProxy(contract(TrustToken), () => {})
-  //   : timeProxy(contract(TestTrustToken), () => {})
-  // const stkTruToken = proxy(contract(StkTruToken), () => {})
-  // const trueFiPool = isMainnet
-  //   ? proxy(contract(TrueFiPool), () => {})
-  //   : proxy(contract(TestTrueFiPool), () => {})
-  // const usdc = isMainnet
-  //   ? deployParams['mainnet'].USDC
-  //   : contract(TestUSDCToken)
-  // const usdt = isMainnet
-  //   ? deployParams['mainnet'].USDT
-  //   : contract(TestUSDTToken)
-  // const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
+  // Existing contracts
+  const trustToken = isMainnet
+    ? timeProxy(contract(TrustToken), () => {})
+    : timeProxy(contract(TestTrustToken), () => {})
+  const stkTruToken = proxy(contract(StkTruToken), () => {})
+  const trueFiPool = isMainnet
+    ? proxy(contract(TrueFiPool), () => {})
+    : proxy(contract(TestTrueFiPool), () => {})
+  const usdc = isMainnet
+    ? deployParams['mainnet'].USDC
+    : contract(TestUSDCToken)
+  const usdt = isMainnet
+    ? deployParams['mainnet'].USDT
+    : contract(TestUSDTToken)
+  const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
 
-  // // New contract impls
-  // const trueLender2_impl = contract(TrueLender2)
-  // const poolFactory_impl = contract(PoolFactory)
+  // New contract impls
+  const trueLender2_impl = contract(TrueLender2)
+  const poolFactory_impl = contract(PoolFactory)
   const liquidator2_impl = contract(Liquidator2)
-  // const loanFactory2_impl = contract(LoanFactory2)
-  // const safu_impl = contract(SAFU)
-  // const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  // const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
-  // const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  // const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
-  // const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
+  const loanFactory2_impl = contract(LoanFactory2)
+  const safu_impl = contract(SAFU)
+  const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
+  const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
+  const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
 
-  // // New contract proxies
-  // const trueLender2 = proxy(trueLender2_impl, () => {})
-  // const poolFactory = proxy(poolFactory_impl, () => {})
-  // const liquidator2 = proxy(liquidator2_impl, () => {})
-  // const loanFactory2 = proxy(loanFactory2_impl, () => {})
-  // const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  // const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
-  // const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  // const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
-  // const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
-  // const safu = proxy(safu_impl, () => {})
-  // // New bare contracts
-  // const trueFiPool2 = contract(TrueFiPool2)
-  // const implementationReference = contract(ImplementationReference, [trueFiPool2])
-  // const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
-  // const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
-  // const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
-  // const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
+  // New contract proxies
+  const trueLender2 = proxy(trueLender2_impl, () => {})
+  const poolFactory = proxy(poolFactory_impl, () => {})
+  const liquidator2 = proxy(liquidator2_impl, () => {})
+  const loanFactory2 = proxy(loanFactory2_impl, () => {})
+  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
+  const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
+  const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
+  const safu = proxy(safu_impl, () => {})
+  // New bare contracts
+  const trueFiPool2 = contract(TrueFiPool2)
+  const implementationReference = contract(ImplementationReference, [trueFiPool2])
+  const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
+  const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
+  const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
+  const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
 
-  // // Contract initialization
-  // runIf(safu.isInitialized().not(), () => {
-  //   safu.initialize(loanFactory2, liquidator2, oneInch)
-  // })
-  // runIf(poolFactory.isInitialized().not(), () => {
-  //   poolFactory.initialize(implementationReference, trueLender2, safu)
-  // })
-  // runIf(trueLender2.isInitialized().not(), () => {
-  //   trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle)
-  // })
-  // runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
-  //   trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
-  // })
-  // runIf(loanFactory2.isInitialized().not(), () => {
-  //   loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, AddressZero)
-  // })
-  // runIf(liquidator2.isInitialized().not(), () => {
-  //   liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
-  // })
-  // runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
-  //   poolFactory.allowToken(usdc, true)
-  //   poolFactory.createPool(usdc)
-  // })
-  // const usdc_TrueFiPool2 = poolFactory.pool(usdc)
-  // runIf(trueLender2.feePool().equals(AddressZero), () => {
-  //   trueLender2.setFeePool(usdc_TrueFiPool2)
-  // })
-  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-  //   usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  // })
-  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
-  //   usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
-  // })
-  // runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-  //   usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
-  // })
-  // runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
-  //   poolFactory.allowToken(usdt, true)
-  //   poolFactory.createPool(usdt)
-  // })
-  // const usdt_TrueFiPool2 = poolFactory.pool(usdt)
-  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-  //   usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  // })
-  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
-  //   usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
-  // })
-  // runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-  //   usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
-  // })
-  // runIf(trueFiCreditOracle.isInitialized().not(), () => {
-  //   trueFiCreditOracle.initialize()
-  // })
-  // if (!isMainnet) {
-  //   trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
-  // }
-  // runIf(poolFactory.isPool(trueFiPool).not(), () => {
-  //   poolFactory.addLegacyPool(trueFiPool)
-  // })
+  // Contract initialization
+  runIf(safu.isInitialized().not(), () => {
+    safu.initialize(loanFactory2, liquidator2, oneInch)
+  })
+  runIf(poolFactory.isInitialized().not(), () => {
+    poolFactory.initialize(implementationReference, trueLender2, safu)
+  })
+  runIf(trueLender2.isInitialized().not(), () => {
+    trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle)
+  })
+  runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
+    trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
+  })
+  runIf(loanFactory2.isInitialized().not(), () => {
+    loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, AddressZero)
+  })
+  runIf(liquidator2.isInitialized().not(), () => {
+    liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
+  })
+  runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
+    poolFactory.allowToken(usdc, true)
+    poolFactory.createPool(usdc)
+  })
+  const usdc_TrueFiPool2 = poolFactory.pool(usdc)
+  runIf(trueLender2.feePool().equals(AddressZero), () => {
+    trueLender2.setFeePool(usdc_TrueFiPool2)
+  })
+  runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+    usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  })
+  runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
+    usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
+  })
+  runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+    usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
+  })
+  runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
+    poolFactory.allowToken(usdt, true)
+    poolFactory.createPool(usdt)
+  })
+  const usdt_TrueFiPool2 = poolFactory.pool(usdt)
+  runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+    usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  })
+  runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
+    usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
+  })
+  runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+    usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
+  })
+  runIf(trueFiCreditOracle.isInitialized().not(), () => {
+    trueFiCreditOracle.initialize()
+  })
+  if (!isMainnet) {
+    trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
+  }
+  runIf(poolFactory.isPool(trueFiPool).not(), () => {
+    poolFactory.addLegacyPool(trueFiPool)
+  })
 })

--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -51,115 +51,115 @@ const deployParams = {
 }
 
 deploy({}, (_, config) => {
-  const proxy = createProxy(OwnedUpgradeabilityProxy)
-  const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
-  const isMainnet = config.network === 'mainnet'
-  const NETWORK = isMainnet ? 'mainnet' : 'testnet'
+  // const proxy = createProxy(OwnedUpgradeabilityProxy)
+  // const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
+  // const isMainnet = config.network === 'mainnet'
+  // const NETWORK = isMainnet ? 'mainnet' : 'testnet'
 
-  // Existing contracts
-  const trustToken = isMainnet
-    ? timeProxy(contract(TrustToken), () => {})
-    : timeProxy(contract(TestTrustToken), () => {})
-  const stkTruToken = proxy(contract(StkTruToken), () => {})
-  const trueFiPool = isMainnet
-    ? proxy(contract(TrueFiPool), () => {})
-    : proxy(contract(TestTrueFiPool), () => {})
-  const usdc = isMainnet
-    ? deployParams['mainnet'].USDC
-    : contract(TestUSDCToken)
-  const usdt = isMainnet
-    ? deployParams['mainnet'].USDT
-    : contract(TestUSDTToken)
-  const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
+  // // Existing contracts
+  // const trustToken = isMainnet
+  //   ? timeProxy(contract(TrustToken), () => {})
+  //   : timeProxy(contract(TestTrustToken), () => {})
+  // const stkTruToken = proxy(contract(StkTruToken), () => {})
+  // const trueFiPool = isMainnet
+  //   ? proxy(contract(TrueFiPool), () => {})
+  //   : proxy(contract(TestTrueFiPool), () => {})
+  // const usdc = isMainnet
+  //   ? deployParams['mainnet'].USDC
+  //   : contract(TestUSDCToken)
+  // const usdt = isMainnet
+  //   ? deployParams['mainnet'].USDT
+  //   : contract(TestUSDTToken)
+  // const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
 
-  // New contract impls
-  const trueLender2_impl = contract(TrueLender2)
-  const poolFactory_impl = contract(PoolFactory)
+  // // New contract impls
+  // const trueLender2_impl = contract(TrueLender2)
+  // const poolFactory_impl = contract(PoolFactory)
   const liquidator2_impl = contract(Liquidator2)
-  const loanFactory2_impl = contract(LoanFactory2)
-  const safu_impl = contract(SAFU)
-  const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
-  const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
-  const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
+  // const loanFactory2_impl = contract(LoanFactory2)
+  // const safu_impl = contract(SAFU)
+  // const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  // const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
+  // const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  // const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
+  // const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
 
-  // New contract proxies
-  const trueLender2 = proxy(trueLender2_impl, () => {})
-  const poolFactory = proxy(poolFactory_impl, () => {})
-  const liquidator2 = proxy(liquidator2_impl, () => {})
-  const loanFactory2 = proxy(loanFactory2_impl, () => {})
-  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
-  const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
-  const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
-  const safu = proxy(safu_impl, () => {})
-  // New bare contracts
-  const trueFiPool2 = contract(TrueFiPool2)
-  const implementationReference = contract(ImplementationReference, [trueFiPool2])
-  const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
-  const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
-  const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
-  const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
+  // // New contract proxies
+  // const trueLender2 = proxy(trueLender2_impl, () => {})
+  // const poolFactory = proxy(poolFactory_impl, () => {})
+  // const liquidator2 = proxy(liquidator2_impl, () => {})
+  // const loanFactory2 = proxy(loanFactory2_impl, () => {})
+  // const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  // const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
+  // const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  // const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
+  // const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
+  // const safu = proxy(safu_impl, () => {})
+  // // New bare contracts
+  // const trueFiPool2 = contract(TrueFiPool2)
+  // const implementationReference = contract(ImplementationReference, [trueFiPool2])
+  // const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
+  // const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
+  // const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
+  // const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
 
-  // Contract initialization
-  runIf(safu.isInitialized().not(), () => {
-    safu.initialize(loanFactory2, liquidator2, oneInch)
-  })
-  runIf(poolFactory.isInitialized().not(), () => {
-    poolFactory.initialize(implementationReference, trueLender2, safu)
-  })
-  runIf(trueLender2.isInitialized().not(), () => {
-    trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle)
-  })
-  runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
-    trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
-  })
-  runIf(loanFactory2.isInitialized().not(), () => {
-    loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, AddressZero)
-  })
-  runIf(liquidator2.isInitialized().not(), () => {
-    liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
-  })
-  runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
-    poolFactory.allowToken(usdc, true)
-    poolFactory.createPool(usdc)
-  })
-  const usdc_TrueFiPool2 = poolFactory.pool(usdc)
-  runIf(trueLender2.feePool().equals(AddressZero), () => {
-    trueLender2.setFeePool(usdc_TrueFiPool2)
-  })
-  runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-    usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  })
-  runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
-    usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
-  })
-  runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-    usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
-  })
-  runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
-    poolFactory.allowToken(usdt, true)
-    poolFactory.createPool(usdt)
-  })
-  const usdt_TrueFiPool2 = poolFactory.pool(usdt)
-  runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-    usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  })
-  runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
-    usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
-  })
-  runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-    usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
-  })
-  runIf(trueFiCreditOracle.isInitialized().not(), () => {
-    trueFiCreditOracle.initialize()
-  })
-  if (!isMainnet) {
-    trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
-  }
-  runIf(poolFactory.isPool(trueFiPool).not(), () => {
-    poolFactory.addLegacyPool(trueFiPool)
-  })
+  // // Contract initialization
+  // runIf(safu.isInitialized().not(), () => {
+  //   safu.initialize(loanFactory2, liquidator2, oneInch)
+  // })
+  // runIf(poolFactory.isInitialized().not(), () => {
+  //   poolFactory.initialize(implementationReference, trueLender2, safu)
+  // })
+  // runIf(trueLender2.isInitialized().not(), () => {
+  //   trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle)
+  // })
+  // runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
+  //   trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
+  // })
+  // runIf(loanFactory2.isInitialized().not(), () => {
+  //   loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, AddressZero)
+  // })
+  // runIf(liquidator2.isInitialized().not(), () => {
+  //   liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
+  // })
+  // runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
+  //   poolFactory.allowToken(usdc, true)
+  //   poolFactory.createPool(usdc)
+  // })
+  // const usdc_TrueFiPool2 = poolFactory.pool(usdc)
+  // runIf(trueLender2.feePool().equals(AddressZero), () => {
+  //   trueLender2.setFeePool(usdc_TrueFiPool2)
+  // })
+  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+  //   usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  // })
+  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
+  //   usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
+  // })
+  // runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+  //   usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
+  // })
+  // runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
+  //   poolFactory.allowToken(usdt, true)
+  //   poolFactory.createPool(usdt)
+  // })
+  // const usdt_TrueFiPool2 = poolFactory.pool(usdt)
+  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+  //   usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  // })
+  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
+  //   usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
+  // })
+  // runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+  //   usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
+  // })
+  // runIf(trueFiCreditOracle.isInitialized().not(), () => {
+  //   trueFiCreditOracle.initialize()
+  // })
+  // if (!isMainnet) {
+  //   trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
+  // }
+  // runIf(poolFactory.isPool(trueFiPool).not(), () => {
+  //   poolFactory.addLegacyPool(trueFiPool)
+  // })
 })

--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -52,128 +52,114 @@ const deployParams = {
 
 deploy({}, (_, config) => {
   const proxy = createProxy(OwnedUpgradeabilityProxy)
-  // const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
-  // const isMainnet = config.network === 'mainnet'
-  // const NETWORK = isMainnet ? 'mainnet' : 'testnet'
+  const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
+  const isMainnet = config.network === 'mainnet'
+  const NETWORK = isMainnet ? 'mainnet' : 'testnet'
 
-  // // Existing contracts
-  // const trustToken = isMainnet
-  //   ? timeProxy(contract(TrustToken), () => {})
-  //   : timeProxy(contract(TestTrustToken), () => {})
-  // const stkTruToken = proxy(contract(StkTruToken), () => {})
-  // const trueFiPool = isMainnet
-  //   ? proxy(contract(TrueFiPool), () => {})
-  //   : proxy(contract(TestTrueFiPool), () => {})
-  // const usdc = isMainnet
-  //   ? deployParams['mainnet'].USDC
-  //   : contract(TestUSDCToken)
-  // const usdt = isMainnet
-  //   ? deployParams['mainnet'].USDT
-  //   : contract(TestUSDTToken)
-  // const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
+  // Existing contracts
+  const trustToken = isMainnet
+    ? timeProxy(contract(TrustToken), () => {})
+    : timeProxy(contract(TestTrustToken), () => {})
+  const stkTruToken = proxy(contract(StkTruToken), () => {})
+  const trueFiPool = isMainnet
+    ? proxy(contract(TrueFiPool), () => {})
+    : proxy(contract(TestTrueFiPool), () => {})
+  const usdc = isMainnet
+    ? deployParams['mainnet'].USDC
+    : contract(TestUSDCToken)
+  const usdt = isMainnet
+    ? deployParams['mainnet'].USDT
+    : contract(TestUSDTToken)
+  const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
 
-  // // New contract impls
-  // const trueLender2_impl = contract(TrueLender2)
-  // const poolFactory_impl = contract(PoolFactory)
-  // const liquidator2_impl = contract(Liquidator2)
-  // const loanFactory2_impl = contract(LoanFactory2)
+  // New contract impls
+  const trueLender2_impl = contract(TrueLender2)
+  const poolFactory_impl = contract(PoolFactory)
+  const liquidator2_impl = contract(Liquidator2)
+  const loanFactory2_impl = contract(LoanFactory2)
   const safu_impl = contract(SAFU)
-  // const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  // const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
-  // const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  // const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
-  // const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
+  const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
+  const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
+  const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
 
-  // // New contract proxies
-  // const trueLender2 = proxy(trueLender2_impl, () => {})
-  // const poolFactory = proxy(poolFactory_impl, () => {})
-  // const liquidator2 = proxy(liquidator2_impl, () => {})
-  // const loanFactory2 = proxy(loanFactory2_impl, () => {})
-  // const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  // const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
-  // const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  // const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
-  // const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
+  // New contract proxies
+  const trueLender2 = proxy(trueLender2_impl, () => {})
+  const poolFactory = proxy(poolFactory_impl, () => {})
+  const liquidator2 = proxy(liquidator2_impl, () => {})
+  const loanFactory2 = proxy(loanFactory2_impl, () => {})
+  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
+  const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
+  const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
   const safu = proxy(safu_impl, () => {})
-  // // New bare contracts
-  // const trueFiPool2 = contract(TrueFiPool2)
-  // const implementationReference = contract(ImplementationReference, [trueFiPool2])
-  // const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
-  // const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
-  // const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
-  // const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
+  // New bare contracts
+  const trueFiPool2 = contract(TrueFiPool2)
+  const implementationReference = contract(ImplementationReference, [trueFiPool2])
+  const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
+  const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
+  const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
+  const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
 
-  // // Contract initialization
-  const MULTISIG = '0x16cEa306506c387713C70b9C1205fd5aC997E78E'
-  const LOAN_FACTORY_2 = '0x69d844fB5928d0e7Bc530cC6325A88e53d6685BC'
-  const LIQUIDATOR_2 = '0x7aC899754Dd042024bb168fd5c9a07420F444Bdf'
+  // Contract initialization
   runIf(safu.isInitialized().not(), () => {
-    safu.initialize(LOAN_FACTORY_2, LIQUIDATOR_2, ONE_INCH_EXCHANGE)
+    safu.initialize(loanFactory2, liquidator2, oneInch)
   })
-  safu.transferOwnership(MULTISIG)
-  // TODO manually call:
-  // safu.transferProxyOwnership(MULTISIG)
-
-  // TODO multisig call:
-  // safu.claimOwnership()
-  // safu.claimProxyOwnership()
-  // poolFactory.setSafuAddress(safu)
-  // legacytfTUSD.setSafuAddress(safu)
-  // tfTUSD.setSafuAddress(safu)
-  // tfUSDC.setSafuAddress(safu)
-  // tfUSDT.setSafuAddress(safu)
-
-
-  // runIf(trueLender2.isInitialized().not(), () => {
-  //   trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle)
-  // })
-  // runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
-  //   trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
-  // })
-  // runIf(loanFactory2.isInitialized().not(), () => {
-  //   loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, AddressZero)
-  // })
-  // runIf(liquidator2.isInitialized().not(), () => {
-  //   liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
-  // })
-  // runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
-  //   poolFactory.allowToken(usdc, true)
-  //   poolFactory.createPool(usdc)
-  // })
-  // const usdc_TrueFiPool2 = poolFactory.pool(usdc)
-  // runIf(trueLender2.feePool().equals(AddressZero), () => {
-  //   trueLender2.setFeePool(usdc_TrueFiPool2)
-  // })
-  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-  //   usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  // })
-  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
-  //   usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
-  // })
-  // runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-  //   usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
-  // })
-  // runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
-  //   poolFactory.allowToken(usdt, true)
-  //   poolFactory.createPool(usdt)
-  // })
-  // const usdt_TrueFiPool2 = poolFactory.pool(usdt)
-  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-  //   usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  // })
-  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
-  //   usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
-  // })
-  // runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-  //   usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
-  // })
-  // runIf(trueFiCreditOracle.isInitialized().not(), () => {
-  //   trueFiCreditOracle.initialize()
-  // })
-  // if (!isMainnet) {
-  //   trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
-  // }
-  // runIf(poolFactory.isPool(trueFiPool).not(), () => {
-  //   poolFactory.addLegacyPool(trueFiPool)
-  // })
+  runIf(poolFactory.isInitialized().not(), () => {
+    poolFactory.initialize(implementationReference, trueLender2, safu)
+  })
+  runIf(trueLender2.isInitialized().not(), () => {
+    trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle)
+  })
+  runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
+    trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
+  })
+  runIf(loanFactory2.isInitialized().not(), () => {
+    loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, AddressZero)
+  })
+  runIf(liquidator2.isInitialized().not(), () => {
+    liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
+  })
+  runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
+    poolFactory.allowToken(usdc, true)
+    poolFactory.createPool(usdc)
+  })
+  const usdc_TrueFiPool2 = poolFactory.pool(usdc)
+  runIf(trueLender2.feePool().equals(AddressZero), () => {
+    trueLender2.setFeePool(usdc_TrueFiPool2)
+  })
+  runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+    usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  })
+  runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
+    usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
+  })
+  runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+    usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
+  })
+  runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
+    poolFactory.allowToken(usdt, true)
+    poolFactory.createPool(usdt)
+  })
+  const usdt_TrueFiPool2 = poolFactory.pool(usdt)
+  runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+    usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  })
+  runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
+    usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
+  })
+  runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+    usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
+  })
+  runIf(trueFiCreditOracle.isInitialized().not(), () => {
+    trueFiCreditOracle.initialize()
+  })
+  if (!isMainnet) {
+    trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
+  }
+  runIf(poolFactory.isPool(trueFiPool).not(), () => {
+    poolFactory.addLegacyPool(trueFiPool)
+  })
 })

--- a/deployments.json
+++ b/deployments.json
@@ -441,8 +441,8 @@
       "address": "0x1391D9223E08845e536157995085fE0Cef8Bd393"
     },
     "liquidator2": {
-      "txHash": "0xd49abffbdae1d07ec2cb0b021c3fa75b4d356b0e5b2e30c9254dcca27bce8e04",
-      "address": "0xF0F9365517FcD1C28CC4FfaCED1954816883a731"
+      "txHash": "0x469947a6bb045089dccdee36a1492585bb1d5bc55026c874e5e54ddbdecd7289",
+      "address": "0xC87079dBcC6835ABb3C85C0366122f5fe7C28271"
     },
     "liquidator2_proxy": {
       "txHash": "0x6e5e772f5d64aa07483b79e0b61e4be2815fea50f313312b90eae2c1d86f742c",

--- a/deployments.json
+++ b/deployments.json
@@ -555,6 +555,14 @@
     "tusd_CurveYearnStrategy_proxy": {
       "txHash": "0x3dbba48885efe2b6faf004b1a3616dfe7cabe608d8a6144040696ac63f9f8c71",
       "address": "0xCB829B1Aa77B8B57D320AF05a780757c8c2B88C1"
+    },
+    "sAFU": {
+      "txHash": "0x069ca631faace9d865bf47ad09df5326633eb4d1d34aafafd0df3bcd7c37cd14",
+      "address": "0xC83E731e0cab21ce5B0Bbbe3252bAefD0e11fc03"
+    },
+    "sAFU_proxy": {
+      "txHash": "0xaa5bbaa6ca71899793cea116bfa42e4b06791c7ab85523e83bf911a4b9e12c42",
+      "address": "0x1eA63189eB1F4c109B10Cf6567f328C826AA6151"
     }
   }
 }


### PR DESCRIPTION
Mars magically succeeded at Etherscan verification this time!

https://etherscan.io/address/0xc87079dbcc6835abb3c85c0366122f5fe7c28271
https://etherscan.io/address/0x1eA63189eB1F4c109B10Cf6567f328C826AA6151

I've initialized the SAFU contract and transferred ownerships to the multisig. We still need to:
- review Liquidator2 diff
- upgrade Liquidator2 impl
- claim SAFU ownerships
- set the SAFU address in various places