### PR TITLE
Make DebtToken functional

### DIFF
--- a/contracts/truefi2/DebtToken.sol
+++ b/contracts/truefi2/DebtToken.sol
@@ -57,6 +57,9 @@ contract DebtToken is IDebtToken, ERC20 {
      * @param _amount amount to redeem
      */
     function redeem(uint256 _amount) external override {
+        // TODO remove the require checks when Awaiting/Funded/Withdrawn enum values are removed from IDebtToken
+        require(status >= Status.Defaulted, "DebtToken: The debt has not defaulted yet");
+
         uint256 amountToReturn = _amount.mul(_balance()).div(totalSupply());
         redeemed = redeemed.add(amountToReturn);
         _burn(msg.sender, _amount);

--- a/contracts/truefi2/DebtToken.sol
+++ b/contracts/truefi2/DebtToken.sol
@@ -16,7 +16,6 @@ contract DebtToken is IDebtToken, ERC20 {
 
     address public liquidator;
     ITrueFiPool2 public override pool;
-    ERC20 public override token;
 
     uint256 public redeemed;
 
@@ -32,9 +31,8 @@ contract DebtToken is IDebtToken, ERC20 {
 
     /**
      * @dev Emitted when loan gets liquidated
-     * @param status Final loan status
      */
-    event Liquidated(Status status);
+    event Liquidated();
 
     function initialize(
         ITrueFiPool2 _pool,
@@ -46,7 +44,6 @@ contract DebtToken is IDebtToken, ERC20 {
         ERC20.__ERC20_initialize("TrueFi Debt Token", "DEBT");
 
         pool = _pool;
-        token = _pool.token();
         borrower = _borrower;
         liquidator = _liquidator;
         debt = _debt;
@@ -63,7 +60,7 @@ contract DebtToken is IDebtToken, ERC20 {
         uint256 amountToReturn = _amount.mul(_balance()).div(totalSupply());
         redeemed = redeemed.add(amountToReturn);
         _burn(msg.sender, _amount);
-        token.safeTransfer(msg.sender, amountToReturn);
+        token().safeTransfer(msg.sender, amountToReturn);
 
         emit Redeemed(msg.sender, _amount, amountToReturn);
     }
@@ -77,7 +74,7 @@ contract DebtToken is IDebtToken, ERC20 {
 
         status = Status.Liquidated;
 
-        emit Liquidated(status);
+        emit Liquidated();
     }
 
     /**
@@ -97,6 +94,14 @@ contract DebtToken is IDebtToken, ERC20 {
         return _balance();
     }
 
+    function token() public override view returns (ERC20) {
+        return pool.token();
+    }
+
+    function decimals() public override view returns (uint8) {
+        return token().decimals();
+    }
+
     function version() external override pure returns (uint8) {
         return 1;
     }
@@ -106,6 +111,6 @@ contract DebtToken is IDebtToken, ERC20 {
      * @return token balance of this contract
      */
     function _balance() internal view returns (uint256) {
-        return token.balanceOf(address(this));
+        return token().balanceOf(address(this));
     }
 }

--- a/contracts/truefi2/DebtToken.sol
+++ b/contracts/truefi2/DebtToken.sol
@@ -4,37 +4,108 @@ pragma solidity 0.6.10;
 import {ERC20} from "../common/UpgradeableERC20.sol";
 import {IDebtToken} from "./interface/ILoanToken2.sol";
 import {ITrueFiPool2} from "./interface/ITrueFiPool2.sol";
+import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
 contract DebtToken is IDebtToken, ERC20 {
-    function borrower() external override view returns (address) {}
+    using SafeMath for uint256;
+    using SafeERC20 for ERC20;
 
-    function amount() external override view returns (uint256) {}
+    address public override borrower;
+    uint256 public override debt;
 
-    function debt() external override view returns (uint256) {}
+    address public liquidator;
+    ITrueFiPool2 public override pool;
+    ERC20 public override token;
 
-    function pool() external override view returns (ITrueFiPool2) {}
+    uint256 public redeemed;
 
-    function status() external override view returns (Status) {}
+    Status public override status;
 
-    function redeem(uint256 _amount) external override {}
+    /**
+     * @dev Emitted when a DebtToken is redeemed for underlying tokens
+     * @param receiver Receiver of tokens
+     * @param burnedAmount Amount of DebtTokens burned
+     * @param redeemedAmount Amount of token received
+     */
+    event Redeemed(address receiver, uint256 burnedAmount, uint256 redeemedAmount);
 
-    function repay(address _sender, uint256 _amount) external override {}
+    /**
+     * @dev Emitted when loan gets liquidated
+     * @param status Final loan status
+     */
+    event Liquidated(Status status);
 
-    function repayInFull(address _sender) external override {}
+    function initialize(
+        ITrueFiPool2 _pool,
+        address _lender,
+        address _borrower,
+        address _liquidator,
+        uint256 _debt
+    ) external initializer {
+        ERC20.__ERC20_initialize("TrueFi Debt Token", "DEBT");
 
-    function reclaim() external override {}
+        pool = _pool;
+        token = _pool.token();
+        borrower = _borrower;
+        liquidator = _liquidator;
+        debt = _debt;
+        status = Status.Defaulted;
+        _mint(_lender, _debt);
+    }
 
-    function liquidate() external override {}
+    /**
+     * @dev Redeem DebtToken balances for underlying token
+     * Can only call this function after the loan is Closed
+     * @param _amount amount to redeem
+     */
+    function redeem(uint256 _amount) external override {
+        uint256 amountToReturn = _amount.mul(_balance()).div(totalSupply());
+        redeemed = redeemed.add(amountToReturn);
+        _burn(msg.sender, _amount);
+        token.safeTransfer(msg.sender, amountToReturn);
 
-    function repaid() external override view returns (uint256) {}
+        emit Redeemed(msg.sender, _amount, amountToReturn);
+    }
 
-    function isRepaid() external override view returns (bool) {}
+    /**
+     * @dev Liquidate the loan if it has defaulted
+     */
+    function liquidate() external override {
+        require(status == Status.Defaulted, "DebtToken: Current status should be Defaulted");
+        require(msg.sender == liquidator, "DebtToken: Caller is not the liquidator");
 
-    function balance() external override view returns (uint256) {}
+        status = Status.Liquidated;
 
-    function value(uint256 _balance) external override view returns (uint256) {}
+        emit Liquidated(status);
+    }
 
-    function token() external override view returns (ERC20) {}
+    /**
+     * @dev Check how much was already repaid
+     * Funds stored on the contract's address plus funds already redeemed by lenders
+     * @return Uint256 representing what value was already repaid
+     */
+    function repaid() external override view returns (uint256) {
+        return _balance().add(redeemed);
+    }
 
-    function version() external override pure returns (uint8) {}
+    /**
+     * @dev Public currency token balance function
+     * @return token balance of this contract
+     */
+    function balance() external override view returns (uint256) {
+        return _balance();
+    }
+
+    function version() external override pure returns (uint8) {
+        return 1;
+    }
+
+    /**
+     * @dev Get currency token balance for this contract
+     * @return token balance of this contract
+     */
+    function _balance() internal view returns (uint256) {
+        return token.balanceOf(address(this));
+    }
 }

--- a/contracts/truefi2/interface/ILoanToken2.sol
+++ b/contracts/truefi2/interface/ILoanToken2.sol
@@ -11,8 +11,6 @@ interface IDebtToken is IERC20 {
 
     function borrower() external view returns (address);
 
-    function amount() external view returns (uint256);
-
     function debt() external view returns (uint256);
 
     function pool() external view returns (ITrueFiPool2);
@@ -21,21 +19,11 @@ interface IDebtToken is IERC20 {
 
     function redeem(uint256 _amount) external;
 
-    function repay(address _sender, uint256 _amount) external;
-
-    function repayInFull(address _sender) external;
-
-    function reclaim() external;
-
     function liquidate() external;
 
     function repaid() external view returns (uint256);
 
-    function isRepaid() external view returns (bool);
-
     function balance() external view returns (uint256);
-
-    function value(uint256 _balance) external view returns (uint256);
 
     function token() external view returns (ERC20);
 
@@ -47,11 +35,19 @@ interface ILoanToken2 is IDebtToken {
 
     function apy() external view returns (uint256);
 
+    function amount() external view returns (uint256);
+
     function start() external view returns (uint256);
 
     function lender() external view returns (address);
 
     function profit() external view returns (uint256);
+
+    function repay(address _sender, uint256 _amount) external;
+
+    function repayInFull(address _sender) external;
+
+    function value(uint256 _balance) external view returns (uint256);
 
     function getParameters()
         external
@@ -69,6 +65,10 @@ interface ILoanToken2 is IDebtToken {
     function settle() external;
 
     function enterDefault() external;
+
+    function reclaim() external;
+
+    function isRepaid() external view returns (bool);
 
     function allowTransfer(address account, bool _status) external;
 }

--- a/test/truefi2/lines-of-credit/DebtToken.test.ts
+++ b/test/truefi2/lines-of-credit/DebtToken.test.ts
@@ -1,0 +1,166 @@
+import { expect, use } from 'chai'
+import { MockProvider, solidity } from 'ethereum-waffle'
+import { BigNumberish, Wallet } from 'ethers'
+
+import { beforeEachWithFixture, parseEth, setupTruefi2 } from 'utils'
+
+import { DebtToken, DebtToken__factory, MockTrueCurrency, MockTrueCurrency__factory } from 'contracts'
+
+use(solidity)
+
+describe('DebtToken', () => {
+  enum LoanTokenStatus {
+    Defaulted = 4,
+    Liquidated
+  }
+
+  const payback = async (wallet: Wallet, amount: BigNumberish) => token.mint(debtToken.address, amount)
+  const debt = parseEth(1)
+
+  let lender: Wallet
+  let borrower: Wallet
+  let safu: Wallet
+  let debtToken: DebtToken
+  let token: MockTrueCurrency
+  let poolAddress: string
+  let provider: MockProvider
+
+  beforeEachWithFixture(async (wallets, _provider) => {
+    [lender, borrower, safu] = wallets
+    provider = _provider
+
+    const { standardPool } = await setupTruefi2(lender, provider)
+    poolAddress = standardPool.address
+    token = MockTrueCurrency__factory.connect(await standardPool.token(), lender)
+    debtToken = await new DebtToken__factory(lender).deploy()
+    await debtToken.initialize(standardPool.address, lender.address, borrower.address, safu.address, debt)
+  })
+
+  describe('Constructor', () => {
+    it('correctly takes token from pool', async () => {
+      expect(await debtToken.token()).to.equal(token.address)
+    })
+
+    it('sets pool address', async () => {
+      expect(await debtToken.pool()).to.equal(poolAddress)
+    })
+
+    it('sets borrowers debt', async () => {
+      expect(await debtToken.debt()).to.equal(debt)
+    })
+
+    it('sets erc20 params', async () => {
+      expect(await debtToken.name()).to.equal('TrueFi Debt Token')
+      expect(await debtToken.symbol()).to.equal('DEBT')
+      expect(await debtToken.decimals()).to.equal(18)
+    })
+
+    it('mints tokens for the lender', async () => {
+      expect(await debtToken.balanceOf(lender.address)).to.equal(debt)
+      expect(await debtToken.totalSupply()).to.equal(debt)
+    })
+
+    it('sets status to Defaulted', async () => {
+      expect(await debtToken.status()).to.equal(LoanTokenStatus.Defaulted)
+    })
+  })
+
+  describe('liquidate', () => {
+    it('reverts if liquidated twice', async () => {
+      await debtToken.connect(safu).liquidate()
+      await expect(debtToken.connect(safu).liquidate())
+        .to.be.revertedWith('DebtToken: Current status should be Defaulted')
+    })
+
+    it('reverts if not called by liquidator', async () => {
+      await expect(debtToken.liquidate())
+        .to.be.revertedWith('DebtToken: Caller is not the liquidator')
+    })
+
+    it('sets status to liquidated', async () => {
+      await debtToken.connect(safu).liquidate()
+      expect(await debtToken.status()).to.equal(LoanTokenStatus.Liquidated)
+    })
+  })
+
+  describe('Redeem', () => {
+    beforeEach(async () => {
+      await token.mint(borrower.address, parseEth(100))
+    })
+
+    it('reverts if redeeming more than own balance', async () => {
+      await payback(borrower, parseEth(100))
+      await expect(debtToken.redeem(debt.add(1))).to.be.revertedWith('ERC20: burn amount exceeds balance')
+    })
+
+    it('emits event', async () => {
+      await payback(borrower, parseEth(100))
+      await expect(debtToken.redeem(debt)).to.emit(debtToken, 'Redeemed').withArgs(lender.address, debt, parseEth(100))
+    })
+
+    describe('Simple case: whole debt paid back, redeem all', () => {
+      beforeEach(async () => {
+        await payback(borrower, debt)
+        await expect(() => debtToken.redeem(debt)).to.changeTokenBalance(token, lender, debt)
+      })
+
+      it('burns loan tokens', async () => {
+        expect(await debtToken.totalSupply()).to.equal(0)
+        expect(await debtToken.balanceOf(lender.address)).to.equal(0)
+      })
+
+      it('repaid amount does not change', async () => {
+        expect(await debtToken.repaid()).to.equal(debt)
+      })
+    })
+
+    describe('3/4 paid back, redeem all', () => {
+      const repaid = debt.mul(3).div(4)
+
+      beforeEach(async () => {
+        await payback(borrower, repaid)
+        await expect(() => debtToken.redeem(debt)).to.changeTokenBalance(token, lender, repaid)
+      })
+
+      it('burns debt tokens', async () => {
+        expect(await debtToken.totalSupply()).to.equal(0)
+        expect(await debtToken.balanceOf(lender.address)).to.equal(0)
+      })
+
+      it('repaid amount does not change', async () => {
+        expect(await debtToken.repaid()).to.equal(repaid)
+      })
+    })
+
+    describe('1/2 paid back redeem half, then rest is paid back, redeem rest', () => {
+      beforeEach(async () => {
+        await payback(borrower, debt.div(2))
+        await debtToken.redeem(debt.div(2))
+        expect(await token.balanceOf(lender.address)).to.equal(debt.div(4))
+        await payback(borrower, debt.div(2))
+        await debtToken.redeem(debt.div(2))
+      })
+
+      it('transfers all tokens to the lender', async () => {
+        expect(await token.balanceOf(lender.address)).to.equal(debt)
+      })
+
+      it('burns loan tokens', async () => {
+        expect(await debtToken.totalSupply()).to.equal(0)
+        expect(await debtToken.balanceOf(lender.address)).to.equal(0)
+      })
+
+      it('repaid is total paid back amount', async () => {
+        expect(await debtToken.repaid()).to.equal(debt)
+      })
+
+      it('status is still DEFAULTED', async () => {
+        expect(await debtToken.status()).to.equal(LoanTokenStatus.Defaulted)
+      })
+    })
+  })
+
+  it('version', async () => {
+    expect(await debtToken.version()).to.equal(1)
+  })
+})

--- a/test/truefi2/lines-of-credit/DebtToken.test.ts
+++ b/test/truefi2/lines-of-credit/DebtToken.test.ts
@@ -9,7 +9,7 @@ import { DebtToken, DebtToken__factory, MockTrueCurrency, MockTrueCurrency__fact
 use(solidity)
 
 describe('DebtToken', () => {
-  enum LoanTokenStatus {
+  enum DebtTokenStatus {
     Defaulted = 4,
     Liquidated
   }
@@ -61,7 +61,7 @@ describe('DebtToken', () => {
     })
 
     it('sets status to Defaulted', async () => {
-      expect(await debtToken.status()).to.equal(LoanTokenStatus.Defaulted)
+      expect(await debtToken.status()).to.equal(DebtTokenStatus.Defaulted)
     })
   })
 
@@ -79,7 +79,7 @@ describe('DebtToken', () => {
 
     it('sets status to liquidated', async () => {
       await debtToken.connect(safu).liquidate()
-      expect(await debtToken.status()).to.equal(LoanTokenStatus.Liquidated)
+      expect(await debtToken.status()).to.equal(DebtTokenStatus.Liquidated)
     })
   })
 
@@ -155,7 +155,7 @@ describe('DebtToken', () => {
       })
 
       it('status is still DEFAULTED', async () => {
-        expect(await debtToken.status()).to.equal(LoanTokenStatus.Defaulted)
+        expect(await debtToken.status()).to.equal(DebtTokenStatus.Defaulted)
       })
     })
   })

--- a/test/truefi2/lines-of-credit/DebtToken.test.ts
+++ b/test/truefi2/lines-of-credit/DebtToken.test.ts
@@ -49,6 +49,10 @@ describe('DebtToken', () => {
       expect(await debtToken.debt()).to.equal(debt)
     })
 
+    it('sets borrower', async () => {
+      expect(await debtToken.borrower()).to.equal(borrower.address)
+    })
+
     it('sets erc20 params', async () => {
       expect(await debtToken.name()).to.equal('TrueFi Debt Token')
       expect(await debtToken.symbol()).to.equal('DEBT')
@@ -80,6 +84,10 @@ describe('DebtToken', () => {
     it('sets status to liquidated', async () => {
       await debtToken.connect(safu).liquidate()
       expect(await debtToken.status()).to.equal(DebtTokenStatus.Liquidated)
+    })
+
+    it('emits event', async () => {
+      await expect(debtToken.connect(safu).liquidate()).to.emit(debtToken, 'Liquidated')
     })
   })
 


### PR DESCRIPTION
I removed all functions from IDebtToken interface that are not essential to liquidation flow. If we decide we need them, it can be added later