### PR TITLE
TCA-01 | Remove redundant variable initialization from TVL and totalBorrowed

### DIFF
--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -252,8 +252,7 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
      * @param decimals Precision to return
      * @return TVL for all pools with lines of credit
      */
-    function totalTVL(uint8 decimals) public view returns (uint256) {
-        uint256 tvl = 0;
+    function totalTVL(uint8 decimals) public view returns (uint256 tvl) {
         uint256 resultPrecision = uint256(10)**decimals;
 
         // loop through pools and sum tvl accounting for precision
@@ -262,7 +261,6 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
                 pools[i].poolValue().mul(resultPrecision).div(uint256(10)**(ITrueFiPool2WithDecimals(address(pools[i])).decimals()))
             );
         }
-        return tvl;
     }
 
     /**
@@ -271,8 +269,7 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
      * @param decimals Precision to use when calculating total borrowed
      * @return Total amount borrowed for `borrower` in USD
      */
-    function totalBorrowed(address borrower, uint8 decimals) public view returns (uint256) {
-        uint256 borrowSum = 0;
+    function totalBorrowed(address borrower, uint8 decimals) public view returns (uint256 borrowSum) {
         uint256 resultPrecision = uint256(10)**decimals;
 
         // loop through pools and sum amount borrowed accounting for precision
@@ -283,7 +280,6 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
                 )
             );
         }
-        return borrowSum;
     }
 
     /**

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -250,7 +250,7 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
     /**
      * @dev Calculate total TVL in USD
      * @param decimals Precision to return
-     * @return TVL for all pools with lines of credit
+     * @return tvl TVL for all pools with lines of credit
      */
     function totalTVL(uint8 decimals) public view returns (uint256 tvl) {
         uint256 resultPrecision = uint256(10)**decimals;
@@ -267,7 +267,7 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
      * @dev Get total amount borrowed for `borrower` from lines of credit in USD
      * @param borrower Borrower to get amount borrowed for
      * @param decimals Precision to use when calculating total borrowed
-     * @return Total amount borrowed for `borrower` in USD
+     * @return borrowSum Total amount borrowed for `borrower` in USD
      */
     function totalBorrowed(address borrower, uint8 decimals) public view returns (uint256 borrowSum) {
         uint256 resultPrecision = uint256(10)**decimals;

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -250,9 +250,10 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
     /**
      * @dev Calculate total TVL in USD
      * @param decimals Precision to return
-     * @return tvl TVL for all pools with lines of credit
+     * @return TVL for all pools with lines of credit
      */
-    function totalTVL(uint8 decimals) public view returns (uint256 tvl) {
+    function totalTVL(uint8 decimals) public view returns (uint256) {
+        uint256 tvl;
         uint256 resultPrecision = uint256(10)**decimals;
 
         // loop through pools and sum tvl accounting for precision
@@ -261,15 +262,17 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
                 pools[i].poolValue().mul(resultPrecision).div(uint256(10)**(ITrueFiPool2WithDecimals(address(pools[i])).decimals()))
             );
         }
+        return tvl;
     }
 
     /**
      * @dev Get total amount borrowed for `borrower` from lines of credit in USD
      * @param borrower Borrower to get amount borrowed for
      * @param decimals Precision to use when calculating total borrowed
-     * @return borrowSum Total amount borrowed for `borrower` in USD
+     * @return Total amount borrowed for `borrower` in USD
      */
-    function totalBorrowed(address borrower, uint8 decimals) public view returns (uint256 borrowSum) {
+    function totalBorrowed(address borrower, uint8 decimals) public view returns (uint256) {
+        uint256 borrowSum;
         uint256 resultPrecision = uint256(10)**decimals;
 
         // loop through pools and sum amount borrowed accounting for precision
@@ -280,6 +283,7 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
                 )
             );
         }
+        return borrowSum;
     }
 
     /**


### PR DESCRIPTION
This isn't my personal style preference, but let's go with this to satisfy the audit and be consistent with the repo style.