### PR TITLE
Deploy TrueFiCreditOracle impl to mainnet

### DIFF
--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -53,117 +53,117 @@ const deployParams = {
 }
 
 deploy({}, (_, config) => {
-  // const proxy = createProxy(OwnedUpgradeabilityProxy)
-  // const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
-  // const isMainnet = config.network === 'mainnet'
-  // const NETWORK = isMainnet ? 'mainnet' : 'testnet'
+  const proxy = createProxy(OwnedUpgradeabilityProxy)
+  const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
+  const isMainnet = config.network === 'mainnet'
+  const NETWORK = isMainnet ? 'mainnet' : 'testnet'
 
-  // // Existing contracts
-  // const trustToken = isMainnet
-  //   ? timeProxy(contract(TrustToken), () => {})
-  //   : timeProxy(contract(TestTrustToken), () => {})
-  // const stkTruToken = proxy(contract(StkTruToken), () => {})
-  // const trueFiPool = isMainnet
-  //   ? proxy(contract(TrueFiPool), () => {})
-  //   : proxy(contract(TestTrueFiPool), () => {})
-  // const usdc = isMainnet
-  //   ? deployParams['mainnet'].USDC
-  //   : contract(TestUSDCToken)
-  // const usdt = isMainnet
-  //   ? deployParams['mainnet'].USDT
-  //   : contract(TestUSDTToken)
-  // const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
+  // Existing contracts
+  const trustToken = isMainnet
+    ? timeProxy(contract(TrustToken), () => {})
+    : timeProxy(contract(TestTrustToken), () => {})
+  const stkTruToken = proxy(contract(StkTruToken), () => {})
+  const trueFiPool = isMainnet
+    ? proxy(contract(TrueFiPool), () => {})
+    : proxy(contract(TestTrueFiPool), () => {})
+  const usdc = isMainnet
+    ? deployParams['mainnet'].USDC
+    : contract(TestUSDCToken)
+  const usdt = isMainnet
+    ? deployParams['mainnet'].USDT
+    : contract(TestUSDTToken)
+  const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
 
-  // // New contract impls
-  // const trueLender2_impl = contract(TrueLender2)
-  // const poolFactory_impl = contract(PoolFactory)
-  // const liquidator2_impl = contract(Liquidator2)
-  // const loanFactory2_impl = contract(LoanFactory2)
-  // const safu_impl = contract(SAFU)
-  // const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  // const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
-  // const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  // const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
+  // New contract impls
+  const trueLender2_impl = contract(TrueLender2)
+  const poolFactory_impl = contract(PoolFactory)
+  const liquidator2_impl = contract(Liquidator2)
+  const loanFactory2_impl = contract(LoanFactory2)
+  const safu_impl = contract(SAFU)
+  const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
+  const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
   const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
-  // const borrowingMutex_impl = contract(BorrowingMutex)
+  const borrowingMutex_impl = contract(BorrowingMutex)
 
-  // // New contract proxies
-  // const trueLender2 = proxy(trueLender2_impl, () => {})
-  // const poolFactory = proxy(poolFactory_impl, () => {})
-  // const liquidator2 = proxy(liquidator2_impl, () => {})
-  // const loanFactory2 = proxy(loanFactory2_impl, () => {})
-  // const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  // const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
-  // const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  // const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
-  // const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
-  // const safu = proxy(safu_impl, () => {})
-  // const borrowingMutex = proxy(borrowingMutex_impl, () => {})
-  // // New bare contracts
-  // const trueFiPool2 = contract(TrueFiPool2)
-  // const implementationReference = contract(ImplementationReference, [trueFiPool2])
-  // const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
-  // const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
-  // const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
-  // const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
+  // New contract proxies
+  const trueLender2 = proxy(trueLender2_impl, () => {})
+  const poolFactory = proxy(poolFactory_impl, () => {})
+  const liquidator2 = proxy(liquidator2_impl, () => {})
+  const loanFactory2 = proxy(loanFactory2_impl, () => {})
+  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
+  const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
+  const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
+  const safu = proxy(safu_impl, () => {})
+  const borrowingMutex = proxy(borrowingMutex_impl, () => {})
+  // New bare contracts
+  const trueFiPool2 = contract(TrueFiPool2)
+  const implementationReference = contract(ImplementationReference, [trueFiPool2])
+  const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
+  const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
+  const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
+  const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
 
-  // // Contract initialization
-  // runIf(safu.isInitialized().not(), () => {
-  //   safu.initialize(loanFactory2, liquidator2, oneInch)
-  // })
-  // runIf(poolFactory.isInitialized().not(), () => {
-  //   poolFactory.initialize(implementationReference, trueLender2, safu)
-  // })
-  // runIf(trueLender2.isInitialized().not(), () => {
-  //   trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle, borrowingMutex)
-  // })
-  // runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
-  //   trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
-  // })
-  // runIf(loanFactory2.isInitialized().not(), () => {
-  //   loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, trueFiCreditOracle, borrowingMutex)
-  // })
-  // runIf(liquidator2.isInitialized().not(), () => {
-  //   liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
-  // })
-  // runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
-  //   poolFactory.allowToken(usdc, true)
-  //   poolFactory.createPool(usdc)
-  // })
-  // const usdc_TrueFiPool2 = poolFactory.pool(usdc)
-  // runIf(trueLender2.feePool().equals(AddressZero), () => {
-  //   trueLender2.setFeePool(usdc_TrueFiPool2)
-  // })
-  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-  //   usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  // })
-  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
-  //   usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
-  // })
-  // runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-  //   usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
-  // })
-  // runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
-  //   poolFactory.allowToken(usdt, true)
-  //   poolFactory.createPool(usdt)
-  // })
-  // const usdt_TrueFiPool2 = poolFactory.pool(usdt)
-  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-  //   usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  // })
-  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
-  //   usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
-  // })
-  // runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-  //   usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
-  // })
-  // runIf(trueFiCreditOracle.isInitialized().not(), () => {
-  //   trueFiCreditOracle.initialize()
-  // })
-  // if (!isMainnet) {
-  //   trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
-  // }
-  // runIf(poolFactory.isPool(trueFiPool).not(), () => {
-  //   poolFactory.addLegacyPool(trueFiPool)
-  // })
+  // Contract initialization
+  runIf(safu.isInitialized().not(), () => {
+    safu.initialize(loanFactory2, liquidator2, oneInch)
+  })
+  runIf(poolFactory.isInitialized().not(), () => {
+    poolFactory.initialize(implementationReference, trueLender2, safu)
+  })
+  runIf(trueLender2.isInitialized().not(), () => {
+    trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle, borrowingMutex)
+  })
+  runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
+    trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
+  })
+  runIf(loanFactory2.isInitialized().not(), () => {
+    loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, trueFiCreditOracle, borrowingMutex)
+  })
+  runIf(liquidator2.isInitialized().not(), () => {
+    liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
+  })
+  runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
+    poolFactory.allowToken(usdc, true)
+    poolFactory.createPool(usdc)
+  })
+  const usdc_TrueFiPool2 = poolFactory.pool(usdc)
+  runIf(trueLender2.feePool().equals(AddressZero), () => {
+    trueLender2.setFeePool(usdc_TrueFiPool2)
+  })
+  runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+    usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  })
+  runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
+    usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
+  })
+  runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+    usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
+  })
+  runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
+    poolFactory.allowToken(usdt, true)
+    poolFactory.createPool(usdt)
+  })
+  const usdt_TrueFiPool2 = poolFactory.pool(usdt)
+  runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+    usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  })
+  runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
+    usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
+  })
+  runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+    usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
+  })
+  runIf(trueFiCreditOracle.isInitialized().not(), () => {
+    trueFiCreditOracle.initialize()
+  })
+  if (!isMainnet) {
+    trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
+  }
+  runIf(poolFactory.isPool(trueFiPool).not(), () => {
+    poolFactory.addLegacyPool(trueFiPool)
+  })
 })

