### PR TITLE
Call LF2.createFTLALoanToken() from FTLA.fund()

### DIFF
--- a/contracts/truefi2/FixedTermLoanAgency.sol
+++ b/contracts/truefi2/FixedTermLoanAgency.sol
@@ -327,8 +327,6 @@ contract FixedTermLoanAgency is IFixedTermLoanAgency, UpgradeableClaimable {
         require(amount <= borrowLimit(pool, loanToken.borrower()), "FixedTermLoanAgency: Loan amount cannot exceed borrow limit");
 
         uint256 apy = rate(pool, borrower, amount, term);
-        // TODO use the above apy calculation and delete the below apy when calling LF2.createFTLALoanToken()
-        apy = loanToken.apy();
         require(apy <= _maxApy, "LoanFactory: Calculated apy is higher than max apy");
 
         poolLoans[pool].push(loanToken);

--- a/contracts/truefi2/FixedTermLoanAgency.sol
+++ b/contracts/truefi2/FixedTermLoanAgency.sol
@@ -526,7 +526,7 @@ contract FixedTermLoanAgency is IFixedTermLoanAgency, UpgradeableClaimable {
         }
         // If we reach this, it means loanToken was not present in _loans array
         // This prevents invalid loans from being reclaimed
-        revert("FixedTermLoanAgency: This loan has not been funded by the agency");
+        revert("FixedTermLoanAgency: This loan has not been funded by the agency");\
     }
 
     // @dev Transfer (numerator/denominator)*balance of loan to the recipient

--- a/contracts/truefi2/FixedTermLoanAgency.sol
+++ b/contracts/truefi2/FixedTermLoanAgency.sol
@@ -524,7 +524,7 @@ contract FixedTermLoanAgency is IFixedTermLoanAgency, UpgradeableClaimable {
         }
         // If we reach this, it means loanToken was not present in _loans array
         // This prevents invalid loans from being reclaimed
-        revert("FixedTermLoanAgency: This loan has not been funded by the agency");\
+        revert("FixedTermLoanAgency: This loan has not been funded by the agency");
     }
 
     // @dev Transfer (numerator/denominator)*balance of loan to the recipient

