### PR TITLE
TCA default review follow up to #944

### DIFF
--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -401,18 +401,22 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
         );
         if (!isBorrowerAllowed[borrower]) {
             _enterDefault(borrower);
+            return;
         }
         if (creditOracle.status(borrower) == ITrueFiCreditOracle.Status.Ineligible) {
             _enterDefault(borrower);
+            return;
         }
         if (creditOracle.score(borrower) < minCreditScore) {
             _enterDefault(borrower);
+            return;
         }
         ITrueFiPool2[] memory pools = poolFactory.getSupportedPools();
         for (uint256 i = 0; i < pools.length; i++) {
             ITrueFiPool2 pool = pools[i];
             if (block.timestamp >= nextInterestRepayTime[pool][borrower].add(creditOracle.gracePeriod())) {
                 _enterDefault(borrower);
+                return;
             }
         }
         revert("TrueCreditAgency: Borrower has no reason to enter default at this time")

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -411,10 +411,11 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
             _enterDefault(borrower);
             return;
         }
+        uint256 defaultTime = block.timestamp.sub(creditOracle.gracePeriod());
         ITrueFiPool2[] memory pools = poolFactory.getSupportedPools();
         for (uint256 i = 0; i < pools.length; i++) {
             ITrueFiPool2 pool = pools[i];
-            if (block.timestamp >= nextInterestRepayTime[pool][borrower].add(creditOracle.gracePeriod())) {
+            if (defaultTime >= nextInterestRepayTime[pool][borrower]) {
                 _enterDefault(borrower);
                 return;
             }

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -167,9 +167,10 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
         UpgradeableClaimable.initialize(msg.sender);
         creditOracle = _creditOracle;
         rateAdjuster = _rateAdjuster;
-        interestRepaymentPeriod = 31 days;
         borrowingMutex = _borrowingMutex;
         poolFactory = _poolFactory;
+        minCreditScore = 191;
+        interestRepaymentPeriod = 31 days;
     }
 
     /// @dev modifier for only whitelisted borrowers

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -428,8 +428,9 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
             (uint8 oldScore, uint8 newScore) = _updateCreditScore(pool, borrower);
             _rebucket(pool, borrower, oldScore, newScore, 0);
 
-            borrowerTotalPaidInterest[pool][borrower] = borrowerTotalPaidInterest[pool][borrower].add(interest(pool, borrower));
-            poolTotalPaidInterest[pool] = poolTotalPaidInterest[pool].add(interest(pool, borrower));
+            uint256 _interest = interest(pool, borrower);
+            borrowerTotalPaidInterest[pool][borrower] = borrowerTotalPaidInterest[pool][borrower].add(_interest);
+            poolTotalPaidInterest[pool] = poolTotalPaidInterest[pool].add(_interest);
         }
         borrowingMutex.unlock(borrower);
         // TODO lock borrower to a new DebtToken. This placeholder currently locks borrower to an inaccessible locker address.

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -408,14 +408,9 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
         if (creditOracle.score(borrower) < minCreditScore) {
             _enterDefault(borrower);
         }