--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -53,117 +53,117 @@ const deployParams = {
 }
 
 deploy({}, (_, config) => {
-  const proxy = createProxy(OwnedUpgradeabilityProxy)
-  const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
-  const isMainnet = config.network === 'mainnet'
-  const NETWORK = isMainnet ? 'mainnet' : 'testnet'
+  // const proxy = createProxy(OwnedUpgradeabilityProxy)
+  // const timeProxy = createProxy(TimeOwnedUpgradeabilityProxy)
+  // const isMainnet = config.network === 'mainnet'
+  // const NETWORK = isMainnet ? 'mainnet' : 'testnet'
 
-  // Existing contracts
-  const trustToken = isMainnet
-    ? timeProxy(contract(TrustToken), () => {})
-    : timeProxy(contract(TestTrustToken), () => {})
-  const stkTruToken = proxy(contract(StkTruToken), () => {})
-  const trueFiPool = isMainnet
-    ? proxy(contract(TrueFiPool), () => {})
-    : proxy(contract(TestTrueFiPool), () => {})
-  const usdc = isMainnet
-    ? deployParams['mainnet'].USDC
-    : contract(TestUSDCToken)
-  const usdt = isMainnet
-    ? deployParams['mainnet'].USDT
-    : contract(TestUSDTToken)
-  const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
+  // // Existing contracts
+  // const trustToken = isMainnet
+  //   ? timeProxy(contract(TrustToken), () => {})
+  //   : timeProxy(contract(TestTrustToken), () => {})
+  // const stkTruToken = proxy(contract(StkTruToken), () => {})
+  // const trueFiPool = isMainnet
+  //   ? proxy(contract(TrueFiPool), () => {})
+  //   : proxy(contract(TestTrueFiPool), () => {})
+  // const usdc = isMainnet
+  //   ? deployParams['mainnet'].USDC
+  //   : contract(TestUSDCToken)
+  // const usdt = isMainnet
+  //   ? deployParams['mainnet'].USDT
+  //   : contract(TestUSDTToken)
+  // const trueRatingAgencyV2 = proxy(contract(TrueRatingAgencyV2), () => {})
 
-  // New contract impls
-  const trueLender2_impl = contract(TrueLender2)
-  const poolFactory_impl = contract(PoolFactory)
-  const liquidator2_impl = contract(Liquidator2)
-  const loanFactory2_impl = contract(LoanFactory2)
-  const safu_impl = contract(SAFU)
-  const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
-  const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
-  const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
+  // // New contract impls
+  // const trueLender2_impl = contract(TrueLender2)
+  // const poolFactory_impl = contract(PoolFactory)
+  // const liquidator2_impl = contract(Liquidator2)
+  // const loanFactory2_impl = contract(LoanFactory2)
+  // const safu_impl = contract(SAFU)
+  // const usdc_TrueFiPool2_LinearTrueDistributor_impl = contract('usdc_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  // const usdc_TrueFiPool2_TrueFarm_impl = contract('usdc_TrueFiPool2_TrueFarm', TrueFarm)
+  // const usdt_TrueFiPool2_LinearTrueDistributor_impl = contract('usdt_TrueFiPool2_LinearTrueDistributor', LinearTrueDistributor)
+  // const usdt_TrueFiPool2_TrueFarm_impl = contract('usdt_TrueFiPool2_TrueFarm', TrueFarm)
   const trueFiCreditOracle_impl = contract(TrueFiCreditOracle)
-  const borrowingMutex_impl = contract(BorrowingMutex)
+  // const borrowingMutex_impl = contract(BorrowingMutex)
 
-  // New contract proxies
-  const trueLender2 = proxy(trueLender2_impl, () => {})
-  const poolFactory = proxy(poolFactory_impl, () => {})
-  const liquidator2 = proxy(liquidator2_impl, () => {})
-  const loanFactory2 = proxy(loanFactory2_impl, () => {})
-  const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
-  const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
-  const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
-  const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
-  const safu = proxy(safu_impl, () => {})
-  const borrowingMutex = proxy(borrowingMutex_impl, () => {})
-  // New bare contracts
-  const trueFiPool2 = contract(TrueFiPool2)
-  const implementationReference = contract(ImplementationReference, [trueFiPool2])
-  const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
-  const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
-  const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
-  const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
+  // // New contract proxies
+  // const trueLender2 = proxy(trueLender2_impl, () => {})
+  // const poolFactory = proxy(poolFactory_impl, () => {})
+  // const liquidator2 = proxy(liquidator2_impl, () => {})
+  // const loanFactory2 = proxy(loanFactory2_impl, () => {})
+  // const usdc_TrueFiPool2_LinearTrueDistributor = proxy(usdc_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  // const usdc_TrueFiPool2_TrueFarm = proxy(usdc_TrueFiPool2_TrueFarm_impl, () => {})
+  // const usdt_TrueFiPool2_LinearTrueDistributor = proxy(usdt_TrueFiPool2_LinearTrueDistributor_impl, () => {})
+  // const usdt_TrueFiPool2_TrueFarm = proxy(usdt_TrueFiPool2_TrueFarm_impl, () => {})
+  // const trueFiCreditOracle = proxy(trueFiCreditOracle_impl, () => {})
+  // const safu = proxy(safu_impl, () => {})
+  // const borrowingMutex = proxy(borrowingMutex_impl, () => {})
+  // // New bare contracts
+  // const trueFiPool2 = contract(TrueFiPool2)
+  // const implementationReference = contract(ImplementationReference, [trueFiPool2])
+  // const chainlinkTruTusdOracle = contract(ChainlinkTruTusdOracle)
+  // const chainlinkTruUsdcOracle = contract(ChainlinkTruUsdcOracle)
+  // const chainlinkTruUsdtOracle = contract(ChainlinkTruUsdtOracle)
+  // const oneInch = isMainnet ? ONE_INCH_EXCHANGE : contract(Mock1InchV3)
 
-  // Contract initialization
-  runIf(safu.isInitialized().not(), () => {
-    safu.initialize(loanFactory2, liquidator2, oneInch)
-  })
-  runIf(poolFactory.isInitialized().not(), () => {
-    poolFactory.initialize(implementationReference, trueLender2, safu)
-  })
-  runIf(trueLender2.isInitialized().not(), () => {
-    trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle, borrowingMutex)
-  })
-  runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
-    trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
-  })
-  runIf(loanFactory2.isInitialized().not(), () => {
-    loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, trueFiCreditOracle, borrowingMutex)
-  })
-  runIf(liquidator2.isInitialized().not(), () => {
-    liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
-  })
-  runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
-    poolFactory.allowToken(usdc, true)
-    poolFactory.createPool(usdc)
-  })
-  const usdc_TrueFiPool2 = poolFactory.pool(usdc)
-  runIf(trueLender2.feePool().equals(AddressZero), () => {
-    trueLender2.setFeePool(usdc_TrueFiPool2)
-  })
-  runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-    usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  })
-  runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
-    usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
-  })
-  runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-    usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
-  })
-  runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
-    poolFactory.allowToken(usdt, true)
-    poolFactory.createPool(usdt)
-  })
-  const usdt_TrueFiPool2 = poolFactory.pool(usdt)
-  runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
-    usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
-  })
-  runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
-    usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
-  })
-  runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
-    usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
-  })
-  runIf(trueFiCreditOracle.isInitialized().not(), () => {
-    trueFiCreditOracle.initialize()
-  })
-  if (!isMainnet) {
-    trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
-  }
-  runIf(poolFactory.isPool(trueFiPool).not(), () => {
-    poolFactory.addLegacyPool(trueFiPool)
-  })
+  // // Contract initialization
+  // runIf(safu.isInitialized().not(), () => {
+  //   safu.initialize(loanFactory2, liquidator2, oneInch)
+  // })
+  // runIf(poolFactory.isInitialized().not(), () => {
+  //   poolFactory.initialize(implementationReference, trueLender2, safu)
+  // })
+  // runIf(trueLender2.isInitialized().not(), () => {
+  //   trueLender2.initialize(stkTruToken, poolFactory, trueRatingAgencyV2, oneInch, trueFiCreditOracle, borrowingMutex)
+  // })
+  // runIf(trueLender2.votingPeriod().equals(deployParams[NETWORK].WITHDRAW_PERIOD).not(), () => {
+  //   trueLender2.setVotingPeriod(deployParams[NETWORK].WITHDRAW_PERIOD)
+  // })
+  // runIf(loanFactory2.isInitialized().not(), () => {
+  //   loanFactory2.initialize(poolFactory, trueLender2, liquidator2, AddressZero, trueFiCreditOracle, borrowingMutex)
+  // })
+  // runIf(liquidator2.isInitialized().not(), () => {
+  //   liquidator2.initialize(stkTruToken, trustToken, loanFactory2, AddressZero)
+  // })
+  // runIf(poolFactory.pool(usdc).equals(AddressZero), () => {
+  //   poolFactory.allowToken(usdc, true)
+  //   poolFactory.createPool(usdc)
+  // })
+  // const usdc_TrueFiPool2 = poolFactory.pool(usdc)
+  // runIf(trueLender2.feePool().equals(AddressZero), () => {
+  //   trueLender2.setFeePool(usdc_TrueFiPool2)
+  // })
+  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+  //   usdc_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  // })
+  // runIf(usdc_TrueFiPool2_LinearTrueDistributor.farm().equals(usdc_TrueFiPool2_TrueFarm).not(), () => {
+  //   usdc_TrueFiPool2_LinearTrueDistributor.setFarm(usdc_TrueFiPool2_TrueFarm)
+  // })
+  // runIf(usdc_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+  //   usdc_TrueFiPool2_TrueFarm.initialize(usdc_TrueFiPool2, usdc_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDC Farm')
+  // })
+  // runIf(poolFactory.pool(usdt).equals(AddressZero), () => {
+  //   poolFactory.allowToken(usdt, true)
+  //   poolFactory.createPool(usdt)
+  // })
+  // const usdt_TrueFiPool2 = poolFactory.pool(usdt)
+  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.isInitialized().not(), () => {
+  //   usdt_TrueFiPool2_LinearTrueDistributor.initialize(deployParams[NETWORK].DISTRIBUTION_START, deployParams[NETWORK].DISTRIBUTION_DURATION, deployParams[NETWORK].STAKE_DISTRIBUTION_AMOUNT, trustToken)
+  // })
+  // runIf(usdt_TrueFiPool2_LinearTrueDistributor.farm().equals(usdt_TrueFiPool2_TrueFarm).not(), () => {
+  //   usdt_TrueFiPool2_LinearTrueDistributor.setFarm(usdt_TrueFiPool2_TrueFarm)
+  // })
+  // runIf(usdt_TrueFiPool2_TrueFarm.isInitialized().not(), () => {
+  //   usdt_TrueFiPool2_TrueFarm.initialize(usdt_TrueFiPool2, usdt_TrueFiPool2_LinearTrueDistributor, 'TrueFi tfUSDT Farm')
+  // })
+  // runIf(trueFiCreditOracle.isInitialized().not(), () => {
+  //   trueFiCreditOracle.initialize()
+  // })
+  // if (!isMainnet) {
+  //   trueLender2.setFee(deployParams['testnet'].LOAN_INTEREST_FEE)
+  // }
+  // runIf(poolFactory.isPool(trueFiPool).not(), () => {
+  //   poolFactory.addLegacyPool(trueFiPool)
+  // })
 })

--- a/deployments.json
+++ b/deployments.json
@@ -501,8 +501,8 @@
       "address": "0x842D486a5d12b3729c89B0E8968C54f68eADba7c"
     },
     "trueFiCreditOracle": {
-      "txHash": "0xa2531264bc36afe917b044be47d0a5f45b858451a801d2a45e9ae598589620c7",
-      "address": "0x13D6494AEF9e65e5614970676Bc67B08820778b7"
+      "txHash": "0x59a069140a4c8a62e0e4f2b42f11daf2dec7cea8a1ca007f3b1225ddbb6da531",
+      "address": "0x437eEc6498CaBa041CEcd95102b52037c5fC0DeF"
     },
     "trueFiCreditOracle_proxy": {
       "txHash": "0xdd6e5f89621e4060cfce40a90b8a0d87e585805377892c827f9b69c3050dde2d",


### PR DESCRIPTION
This upgrade is primarily meant to allow us to set a manager address to update credit scores.

The contract code is currently UNAUDITED and contains logic that we may want to change before release.

I'm not sure yet that we want to check this in. But if we do, then we should have 3 diff checks on this PR.