--- a/contracts/truefi2/FixedTermLoanAgency.sol
+++ b/contracts/truefi2/FixedTermLoanAgency.sol
@@ -307,7 +307,7 @@ contract FixedTermLoanAgency is IFixedTermLoanAgency, UpgradeableClaimable {
         address borrower,
         uint256 amount,
         uint256 term
-    ) internal view returns (uint256) {
+    ) public view returns (uint256) {
         uint8 borrowerScore = creditOracle.score(borrower);
         uint256 fixedTermLoanAdjustment = rateAdjuster.fixedTermLoanAdjustment(term);
         return rateAdjuster.rate(pool, borrowerScore, amount).add(fixedTermLoanAdjustment);
@@ -336,15 +336,15 @@ contract FixedTermLoanAgency is IFixedTermLoanAgency, UpgradeableClaimable {
             "FixedTermLoanAgency: Sender is not eligible for loan"
         );
 
-        require(amount > 0, "LoanFactory: Loans of amount 0, will not be approved");
+        require(amount > 0, "FixedTermLoanAgency: Loans of amount 0, will not be approved");
         require(amount <= borrowLimit(pool, borrower), "FixedTermLoanAgency: Loan amount cannot exceed borrow limit");
 
-        require(term > 0, "LoanFactory: Loans cannot have instantaneous term of repay");
+        require(term > 0, "FixedTermLoanAgency: Loans cannot have instantaneous term of repay");
         require(isTermBelowMax(term), "FixedTermLoanAgency: Loan's term is too long");
         require(isCredibleForTerm(term), "FixedTermLoanAgency: Credit score is too low for loan's term");
 
         uint256 apy = rate(pool, borrower, amount, term);
-        require(apy <= _maxApy, "LoanFactory: Calculated apy is higher than max apy");
+        require(apy <= _maxApy, "FixedTermLoanAgency: Calculated apy is higher than max apy");
 
         ILoanToken2 loanToken = loanFactory.createFTLALoanToken(pool, borrower, amount, term, apy);
         borrowingMutex.lock(borrower, address(loanToken));

--- a/deploy/truefi2.ts
+++ b/deploy/truefi2.ts
@@ -119,7 +119,7 @@ deploy({}, (_, config) => {
     trueLender2.initialize(stkTruToken, poolFactory, oneInch, trueFiCreditOracle, AddressZero, borrowingMutex)
   })
   runIf(ftlAgency.isInitialized().not(), () => {
-    ftlAgency.initialize(stkTruToken, poolFactory, oneInch, trueFiCreditOracle, AddressZero, borrowingMutex)
+    ftlAgency.initialize(stkTruToken, poolFactory, oneInch, trueFiCreditOracle, AddressZero, borrowingMutex, loanFactory2)
   })
   runIf(loanFactory2.isInitialized().not(), () => {
     loanFactory2.initialize(poolFactory, trueLender2, ftlAgency, liquidator2, AddressZero, trueFiCreditOracle, borrowingMutex, AddressZero)

--- a/test/truefi2/FixedTermLoanAgency.test.ts
+++ b/test/truefi2/FixedTermLoanAgency.test.ts
@@ -28,7 +28,8 @@ import {
   TrueFiPool2,
   TrueFiPool2__factory,
   TrueRateAdjuster,
-  TimeAveragedBaseRateOracle, DebtToken__factory, LoanToken2__factory,
+  TimeAveragedBaseRateOracle,
+  LoanToken2__factory,
 } from 'contracts'
 
 import { BorrowingMutexJson, LoanToken2Json, Mock1InchV3Json } from 'build'

--- a/test/truefi2/FixedTermLoanAgency.test.ts
+++ b/test/truefi2/FixedTermLoanAgency.test.ts
@@ -322,7 +322,7 @@ describe('FixedTermLoanAgency', () => {
           counterfeitPool.address,
           AddressZero,
           borrower.address,
-          AddressZero,
+          ftlAgency.address,
           ftlAgency.address,
           owner.address,
           AddressZero,

--- a/test/truefi2/FixedTermLoanAgency.test.ts
+++ b/test/truefi2/FixedTermLoanAgency.test.ts
@@ -322,6 +322,7 @@ describe('FixedTermLoanAgency', () => {
           counterfeitPool.address,
           AddressZero,
           borrower.address,
+          AddressZero,
           ftlAgency.address,
           owner.address,
           AddressZero,

--- a/test/truefi2/FixedTermLoanAgency.test.ts
+++ b/test/truefi2/FixedTermLoanAgency.test.ts
@@ -323,7 +323,6 @@ describe('FixedTermLoanAgency', () => {
           AddressZero,
           borrower.address,
           ftlAgency.address,
-          ftlAgency.address,
           owner.address,
           AddressZero,
           100000,

--- a/test/truefi2/FixedTermLoanAgency.test.ts
+++ b/test/truefi2/FixedTermLoanAgency.test.ts
@@ -490,11 +490,11 @@ describe('FixedTermLoanAgency', () => {
 
     it('value stops increasing after term passes', async () => {
       await timeTravel(YEAR)
-      expect(await ftlAgency.value(pool1.address)).to.equal(201002)
-      expect(await ftlAgency.value(pool2.address)).to.equal(550000)
+      expect(await ftlAgency.value(pool1.address)).to.equal(208013)
+      expect(await ftlAgency.value(pool2.address)).to.equal(540000)
       await timeTravel(YEAR * 10)
-      expect(await ftlAgency.value(pool1.address)).to.equal(201002)
-      expect(await ftlAgency.value(pool2.address)).to.equal(550000)
+      expect(await ftlAgency.value(pool1.address)).to.equal(208013)
+      expect(await ftlAgency.value(pool2.address)).to.equal(540000)
     })
   })
 

--- a/test/truefi2/FixedTermLoanAgency.test.ts
+++ b/test/truefi2/FixedTermLoanAgency.test.ts
@@ -1,7 +1,6 @@
 import { expect, use } from 'chai'
 import {
   beforeEachWithFixture,
-  createLoan,
   DAY,
   parseEth,
   parseUSDC,
@@ -46,7 +45,6 @@ describe('FixedTermLoanAgency', () => {
   let borrower2: Wallet
 
   let loanFactory: LoanFactory2
-  let loan1: LoanToken2
   let pool1: TrueFiPool2
   let pool2: TrueFiPool2
   let feePool: TrueFiPool2
@@ -126,8 +124,6 @@ describe('FixedTermLoanAgency', () => {
     await token2.approve(pool2.address, parseEth(1e7))
     await pool1.join(parseEth(1e7))
     await pool2.join(parseEth(1e7))
-
-    loan1 = await createLoan(loanFactory, borrower, pool1, 100000, YEAR, 100)
 
     await creditOracle.setCreditUpdatePeriod(YEAR)
     await creditOracle.setScore(borrower.address, 255)

--- a/test/utils/setupTruefi2.ts
+++ b/test/utils/setupTruefi2.ts
@@ -89,7 +89,7 @@ export const setupTruefi2 = async (owner: Wallet, provider: MockProvider, custom
   await rater.initialize(tru.address, stkTru.address, arbitraryDistributor.address, loanFactory.address)
   await borrowingMutex.initialize()
   await lender.initialize(stkTru.address, poolFactory.address, customDeployed?.oneInch ? customDeployed.oneInch.address : AddressZero, creditOracle.address, rateAdjuster.address, borrowingMutex.address)
-  await ftlAgency.initialize(stkTru.address, poolFactory.address, customDeployed?.oneInch ? customDeployed.oneInch.address : AddressZero, creditOracle.address, rateAdjuster.address, borrowingMutex.address)
+  await ftlAgency.initialize(stkTru.address, poolFactory.address, customDeployed?.oneInch ? customDeployed.oneInch.address : AddressZero, creditOracle.address, rateAdjuster.address, borrowingMutex.address, loanFactory.address)
   await safu.initialize(loanFactory.address, liquidator.address, customDeployed?.oneInch ? customDeployed.oneInch.address : AddressZero)
   await poolFactory.initialize(implementationReference.address, lender.address, ftlAgency.address, safu.address)
   await rateAdjuster.initialize(poolFactory.address)


### PR DESCRIPTION
This PR is a WIP based on PR #958. It merges in the branch for PR #956 so that we can call LF2.createFTLALoanToken from FTLA.fund(). For this PR, please review only the code in FTLA.sol and FTLA.test.ts, compared against PR #958 as a base. Any review comments for LF2 belong in PR #956.

I'm about to drop offline soon for a flight, so someone else is welcome to take over this PR while I'm in the air. I believe the contracts code should be what we desire, but due to limited time and existing test failures (passed down from PR #958), I haven't been able to fix all the tests.