### PR TITLE
Deploy another investor vault

### DIFF
--- a/deployments-mainnet.json
+++ b/deployments-mainnet.json
@@ -267,10 +267,6 @@
     "trueFiVault": {
       "txHash": "0xd3b0cf2ac7331e9fb5e5c4ade75ac7fad427502f5e4a6858adee960306340e11",
       "address": "0xfA15a30EDa728E3cDc628BA7c703039543C8e42f"
-    },
-    "trueFiVault_proxy": {
-      "txHash": "0xe96d57ed210658ad4b392e1b5546fcbcbfaaa9a04c956dafb38257592f05b0a8",
-      "address": "0x95BE1e23Db4Dc0A4b2Fa0AB3D0f3E22E66B57210"
     }
   }
 }

--- a/deployments-mainnet.json
+++ b/deployments-mainnet.json
@@ -267,10 +267,6 @@
     "trueFiVault": {
       "txHash": "0xd3b0cf2ac7331e9fb5e5c4ade75ac7fad427502f5e4a6858adee960306340e11",
       "address": "0xfA15a30EDa728E3cDc628BA7c703039543C8e42f"
-    },
-    "trueFiVault_proxy": {
-      "txHash": "0x0ee506d990d6dd15707e0257d4051388e5d6cb52ecebce3fec6bf3dd175c4610",
-      "address": "0x9BE7163Bb1842270f5dd20cB7F346702314E16Fd"
     }
   }
 }

--- a/deployments-mainnet.json
+++ b/deployments-mainnet.json
@@ -267,6 +267,10 @@
     "trueFiVault": {
       "txHash": "0xd3b0cf2ac7331e9fb5e5c4ade75ac7fad427502f5e4a6858adee960306340e11",
       "address": "0xfA15a30EDa728E3cDc628BA7c703039543C8e42f"
+    },
+    "trueFiVault_proxy": {
+      "txHash": "0xe96d57ed210658ad4b392e1b5546fcbcbfaaa9a04c956dafb38257592f05b0a8",
+      "address": "0x95BE1e23Db4Dc0A4b2Fa0AB3D0f3E22E66B57210"
     }
   }
 }


### PR DESCRIPTION
I'm reverting the proxy so that each new investor vault can reuse the same impl.

Submitting commits that introduce and revert the proxy address adds it to our PR history, in case our internal tracking tools corrupt or lose the address. But these aren't exactly publicly announced addresses, and our strategic round investors would prefer some discretion, so we probably don't want to keep these published on `origin/main`.