### PR TITLE
Remove debtToken lock on default

### DIFF
--- a/contracts/truefi2/TrueCreditAgency.sol
+++ b/contracts/truefi2/TrueCreditAgency.sol
@@ -471,9 +471,10 @@ contract TrueCreditAgency is UpgradeableClaimable, ITrueCreditAgency {
 
         loanFactory.createDebtToken(pool, borrower, principal.add(_interest));
 
-        borrowingMutex.unlock(borrower);
-        // TODO lock borrower to a new DebtToken. This placeholder currently locks borrower to an inaccessible locker address.
-        borrowingMutex.lock(borrower, address(1));
+        if (totalBorrowed(borrower) == 0) {
+            borrowingMutex.unlock(borrower);
+        }
+
         emit EnteredDefault(borrower, reason);
     }
 


### PR DESCRIPTION
I propose to not use mutexd for the defaulted loans for two reasons:
1. Mutex addition was intended to block borrowers from taking multiple loans. Using it as a post-default protection would be a side effect we didn't plan to do at first
2. It blocks us from doing multiple defaults 