-
         ITrueFiPool2[] memory pools = poolFactory.getSupportedPools();
         for (uint256 i = 0; i < pools.length; i++) {
             ITrueFiPool2 pool = pools[i];
-            if (borrowed[pool][borrower] == 0) {
-                continue;
-            }
-
             if (block.timestamp >= nextInterestRepayTime[pool][borrower].add(creditOracle.gracePeriod())) {
                 _enterDefault(borrower);
             }

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -395,10 +395,19 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
      * @dev Enter default for a certain borrower's line of credit
      */
     function enterDefault(address borrower) external onlyOwner {
+        require(
+            borrowingMutex.locker(borrower) == address(this),
+            "TrueCreditAgency: Cannot default a borrower with no open debt position"
+        );
+
         ITrueFiPool2[] memory pools = poolFactory.getSupportedPools();
         for (uint256 i = 0; i < pools.length; i++) {
             _enterDefault(pools[i], borrower);
         }
+
+        borrowingMutex.unlock(borrower);
+        // TODO lock borrower to a new DebtToken. This placeholder currently locks borrower to an inaccessible locker address.
+        borrowingMutex.lock(borrower, address(1));
     }
 
     function _enterDefault(ITrueFiPool2 pool, address borrower) private {

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -405,6 +405,9 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
         if (creditOracle.status(borrower) == ITrueFiCreditOracle.Status.Ineligible) {
             _enterDefault(borrower);
         }
+        if (creditOracle.score(borrower) < minCreditScore) {
+            _enterDefault(borrower);
+        }
 
         ITrueFiPool2[] memory pools = poolFactory.getSupportedPools();
         for (uint256 i = 0; i < pools.length; i++) {

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -394,7 +394,14 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
     /**
      * @dev Enter default for a certain borrower's line of credit
      */
-    function enterDefault(ITrueFiPool2 pool, address borrower) external {
+    function enterDefault(address borrower) external onlyOwner {
+        ITrueFiPool2[] memory pools = poolFactory.getSupportedPools();
+        for (uint256 i = 0; i < pools.length; i++) {
+            _enterDefault(pools[i], borrower);
+        }
+    }
+
+    function _enterDefault(ITrueFiPool2 pool, address borrower) private {
         require(borrowed[pool][borrower] > 0, "TrueCreditAgency: Borrower does not have any debt in pool");
         require(
             block.timestamp >= nextInterestRepayTime[pool][borrower].add(creditOracle.gracePeriod()),

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -420,12 +420,14 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
                 return;
             }
         }
-        revert("TrueCreditAgency: Borrower has no reason to enter default at this time")
+        revert("TrueCreditAgency: Borrower has no reason to enter default at this time");
     }
 
     function _enterDefault(address borrower) private {
         ITrueFiPool2[] memory pools = poolFactory.getSupportedPools();
         for (uint256 i = 0; i < pools.length; i++) {
+            ITrueFiPool2 pool = pools[i];
+
             (uint8 oldScore, uint8 newScore) = _updateCreditScore(pool, borrower);
             _rebucket(pool, borrower, oldScore, newScore, 0);
 

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -415,7 +415,8 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
         ITrueFiPool2[] memory pools = poolFactory.getSupportedPools();
         for (uint256 i = 0; i < pools.length; i++) {
             ITrueFiPool2 pool = pools[i];
-            if (defaultTime >= nextInterestRepayTime[pool][borrower]) {
+            uint256 nextInterestRepay = nextInterestRepayTime[pool][borrower];
+            if (nextInterestRepay != 0 && defaultTime >= nextInterestRepay) {
                 _enterDefault(borrower);
                 return;
             }

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -399,6 +399,9 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
             borrowingMutex.locker(borrower) == address(this),
             "TrueCreditAgency: Cannot default a borrower with no open debt position"
         );
+        if (!isBorrowerAllowed[borrower]) {
+            _enterDefault(borrower);
+        }
         if (creditOracle.status(borrower) == ITrueFiCreditOracle.Status.Ineligible) {
             _enterDefault(borrower);
         }

--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -403,8 +403,10 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
         ITrueFiPool2[] memory pools = poolFactory.getSupportedPools();
         for (uint256 i = 0; i < pools.length; i++) {
             ITrueFiPool2 pool = pools[i];
+            if (borrowed[pool][borrower] == 0) {
+                continue;
+            }
 
-            require(borrowed[pool][borrower] > 0, "TrueCreditAgency: Borrower does not have any debt in pool");
             require(
                 block.timestamp >= nextInterestRepayTime[pool][borrower].add(creditOracle.gracePeriod()),
                 "TrueCreditAgency: Borrower can still repay the debt"

--- a/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
@@ -771,6 +771,7 @@ describe('TrueCreditAgency', () => {
       await creditOracle.setScore(owner.address, 255)
       await creditOracle.setScore(borrower.address, 255)
       await creditAgency.setInterestRepaymentPeriod(YEAR * 10)
+      await creditAgency.setMinCreditScore(150)
     })
 
     it('interest for single borrower and stable rate', async () => {
@@ -932,14 +933,14 @@ describe('TrueCreditAgency', () => {
         await creditAgency.allowBorrower(borrower.address, false)
         await expect(creditAgency.enterDefault(borrower.address))
           .to.emit(creditAgency, 'EnteredDefault')
-          .withArgs(borrower.address, 0 /* DefaultReason.NotAllowed */);
+          .withArgs(borrower.address, 0 /* DefaultReason.NotAllowed */)
       })
 
       it('borrower credit is ineligible', async () => {
         await creditOracle.setIneligible(borrower.address)
         await expect(creditAgency.enterDefault(borrower.address))
           .to.emit(creditAgency, 'EnteredDefault')
-          .withArgs(borrower.address, 1 /* DefaultReason.Ineligible */);
+          .withArgs(borrower.address, 1 /* DefaultReason.Ineligible */)
       })
 
       it('borrower is below min score', async () => {
@@ -947,7 +948,7 @@ describe('TrueCreditAgency', () => {
         await creditOracle.setScore(borrower.address, 190)
         await expect(creditAgency.enterDefault(borrower.address))
           .to.emit(creditAgency, 'EnteredDefault')
-          .withArgs(borrower.address, 2 /* DefaultReason.BelowMinScore */);
+          .withArgs(borrower.address, 2 /* DefaultReason.BelowMinScore */)
       })
 
       it('borrower interest is overdue', async () => {
@@ -955,7 +956,7 @@ describe('TrueCreditAgency', () => {
         await timeTravel(MONTH + DAY * 3 + 1)
         await expect(creditAgency.enterDefault(borrower.address))
           .to.emit(creditAgency, 'EnteredDefault')
-          .withArgs(borrower.address, 3 /* DefaultReason.InterestOverdue */);
+          .withArgs(borrower.address, 3 /* DefaultReason.InterestOverdue */)
       })
     })
 

--- a/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
@@ -906,7 +906,7 @@ describe('TrueCreditAgency', () => {
     })
   })
 
-  describe('enterDefault', () => {
+  describe.only('enterDefault', () => {
     beforeEach(async () => {
       await creditAgency.allowBorrower(borrower.address, true)
       await rateAdjuster.setRiskPremium(700)
@@ -918,19 +918,12 @@ describe('TrueCreditAgency', () => {
       it('borrower has no debt', async () => {
         await creditAgency.connect(borrower).repayInFull(tusdPool.address)
         await expect(creditAgency.enterDefault(borrower.address))
-          .to.be.revertedWith('TrueCreditAgency: Borrower does not have any debt in pool')
+          .to.be.revertedWith('TrueCreditAgency: Cannot default a borrower with no open debt position')
       })
 
-      it('borrower can still repay', async () => {
+      it('borrower has no reason to default', async () => {
         await expect(creditAgency.enterDefault(borrower.address))
-          .to.be.revertedWith('TrueCreditAgency: Borrower can still repay the debt')
-      })
-
-      it('borrower is not ineligible', async () => {
-        await creditOracle.setEligibleForDuration(borrower.address, 2 * MONTH)
-        await timeTravel(MONTH + DAY * 3 + 1)
-        await expect(creditAgency.enterDefault(borrower.address))
-          .to.be.revertedWith('TrueCreditAgency: Borrower status has to be ineligible to default')
+          .to.be.revertedWith('TrueCreditAgency: Borrower has no reason to enter default at this time')
       })
     })
 

--- a/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
@@ -917,19 +917,19 @@ describe('TrueCreditAgency', () => {
     describe('reverts if', () => {
       it('borrower has no debt', async () => {
         await creditAgency.connect(borrower).repayInFull(tusdPool.address)
-        await expect(creditAgency.enterDefault(tusdPool.address, borrower.address))
+        await expect(creditAgency.enterDefault(borrower.address))
           .to.be.revertedWith('TrueCreditAgency: Borrower does not have any debt in pool')
       })
 
       it('borrower can still repay', async () => {
-        await expect(creditAgency.enterDefault(tusdPool.address, borrower.address))
+        await expect(creditAgency.enterDefault(borrower.address))
           .to.be.revertedWith('TrueCreditAgency: Borrower can still repay the debt')
       })
 
       it('borrower is not ineligible', async () => {
         await creditOracle.setEligibleForDuration(borrower.address, 2 * MONTH)
         await timeTravel(MONTH + DAY * 3 + 1)
-        await expect(creditAgency.enterDefault(tusdPool.address, borrower.address))
+        await expect(creditAgency.enterDefault(borrower.address))
           .to.be.revertedWith('TrueCreditAgency: Borrower status has to be ineligible to default')
       })
     })
@@ -941,13 +941,13 @@ describe('TrueCreditAgency', () => {
 
       it('reduces principal debt to 0', async () => {
         expect(await creditAgency.borrowed(tusdPool.address, borrower.address)).to.eq(1000)
-        await creditAgency.enterDefault(tusdPool.address, borrower.address)
+        await creditAgency.enterDefault(borrower.address)
         expect(await creditAgency.borrowed(tusdPool.address, borrower.address)).to.eq(0)
       })
 
       it('reduces interest to 0', async () => {
         expect(await creditAgency.interest(tusdPool.address, borrower.address)).to.be.gt(0)
-        await creditAgency.enterDefault(tusdPool.address, borrower.address)
+        await creditAgency.enterDefault(borrower.address)
         expect(await creditAgency.interest(tusdPool.address, borrower.address)).to.eq(0)
       })
     })

--- a/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/TrueCreditAgency.test.ts
@@ -935,18 +935,20 @@ describe('TrueCreditAgency', () => {
     })
 
     describe('because', () => {
+      enum DefaultReason {NotAllowed, Ineligible, BelowMinScore, InterestOverdue}
+
       it('borrower is not allowed to use LoCs', async () => {
         await creditAgency.allowBorrower(borrower.address, false)
         await expect(creditAgency.enterDefault(tusdPool.address, borrower.address))
           .to.emit(creditAgency, 'EnteredDefault')
-          .withArgs(borrower.address, 0 /* DefaultReason.NotAllowed */)
+          .withArgs(borrower.address, DefaultReason.NotAllowed)
       })
 
       it('borrower credit is ineligible', async () => {
         await creditOracle.setIneligible(borrower.address)
         await expect(creditAgency.enterDefault(tusdPool.address, borrower.address))
           .to.emit(creditAgency, 'EnteredDefault')
-          .withArgs(borrower.address, 1 /* DefaultReason.Ineligible */)
+          .withArgs(borrower.address, DefaultReason.Ineligible)
       })
 
       it('borrower is below min score', async () => {
@@ -954,7 +956,7 @@ describe('TrueCreditAgency', () => {
         await creditOracle.setScore(borrower.address, 190)
         await expect(creditAgency.enterDefault(tusdPool.address, borrower.address))
           .to.emit(creditAgency, 'EnteredDefault')
-          .withArgs(borrower.address, 2 /* DefaultReason.BelowMinScore */)
+          .withArgs(borrower.address, DefaultReason.BelowMinScore)
       })
 
       it('borrower interest is overdue', async () => {
@@ -962,7 +964,7 @@ describe('TrueCreditAgency', () => {
         await timeTravel(MONTH + DAY * 3 + 1)
         await expect(creditAgency.enterDefault(tusdPool.address, borrower.address))
           .to.emit(creditAgency, 'EnteredDefault')
-          .withArgs(borrower.address, 3 /* DefaultReason.InterestOverdue */)
+          .withArgs(borrower.address, DefaultReason.InterestOverdue)
       })
     })
 


### PR DESCRIPTION
Changes to TCA default:
- ~~per {borrower} instead of per {borrower, pool}~~
- onlyOwner
- check and unlock/lock borrowing mutex
- OR conditions instead of AND
- add {not allowed, ineligible, min score, interest overdue} conditions
- emit a descriptive event