### PR TITLE
Move TVL calculation from TRA to PoolFactory supportedPools()

### DIFF
--- a/contracts/truefi2/PoolFactory.sol
+++ b/contracts/truefi2/PoolFactory.sol
@@ -254,7 +254,6 @@ contract PoolFactory is IPoolFactory, UpgradeableClaimable {
      * @dev Add `_pool` to official support
      */
     function supportPool(ITrueFiPool2 _pool) external onlyOwner {
-        //TODO: replace addPoolToTVL with it
         require(isPool[address(_pool)], "PoolFactory: Pool not created by factory");
 
         for (uint256 i = 0; i < supportedPools.length; i++) {
@@ -268,8 +267,6 @@ contract PoolFactory is IPoolFactory, UpgradeableClaimable {
      * @dev Remove `_pool` from official support
      */
     function unsupportPool(ITrueFiPool2 _pool) external onlyOwner {
-        //TODO: replace removePoolFromTVL with it
-
         for (uint256 i = 0; i < supportedPools.length; i++) {
             if (supportedPools[i] == _pool) {
                 supportedPools[i] = supportedPools[supportedPools.length - 1];

--- a/contracts/truefi2/PoolFactory.sol
+++ b/contracts/truefi2/PoolFactory.sol
@@ -306,7 +306,7 @@ contract PoolFactory is IPoolFactory, UpgradeableClaimable {
      * @dev Calculate total TVL in USD
      * @return _tvl TVL for all supported pools
      */
-    function tvl() public view returns (uint256) {
+    function tvl() public override view returns (uint256) {
         uint256 _tvl = 0;
         for (uint256 i = 0; i < supportedPools.length; i++) {
             _tvl = _tvl.add(supportedPools[i].oracle().tokenToUsd(supportedPools[i].poolValue()));

--- a/contracts/truefi2/PoolFactory.sol
+++ b/contracts/truefi2/PoolFactory.sol
@@ -304,7 +304,7 @@ contract PoolFactory is IPoolFactory, UpgradeableClaimable {
      * @return _tvl TVL for all supported pools
      */
     function tvl() public override view returns (uint256) {
-        uint256 _tvl = 0;
+        uint256 _tvl;
         for (uint256 i = 0; i < supportedPools.length; i++) {
             _tvl = _tvl.add(supportedPools[i].oracle().tokenToUsd(supportedPools[i].poolValue()));
         }

--- a/contracts/truefi2/PoolFactory.sol
+++ b/contracts/truefi2/PoolFactory.sol
@@ -49,7 +49,7 @@ contract PoolFactory is IPoolFactory, UpgradeableClaimable {
     mapping(address => bool) public isBorrowerWhitelisted;
 
     /// @dev array of pools officially supported by TrueFi
-    ITrueFiPool2[] public supportedPools; //TODO: replace getTVLPools with this
+    ITrueFiPool2[] public supportedPools;
 
     // ======= STORAGE DECLARATION END ===========
 

--- a/contracts/truefi2/PoolFactory.sol
+++ b/contracts/truefi2/PoolFactory.sol
@@ -303,11 +303,11 @@ contract PoolFactory is IPoolFactory, UpgradeableClaimable {
      * @dev Calculate total TVL in USD
      * @return _tvl TVL for all supported pools
      */
-    function tvl() public override view returns (uint256) {
-        uint256 _tvl;
+    function supportedPoolsTVL() public override view returns (uint256) {
+        uint256 tvl;
         for (uint256 i = 0; i < supportedPools.length; i++) {
-            _tvl = _tvl.add(supportedPools[i].oracle().tokenToUsd(supportedPools[i].poolValue()));
+            tvl = tvl.add(supportedPools[i].oracle().tokenToUsd(supportedPools[i].poolValue()));
         }
-        return _tvl;
+        return tvl;
     }
 }

--- a/contracts/truefi2/TrueLender2.sol
+++ b/contracts/truefi2/TrueLender2.sol
@@ -382,9 +382,10 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
         uint256 borrowSum;
         uint256 resultPrecision = uint256(10)**decimals;
 
-        ITrueFiPool2[] memory tvlPools = factory.getSupportedPools();
-        for (uint8 i = 0; i < tvlPools.length; i++) {
-            ITrueFiPool2 pool = tvlPools[i];
+        // loop through loans and sum amount borrowed accounting for precision
+        ITrueFiPool2[] memory pools = factory.getSupportedPools();
+        for (uint8 i = 0; i < pools.length; i++) {
+            ITrueFiPool2 pool = pools[i];
             uint256 poolPrecision = uint256(10)**ITrueFiPool2WithDecimals(address(pool)).decimals();
             ILoanToken2[] memory _loans = poolLoans[pool];
             for (uint8 j = 0; j < _loans.length; j++) {

--- a/contracts/truefi2/TrueLender2.sol
+++ b/contracts/truefi2/TrueLender2.sol
@@ -383,6 +383,7 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
         uint256 resultPrecision = uint256(10)**decimals;
 
         // loop through loans and sum amount borrowed accounting for precision
+        //TODO: use PoolFactory.supportedPools instead
         ITrueFiPool2[] memory pools = factory.getSupportedPools();
         for (uint8 i = 0; i < pools.length; i++) {
             ITrueFiPool2 pool = pools[i];

--- a/contracts/truefi2/TrueLender2.sol
+++ b/contracts/truefi2/TrueLender2.sol
@@ -382,11 +382,9 @@ contract TrueLender2 is ITrueLender2, UpgradeableClaimable {
         uint256 borrowSum;
         uint256 resultPrecision = uint256(10)**decimals;
 
-        // loop through loans and sum amount borrowed accounting for precision
-        //TODO: use PoolFactory.supportedPools instead
-        ITrueFiPool2[] memory pools = factory.getSupportedPools();
-        for (uint8 i = 0; i < pools.length; i++) {
-            ITrueFiPool2 pool = pools[i];
+        ITrueFiPool2[] memory tvlPools = factory.getSupportedPools();
+        for (uint8 i = 0; i < tvlPools.length; i++) {
+            ITrueFiPool2 pool = tvlPools[i];
             uint256 poolPrecision = uint256(10)**ITrueFiPool2WithDecimals(address(pool)).decimals();
             ILoanToken2[] memory _loans = poolLoans[pool];
             for (uint8 j = 0; j < _loans.length; j++) {

--- a/contracts/truefi2/TrueRateAdjuster.sol
+++ b/contracts/truefi2/TrueRateAdjuster.sol
@@ -129,10 +129,6 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
         factory = _factory;
     }
 
-    function getTVLPools() external override view returns (ITrueFiPool2[] memory) {
-        return tvlPools;
-    }
-
     /// @dev Set risk premium to `newRate`
     function setRiskPremium(uint256 newRate) external onlyOwner {
         riskPremium = newRate;

--- a/contracts/truefi2/TrueRateAdjuster.sol
+++ b/contracts/truefi2/TrueRateAdjuster.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.6.10;
 
-import "hardhat/console.sol";
-
 import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
 
 import {UpgradeableClaimable} from "../common/UpgradeableClaimable.sol";
@@ -131,30 +129,8 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
         factory = _factory;
     }
 
-    /**
-     * @dev Add `pool` to TVL calculation
-     */
-    function addPoolToTVL(ITrueFiPool2 pool) external onlyOwner {
-        //TODO: remove, switch to PoolFactory
-        for (uint256 i = 0; i < tvlPools.length; i++) {
-            require(tvlPools[i] != pool, "TrueRateAdjuster: Pool has already been added to TVL");
-        }
-        tvlPools.push(pool);
-    }
-
-    /**
-     * @dev Remove `pool` from TVL calculation
-     */
-    function removePoolFromTVL(ITrueFiPool2 pool) external onlyOwner {
-        //TODO: remove, switch to PoolFactory
-        for (uint256 i = 0; i < tvlPools.length; i++) {
-            if (tvlPools[i] == pool) {
-                tvlPools[i] = tvlPools[tvlPools.length - 1];
-                tvlPools.pop();
-                return;
-            }
-        }
-        revert("TrueRateAdjuster: Pool already removed from TVL");
+    function getTVLPools() external override view returns (ITrueFiPool2[] memory) {
+        return tvlPools;
     }
 
     /// @dev Set risk premium to `newRate`

--- a/contracts/truefi2/TrueRateAdjuster.sol
+++ b/contracts/truefi2/TrueRateAdjuster.sol
@@ -89,9 +89,11 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
 
     // ======= STORAGE DECLARATION END ============
 
+    //TODO: remove
     /// @dev emit `pool` when adding to TVL
     event PoolAddedToTVL(ITrueFiPool2 pool);
 
+    //TODO: remove
     /// @dev emit `pool` when removing from TVL
     event PoolRemovedFromTVL(ITrueFiPool2 pool);
 
@@ -134,6 +136,7 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
      * @dev Add `pool` to TVL calculation
      */
     function addPoolToTVL(ITrueFiPool2 pool) external onlyOwner {
+        //TODO: remove, switch to PoolFactory
         for (uint256 i = 0; i < tvlPools.length; i++) {
             require(tvlPools[i] != pool, "TrueRateAdjuster: Pool has already been added to TVL");
         }
@@ -145,10 +148,12 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
      * @dev Remove `pool` from TVL calculation
      */
     function removePoolFromTVL(ITrueFiPool2 pool) external onlyOwner {
+        //TODO: remove, switch to PoolFactory
         for (uint256 i = 0; i < tvlPools.length; i++) {
             if (tvlPools[i] == pool) {
                 tvlPools[i] = tvlPools[tvlPools.length - 1];
                 tvlPools.pop();
+
                 emit PoolRemovedFromTVL(pool);
                 return;
             }
@@ -303,6 +308,7 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
      * @return _tvl TVL for all pools
      */
     function tvl() public override view returns (uint256) {
+        //TODO: remove, switch to PoolFactory
         uint256 _tvl;
         // loop through pools and sum tvl converted to USD
         for (uint256 i = 0; i < tvlPools.length; i++) {
@@ -328,6 +334,7 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
         if (score < borrowLimitConfig.scoreFloor) {
             return 0;
         }
+        //TODO: replace tvl(), pass tvl as function argument instead
         uint256 maxTVLLimit = tvl().mul(borrowLimitConfig.tvlLimitCoefficient).div(BASIS_POINTS);
         uint256 adjustment = borrowLimitAdjustment(score);
         uint256 creditLimit = min(maxBorrowerLimit, maxTVLLimit).mul(adjustment).div(BASIS_POINTS);

--- a/contracts/truefi2/TrueRateAdjuster.sol
+++ b/contracts/truefi2/TrueRateAdjuster.sol
@@ -276,20 +276,6 @@ contract TrueRateAdjuster is ITrueRateAdjuster, UpgradeableClaimable {
     }
 
     /**
-     * @dev Calculate total TVL in USD
-     * @return _tvl TVL for all pools
-     */
-    function tvl() public override view returns (uint256) {
-        //TODO: remove, switch to PoolFactory
-        uint256 _tvl;
-        // loop through pools and sum tvl converted to USD
-        for (uint256 i = 0; i < tvlPools.length; i++) {
-            _tvl = _tvl.add(tvlPools[i].oracle().tokenToUsd(tvlPools[i].poolValue()));
-        }
-        return _tvl;
-    }
-
-    /**
      * @dev Get borrow limit in USD with 18 decimal precision
      * @param pool Pool which is being borrowed from
      * @param score Borrower score

--- a/contracts/truefi2/interface/IPoolFactory.sol
+++ b/contracts/truefi2/interface/IPoolFactory.sol
@@ -7,4 +7,6 @@ interface IPoolFactory {
     function isSupportedPool(ITrueFiPool2 pool) external view returns (bool);
 
     function getSupportedPools() external view returns (ITrueFiPool2[] memory);
+
+    function tvl() external view returns (uint256);
 }

--- a/contracts/truefi2/interface/IPoolFactory.sol
+++ b/contracts/truefi2/interface/IPoolFactory.sol
@@ -8,5 +8,5 @@ interface IPoolFactory {
 
     function getSupportedPools() external view returns (ITrueFiPool2[] memory);
 
-    function tvl() external view returns (uint256);
+    function supportedPoolsTVL() external view returns (uint256);
 }

--- a/contracts/truefi2/interface/ITrueRateAdjuster.sol
+++ b/contracts/truefi2/interface/ITrueRateAdjuster.sol
@@ -24,9 +24,6 @@ interface ITrueRateAdjuster {
 
     function borrowLimitAdjustment(uint8 score) external view returns (uint256);
 
-    //TODO: remove
-    function tvl() external view returns (uint256);
-
     function borrowLimit(
         ITrueFiPool2 pool,
         uint8 score,

--- a/contracts/truefi2/interface/ITrueRateAdjuster.sol
+++ b/contracts/truefi2/interface/ITrueRateAdjuster.sol
@@ -24,6 +24,7 @@ interface ITrueRateAdjuster {
 
     function borrowLimitAdjustment(uint8 score) external view returns (uint256);
 
+    //TODO: remove
     function tvl() external view returns (uint256);
 
     function borrowLimit(

--- a/contracts/truefi2/mocks/MockPoolFactory.sol
+++ b/contracts/truefi2/mocks/MockPoolFactory.sol
@@ -14,6 +14,10 @@ contract MockPoolFactory is IPoolFactory {
         return supportedPools;
     }
 
+    function isSupportedPool(ITrueFiPool2 pool) external override view returns (bool) {
+        return address(pool) != address(0);
+    }
+
     function supportPool(ITrueFiPool2 _pool) external {
         supportedPools.push(_pool);
     }

--- a/contracts/truefi2/mocks/MockPoolFactory.sol
+++ b/contracts/truefi2/mocks/MockPoolFactory.sol
@@ -23,7 +23,7 @@ contract MockPoolFactory is IPoolFactory {
     }
 
     function tvl() public override view returns (uint256) {
-        uint256 _tvl = 0;
+        uint256 _tvl;
         for (uint256 i = 0; i < supportedPools.length; i++) {
             _tvl = _tvl.add(supportedPools[i].oracle().tokenToUsd(supportedPools[i].poolValue()));
         }

--- a/contracts/truefi2/mocks/MockPoolFactory.sol
+++ b/contracts/truefi2/mocks/MockPoolFactory.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+import {IPoolFactory} from "../interface/IPoolFactory.sol";
+import {ITrueFiPool2} from "../interface/ITrueFiPool2.sol";
+
+contract MockPoolFactory is IPoolFactory {
+    using SafeMath for uint256;
+    mapping(address => bool) public override isPool;
+    ITrueFiPool2[] public supportedPools;
+
+    function getSupportedPools() external override view returns (ITrueFiPool2[] memory) {
+        return supportedPools;
+    }
+
+    function supportPool(ITrueFiPool2 _pool) external {
+        supportedPools.push(_pool);
+    }
+
+    function tvl() public override view returns (uint256) {
+        uint256 _tvl = 0;
+        for (uint256 i = 0; i < supportedPools.length; i++) {
+            _tvl = _tvl.add(supportedPools[i].oracle().tokenToUsd(supportedPools[i].poolValue()));
+        }
+        return _tvl;
+    }
+}

--- a/contracts/truefi2/mocks/MockPoolFactory.sol
+++ b/contracts/truefi2/mocks/MockPoolFactory.sol
@@ -7,7 +7,6 @@ import {ITrueFiPool2} from "../interface/ITrueFiPool2.sol";
 
 contract MockPoolFactory is IPoolFactory {
     using SafeMath for uint256;
-    mapping(address => bool) public override isPool;
     ITrueFiPool2[] public supportedPools;
 
     function getSupportedPools() external override view returns (ITrueFiPool2[] memory) {
@@ -22,11 +21,11 @@ contract MockPoolFactory is IPoolFactory {
         supportedPools.push(_pool);
     }
 
-    function tvl() public override view returns (uint256) {
-        uint256 _tvl;
+    function supportedPoolsTVL() public override view returns (uint256) {
+        uint256 tvl;
         for (uint256 i = 0; i < supportedPools.length; i++) {
-            _tvl = _tvl.add(supportedPools[i].oracle().tokenToUsd(supportedPools[i].poolValue()));
+            tvl = tvl.add(supportedPools[i].oracle().tokenToUsd(supportedPools[i].poolValue()));
         }
-        return _tvl;
+        return tvl;
     }
 }

--- a/test/truefi/TrueFiPool.test.ts
+++ b/test/truefi/TrueFiPool.test.ts
@@ -514,9 +514,6 @@ describe('TrueFiPool', () => {
     await factory.createPool(usdc.address)
     const feePool = await factory.pool(usdc.address)
     await lender2.setFeePool(feePool)
-    // TODO: remove
-    await rateAdjuster.addPoolToTVL(pool.address)
-    await rateAdjuster.addPoolToTVL(feePool)
     await pool.setLender2(lender2.address)
     const loanFactory2 = await new LoanFactory2__factory(owner).deploy()
     const liquidator2 = await new Liquidator2__factory(owner).deploy()

--- a/test/truefi/TrueFiPool.test.ts
+++ b/test/truefi/TrueFiPool.test.ts
@@ -514,6 +514,7 @@ describe('TrueFiPool', () => {
     await factory.createPool(usdc.address)
     const feePool = await factory.pool(usdc.address)
     await lender2.setFeePool(feePool)
+    // TODO: remove
     await rateAdjuster.addPoolToTVL(pool.address)
     await rateAdjuster.addPoolToTVL(feePool)
     await pool.setLender2(lender2.address)

--- a/test/truefi2/LoanFactory2.test.ts
+++ b/test/truefi2/LoanFactory2.test.ts
@@ -237,7 +237,7 @@ describe('LoanFactory2', () => {
     let fakeRateAdjuster: TrueRateAdjuster
     beforeEach(async () => {
       fakeRateAdjuster = await new TrueRateAdjuster__factory(owner).deploy()
-      await fakeRateAdjuster.initialize()
+      await fakeRateAdjuster.initialize(AddressZero)
     })
 
     it('only admin can call', async () => {

--- a/test/truefi2/TrueLender2.test.ts
+++ b/test/truefi2/TrueLender2.test.ts
@@ -30,7 +30,6 @@ import {
   TrueFiCreditOracle__factory,
   TrueFiPool2,
   TrueFiPool2__factory,
-  TrueRateAdjuster,
   TrueRatingAgencyV2,
 } from 'contracts'
 
@@ -57,7 +56,6 @@ describe('TrueLender2', () => {
   let rater: TrueRatingAgencyV2
   let lender: TestTrueLender
   let creditOracle: TrueFiCreditOracle
-  let rateAdjuster: TrueRateAdjuster
 
   let counterfeitPool: TrueFiPool2
   let token1: MockErc20Token
@@ -93,7 +91,6 @@ describe('TrueLender2', () => {
       feeToken: usdc,
       lender,
       creditOracle,
-      rateAdjuster,
       borrowingMutex,
     } = await setupTruefi2(owner, _provider, { lender: lender, oneInch: oneInch }))
 
@@ -133,14 +130,12 @@ describe('TrueLender2', () => {
     await tru.approve(stkTru.address, parseTRU(15e6))
     await stkTru.stake(parseTRU(15e6))
     await timeTravel(1)
-
     loan1 = await createLoan(loanFactory, borrower, pool1, 100000, YEAR, 100)
 
     loan2 = await createLoan(loanFactory, borrower, pool2, 500000, YEAR, 1000)
 
-    // TODO: remove
-    await rateAdjuster.addPoolToTVL(pool1.address)
-    await rateAdjuster.addPoolToTVL(pool2.address)
+    await poolFactory.supportPool(pool1.address)
+    await poolFactory.supportPool(pool2.address)
 
     await creditOracle.setCreditUpdatePeriod(YEAR)
     await creditOracle.setScore(borrower.address, 255)

--- a/test/truefi2/TrueLender2.test.ts
+++ b/test/truefi2/TrueLender2.test.ts
@@ -151,7 +151,6 @@ describe('TrueLender2', () => {
 
   describe('Initializer', () => {
     it('sets the staking pool address', async () => {
-      // TODO: fix
       expect(await lender.stakingPool()).to.equal(stkTru.address)
     })
 

--- a/test/truefi2/TrueLender2.test.ts
+++ b/test/truefi2/TrueLender2.test.ts
@@ -134,9 +134,6 @@ describe('TrueLender2', () => {
 
     loan2 = await createLoan(loanFactory, borrower, pool2, 500000, YEAR, 1000)
 
-    await poolFactory.supportPool(pool1.address)
-    await poolFactory.supportPool(pool2.address)
-
     await creditOracle.setCreditUpdatePeriod(YEAR)
     await creditOracle.setScore(borrower.address, 255)
     await creditOracle.setMaxBorrowerLimit(borrower.address, parseEth(1e8))

--- a/test/truefi2/TrueLender2.test.ts
+++ b/test/truefi2/TrueLender2.test.ts
@@ -151,6 +151,7 @@ describe('TrueLender2', () => {
 
   describe('Initializer', () => {
     it('sets the staking pool address', async () => {
+      // TODO: fix
       expect(await lender.stakingPool()).to.equal(stkTru.address)
     })
 

--- a/test/truefi2/TrueLender2.test.ts
+++ b/test/truefi2/TrueLender2.test.ts
@@ -138,6 +138,7 @@ describe('TrueLender2', () => {
 
     loan2 = await createLoan(loanFactory, borrower, pool2, 500000, YEAR, 1000)
 
+    // TODO: remove
     await rateAdjuster.addPoolToTVL(pool1.address)
     await rateAdjuster.addPoolToTVL(pool2.address)
 

--- a/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
@@ -1,7 +1,6 @@
 import { BigNumber, BigNumberish, Wallet } from 'ethers'
 import {
   BorrowingMutex,
-  IPoolFactory,
   LoanFactory2,
   MockBorrowingMutex__factory,
   MockTrueCurrency,
@@ -318,7 +317,7 @@ describe('TrueCreditAgency', () => {
 
     it('borrow amount is limited by total TVL', async () => {
       await usdcPool.liquidExit(parseUSDC(19e6))
-      const maxTVLLimit = (await poolFactory.tvl()).mul(15).div(100)
+      const maxTVLLimit = (await poolFactory.supportedPoolsTVL()).mul(15).div(100)
       expect(await creditAgency.borrowLimit(tusdPool.address, borrower.address)).to.equal(maxTVLLimit.mul(8051).div(10000))
     })
 

--- a/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
@@ -1,6 +1,7 @@
 import { BigNumber, BigNumberish, Wallet } from 'ethers'
 import {
   BorrowingMutex,
+  IPoolFactory,
   LoanFactory2,
   MockBorrowingMutex__factory,
   MockTrueCurrency,
@@ -33,7 +34,7 @@ import { setupDeploy } from 'scripts/utils'
 
 use(solidity)
 
-describe('TrueCreditAgency', () => {
+describe.only('TrueCreditAgency', () => {
   let provider: MockProvider
   let owner: Wallet
   let borrower: Wallet
@@ -317,8 +318,7 @@ describe('TrueCreditAgency', () => {
 
     it('borrow amount is limited by total TVL', async () => {
       await usdcPool.liquidExit(parseUSDC(19e6))
-      // TODO: use poolFactory in place of rateAdjuster
-      const maxTVLLimit = (await rateAdjuster.tvl()).mul(15).div(100)
+      const maxTVLLimit = (await poolFactory.tvl()).mul(15).div(100)
       expect(await creditAgency.borrowLimit(tusdPool.address, borrower.address)).to.equal(maxTVLLimit.mul(8051).div(10000))
     })
 

--- a/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
@@ -34,7 +34,7 @@ import { setupDeploy } from 'scripts/utils'
 
 use(solidity)
 
-describe.only('TrueCreditAgency', () => {
+describe('TrueCreditAgency', () => {
   let provider: MockProvider
   let owner: Wallet
   let borrower: Wallet

--- a/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
@@ -317,6 +317,7 @@ describe('TrueCreditAgency', () => {
 
     it('borrow amount is limited by total TVL', async () => {
       await usdcPool.liquidExit(parseUSDC(19e6))
+      // TODO: use poolFactory in place of rateAdjuster
       const maxTVLLimit = (await rateAdjuster.tvl()).mul(15).div(100)
       expect(await creditAgency.borrowLimit(tusdPool.address, borrower.address)).to.equal(maxTVLLimit.mul(8051).div(10000))
     })

--- a/test/truefi2/lines-of-credit/TrueRateAdjuster.test.ts
+++ b/test/truefi2/lines-of-credit/TrueRateAdjuster.test.ts
@@ -1,20 +1,14 @@
 import { expect, use } from 'chai'
 import { Wallet } from 'ethers'
 
-import {
-  beforeEachWithFixture,
-  DAY,
-  parseEth,
-  parseUSDC,
-  timeTravelTo,
-  updateRateOracle,
-} from 'utils'
+import { beforeEachWithFixture, DAY, parseEth, parseUSDC, timeTravelTo, updateRateOracle } from 'utils'
 import { setupDeploy } from 'scripts/utils'
 
 import {
   IPoolFactory,
   MockErc20Token,
   MockErc20Token__factory,
+  MockPoolFactory__factory,
   MockUsdStableCoinOracle__factory,
   TestTimeAveragedBaseRateOracle__factory,
   TimeAveragedBaseRateOracle,
@@ -26,13 +20,7 @@ import {
 } from 'contracts'
 
 import { deployMockContract, MockContract, MockProvider, solidity } from 'ethereum-waffle'
-import {
-  ITimeAveragedBaseRateOracleJson,
-  ITrueFiPool2WithDecimalsJson,
-  SpotBaseRateOracleJson,
-} from 'build'
-
-import { MockPoolFactory__factory } from 'build/types/factories/MockPoolFactory__factory'
+import { ITimeAveragedBaseRateOracleJson, ITrueFiPool2WithDecimalsJson, SpotBaseRateOracleJson } from 'build'
 
 use(solidity)
 

--- a/test/truefi2/lines-of-credit/TrueRateAdjuster.test.ts
+++ b/test/truefi2/lines-of-credit/TrueRateAdjuster.test.ts
@@ -83,6 +83,7 @@ describe('TrueRateAdjuster', () => {
     })
   })
 
+  // TODO: remove tests for addPoolToTVL & removePoolFromTVL
   describe('addPoolToTVL', () => {
     const pool1 = '0x1111111111111111111111111111111111111111'
     const pool2 = '0x2222222222222222222222222222222222222222'
@@ -455,6 +456,7 @@ describe('TrueRateAdjuster', () => {
       await creditOracle.setMaxBorrowerLimit(borrower.address, parseEth(100_000_000))
     })
 
+    // TODO: move TVL tests to PoolFactory.test.ts
     it('tvl returns sum of poolValues of all pools with 18 decimals precision', async () => {
       expect(await rateAdjuster.tvl()).to.equal(parseEth(3e7))
     })

--- a/test/utils/setupCreditAgency.ts
+++ b/test/utils/setupCreditAgency.ts
@@ -10,6 +10,7 @@ import {
   TrueRateAdjuster__factory,
 } from 'contracts'
 import { TimeAveragedBaseRateOracleJson } from 'build'
+import { AddressZero } from '@ethersproject/constants'
 
 export const setupCreditAgency = async (owner: Wallet, poolFactory: PoolFactory, pool: TrueFiPool2 | TestTrueFiPool) => {
   const borrowingMutex = await new BorrowingMutex__factory(owner).deploy()
@@ -20,7 +21,7 @@ export const setupCreditAgency = async (owner: Wallet, poolFactory: PoolFactory,
   await mockBaseRateOracle.mock.getWeeklyAPY.returns(300)
 
   await creditAgency.initialize(creditOracle.address, rateAdjuster.address, borrowingMutex.address, poolFactory.address)
-  await rateAdjuster.initialize()
+  await rateAdjuster.initialize(AddressZero)
   await creditOracle.initialize()
 
   await poolFactory.supportPool(pool.address)

--- a/test/utils/setupTruefi2.ts
+++ b/test/utils/setupTruefi2.ts
@@ -92,13 +92,11 @@ export const setupTruefi2 = async (owner: Wallet, provider: MockProvider, custom
   await poolFactory.allowToken(feeToken.address, true)
   await poolFactory.createPool(feeToken.address)
   const feePool = poolImplementation.attach(await poolFactory.pool(feeToken.address))
-  await poolFactory.supportPool(feePool.address)
   await feePool.setOracle(feeTokenOracle.address)
 
   await poolFactory.allowToken(standardToken.address, true)
   await poolFactory.createPool(standardToken.address)
   const standardPool = poolImplementation.attach(await poolFactory.pool(standardToken.address))
-  await poolFactory.supportPool(standardPool.address)
   await standardPool.setOracle(standardTokenOracle.address)
 
   await rateAdjuster.setBaseRateOracle(standardPool.address, standardBaseRateOracle.address)

--- a/test/utils/setupTruefi2.ts
+++ b/test/utils/setupTruefi2.ts
@@ -103,8 +103,8 @@ export const setupTruefi2 = async (owner: Wallet, provider: MockProvider, custom
 
   await rateAdjuster.setBaseRateOracle(standardPool.address, standardBaseRateOracle.address)
   await rateAdjuster.setBaseRateOracle(feePool.address, feeBaseRateOracle.address)
-  await rateAdjuster.addPoolToTVL(standardPool.address)
-  await rateAdjuster.addPoolToTVL(feePool.address)
+  await poolFactory.supportPool(standardPool.address)
+  await poolFactory.supportPool(feePool.address)
 
   await borrowingMutex.allowLocker(lender.address, true)
   await borrowingMutex.allowLocker(creditAgency.address, true)

--- a/test/utils/setupTruefi2.ts
+++ b/test/utils/setupTruefi2.ts
@@ -92,17 +92,17 @@ export const setupTruefi2 = async (owner: Wallet, provider: MockProvider, custom
   await poolFactory.allowToken(feeToken.address, true)
   await poolFactory.createPool(feeToken.address)
   const feePool = poolImplementation.attach(await poolFactory.pool(feeToken.address))
+  await poolFactory.supportPool(feePool.address)
   await feePool.setOracle(feeTokenOracle.address)
 
   await poolFactory.allowToken(standardToken.address, true)
   await poolFactory.createPool(standardToken.address)
   const standardPool = poolImplementation.attach(await poolFactory.pool(standardToken.address))
+  await poolFactory.supportPool(standardPool.address)
   await standardPool.setOracle(standardTokenOracle.address)
 
   await rateAdjuster.setBaseRateOracle(standardPool.address, standardBaseRateOracle.address)
   await rateAdjuster.setBaseRateOracle(feePool.address, feeBaseRateOracle.address)
-  await poolFactory.supportPool(standardPool.address)
-  await poolFactory.supportPool(feePool.address)
 
   await borrowingMutex.allowLocker(lender.address, true)
   await borrowingMutex.allowLocker(creditAgency.address, true)

--- a/test/utils/setupTruefi2.ts
+++ b/test/utils/setupTruefi2.ts
@@ -84,7 +84,7 @@ export const setupTruefi2 = async (owner: Wallet, provider: MockProvider, custom
   await lender.initialize(stkTru.address, poolFactory.address, customDeployed?.oneInch ? customDeployed.oneInch.address : AddressZero, creditOracle.address, rateAdjuster.address, borrowingMutex.address)
   await safu.initialize(loanFactory.address, liquidator.address, customDeployed?.oneInch ? customDeployed.oneInch.address : AddressZero)
   await poolFactory.initialize(implementationReference.address, lender.address, safu.address)
-  await rateAdjuster.initialize()
+  await rateAdjuster.initialize(poolFactory.address)
   await creditAgency.initialize(creditOracle.address, rateAdjuster.address, borrowingMutex.address, poolFactory.address)
   await standardBaseRateOracle.initialize(mockSpotOracle.address, standardToken.address, DAY)
   await feeBaseRateOracle.initialize(mockSpotOracle.address, feeToken.address, DAY)


### PR DESCRIPTION
Tests of `addPoolToTVL`, `removePoolFromTVL` and `tvl` should be moved to PoolFactory tests. I decided to do it in another PR as this one changes 14 files already.