### PR TITLE
Fix old USDC loans with incorrect reward amounts

### DIFF
--- a/contracts/truefi/TrueRatingAgencyV2.sol
+++ b/contracts/truefi/TrueRatingAgencyV2.sol
@@ -392,7 +392,8 @@ contract TrueRatingAgencyV2 is ITrueRatingAgencyV2, Ownable {
         // Update total and rater's TRU rewards for a loan
         uint256 totalReward = 0;
         uint256 ratersReward = 0;
-        if (loans[id].reward == 0) {
+        // This should fix bug with old decimals on old UDSC loan rewards
+        if (loans[id].reward < 5) {
             uint256 interest = ILoanToken2(id).profit();
 
             // This method of calculation might be erased in the future

--- a/contracts/truefi/TrueRatingAgencyV2.sol
+++ b/contracts/truefi/TrueRatingAgencyV2.sol
@@ -392,7 +392,8 @@ contract TrueRatingAgencyV2 is ITrueRatingAgencyV2, Ownable {
         // Update total and rater's TRU rewards for a loan
         uint256 totalReward = 0;
         uint256 ratersReward = 0;
-        // rewards on older USDC loans were from 1 to 4 due to a bug with decimal conversion
+        // TODO remove this special case logic after the 3 old USDC loans mentioned in PR #932 have been fixed.
+        // Rewards on these loans were from 1 to 4 due to a bug with decimal conversion fixed in PR #685.
         if (loans[id].reward < 5) {
             uint256 interest = ILoanToken2(id).profit();
 

--- a/contracts/truefi/TrueRatingAgencyV2.sol
+++ b/contracts/truefi/TrueRatingAgencyV2.sol
@@ -392,7 +392,7 @@ contract TrueRatingAgencyV2 is ITrueRatingAgencyV2, Ownable {
         // Update total and rater's TRU rewards for a loan
         uint256 totalReward = 0;
         uint256 ratersReward = 0;
-        // This should fix bug with old decimals on old UDSC loan rewards
+        // rewards on older USDC loans were from 1 to 4 due to a bug with decimal conversion
         if (loans[id].reward < 5) {
             uint256 interest = ILoanToken2(id).profit();
 

--- a/test/integration/ratingAgencyBugfix.test.ts
+++ b/test/integration/ratingAgencyBugfix.test.ts
@@ -1,0 +1,42 @@
+import { CONTRACTS_OWNER, forkChain } from './suite'
+import { OwnedUpgradeabilityProxy__factory, TrueRatingAgencyV2, TrueRatingAgencyV2__factory } from 'contracts'
+import { expect, use } from 'chai'
+import { solidity } from 'ethereum-waffle'
+import { parseTRU } from 'utils'
+
+use(solidity)
+
+describe('RatingAgency total rewards bug fix', () => {
+  const corruptedLoan = '0x4fB2D8104706BEf93EeBEF8dbe549E53aDd5185F'
+
+  const raterAddress = '0xfe3795f64a743d3b9a08f50c4115ec119ac9a9d1'
+  const provider = forkChain('https://eth-mainnet.alchemyapi.io/v2/Vc3xNXIWdxEbDOToa69DhWeyhgFVBDWl', [CONTRACTS_OWNER, raterAddress])
+  const owner = provider.getSigner(CONTRACTS_OWNER)
+  const rater = provider.getSigner(raterAddress)
+  const RATING_AGENCY_ADDRESS = '0x05461334340568075be35438b221a3a0d261fb6b'
+
+  let ratingAgency: TrueRatingAgencyV2
+
+  beforeEach(async () => {
+    const newImplementation = await new TrueRatingAgencyV2__factory(owner).deploy()
+    const proxy = OwnedUpgradeabilityProxy__factory.connect(RATING_AGENCY_ADDRESS, owner)
+    await proxy.upgradeTo(newImplementation.address)
+    ratingAgency = TrueRatingAgencyV2__factory.connect(RATING_AGENCY_ADDRESS, rater)
+  })
+
+  it('total loan rewards update after first claim', async () => {
+    const tx = await ratingAgency.claim(corruptedLoan, raterAddress)
+    const receipt = await tx.wait()
+    expect(receipt.events[4].args.claimedReward).to.be.gt(parseTRU(10))
+    expect((await ratingAgency.loans(corruptedLoan)).reward).to.be.gt(parseTRU(10000))
+  })
+
+  it('rewards should not update after following claims', async () => {
+    await ratingAgency.claim(corruptedLoan, raterAddress)
+    const reward = (await ratingAgency.loans(corruptedLoan)).reward
+    await ratingAgency.claim(corruptedLoan, raterAddress)
+    const receipt = await (await ratingAgency.claim(corruptedLoan, raterAddress)).wait()
+    expect(receipt.events.length).to.equal(0)
+    expect((await ratingAgency.loans(corruptedLoan)).reward).to.equal(reward)
+  })
+})


### PR DESCRIPTION
There are 3 loans affected with the bug that was fixed in #685 

0xC09C3aAC0cB40f40EB70E1F4f4246d077622B6CA, total reward: 1
0xb6AA9AB4555A4a5FE1e111C6A9330aD07D8C98fd, total reward: 1
0x4fB2D8104706BEf93EeBEF8dbe549E53aDd5185F, total reward: 3
