### PR TITLE
Fix curve calc_token_amount calculation

### DIFF
--- a/contracts/truefi2/strategies/CurveYearnStrategy.sol
+++ b/contracts/truefi2/strategies/CurveYearnStrategy.sol
@@ -264,6 +264,14 @@ contract CurveYearnStrategy is UpgradeableClaimable, ITrueStrategy {
     }
 
     /**
+     * @dev DEPRECATED For new code, please determine which of
+     * {calcTokenDepositAmount(), calcTokenWithdrawAmount()} is appropriate.
+     */
+    function calcTokenAmount(uint256 currencyAmount) external view returns (uint256) {
+        return calcTokenDepositAmount(currencyAmount);
+    }
+
+    /**
      * @dev Expected amount of minted or burnt Curve.fi yDAI/yUSDC/yUSDT/yTUSD tokens.
      * @param currencyAmount amount to calculate for
      * @param isDeposit true for deposits=mint, false for withdrawals=burn

--- a/test/truefi2/strategies/CurveYearnStrategy.test.ts
+++ b/test/truefi2/strategies/CurveYearnStrategy.test.ts
@@ -5,6 +5,7 @@ import {
   MockCrvPriceOracle__factory,
   MockCurvePool,
   MockCurvePool__factory,
+  MockCurve__factory,
   MockErc20Token,
   MockErc20Token__factory,
   TestCurveStrategy,
@@ -131,6 +132,12 @@ describe('CurveYearnStrategy', () => {
         .to.emit(strategy, 'Deposited')
         .withArgs(amount, amount.div(2))
     })
+
+    it('calls calc_token_amount with correct arguments', async () => {
+      await strategy.connect(pool).deposit(amount)
+      const curve = new MockCurve__factory(owner).attach(await curvePool.curve())
+      expect('calc_token_amount').to.be.calledOnContractWith(curve, [[0, 0, 0, amount], true])
+    })
   })
 
   describe('withdraw', () => {
@@ -183,6 +190,12 @@ describe('CurveYearnStrategy', () => {
       await expect(strategy.connect(pool).withdraw(amount))
         .to.emit(strategy, 'Withdrawn')
         .withArgs(amount, amount.div(2))
+    })
+
+    it('calls calc_token_amount with correct arguments', async () => {
+      await strategy.connect(pool).withdraw(amount)
+      const curve = new MockCurve__factory(owner).attach(await curvePool.curve())
+      expect('calc_token_amount').to.be.calledOnContractWith(curve, [[0, 0, 0, amount], false])
     })
   })
 


### PR DESCRIPTION
calc_token_amount from curve is used incorrectly

Definition from curve ```def calc_token_amount(amounts: uint256[N_COINS], deposit: bool) -> uint256:```

Now, second argument is always ```true```.
When called from ```function withdraw(uint256 minAmount) external override onlyPool``` we need to calculate amount of pool tokens (Curve.fi yDAI/yUSDC/yUSDT/yTUSD - 0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8) to be burned to get ```minAmount``` tokens back.

When curve pool is balanced, the difference in calculation is minimal and using ```.mul(1005).div(1000)``` few lines later solves most problems.
When curve pool is not balanced, ```curvePool.remove_liquidity_one_coin``` call can fail because ```minAmount``` argument is supplied but ```conservativeCurveTokenAmount``` will be too small.
This could cause temporary withdrawal DoS.

---
If this calculation is fixed, you should be able to replace ```.mul(1005).div(1000)``` with ```.mul(1001).div(1000)```, I noticed you already use ```.mul(999).div(1000)``` for deposit calculation.
