### PR TITLE
Simplify yarn scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: yarn deploy:truefi --network kovan --dry-run --yes && yarn deploy:truefi2 --network kovan --dry-run --yes && yarn deploy:farms --network kovan --dry-run --yes
+      - run: yarn deploy:dryrun
   integration:
     docker:
       - image: cimg/node:16.1.0

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "deploy:strategy": "bash ./marsDeploy.sh deploy/strategy.ts",
     "deploy:truefi": "bash ./marsDeploy.sh deploy/truefi.ts",
     "deploy:truefi2": "bash ./marsDeploy.sh deploy/truefi2.ts",
+    "deploy:dryrun" : "yarn deploy:truefi --network kovan --dry-run --yes && yarn deploy:truefi2 --network kovan --dry-run --yes && yarn deploy:farms --network kovan --dry-run --yes",
     "checks": "yarn lint && yarn typecheck && yarn test && yarn test:integration",
     "docs": "npx solidity-docgen --solc-module solc-0.6 -i contracts -o docs",
     "slither": "./slither.sh",


### PR DESCRIPTION
This PR includes 2 changes:
1. Create yarn script `deploy:dryrun`, which replaces a long bash command that is run on CircleCI. This should ease running it locally for troubleshooting, so it does not need to be copied from `config.yml`.