### PR TITLE
💔 Break up liquidation of legacy loans into separate functions

### DIFF
--- a/contracts/truefi2/Liquidator2.sol
+++ b/contracts/truefi2/Liquidator2.sol
@@ -5,6 +5,8 @@ import {UpgradeableClaimable} from "../common/UpgradeableClaimable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
+import {ILiquidator2} from "./interface/ILiquidator2.sol";
+import {ILoanToken2Deprecated} from "./deprecated/ILoanToken2Deprecated.sol";
 import {IPoolFactory} from "./interface/IPoolFactory.sol";
 import {ITrueFiPool2} from "./interface/ITrueFiPool2.sol";
 import {IStakingPool} from "../truefi/interface/IStakingPool.sol";
@@ -19,7 +21,7 @@ import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
  * @dev When a Loan becomes defaulted, Liquidator allows to
  * compensate pool participants, by transferring some of TRU to the pool
  */
-contract Liquidator2 is UpgradeableClaimable {
+contract Liquidator2 is ILiquidator2, UpgradeableClaimable {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
@@ -56,6 +58,8 @@ contract Liquidator2 is UpgradeableClaimable {
      * @param newShare New share set
      */
     event FetchMaxShareChanged(uint256 newShare);
+
+    event LegacyLiquidated(ILoanToken2Deprecated legacyLoan, uint256 defaultedValue, uint256 withdrawnTru);
 
     /**
      * @dev Emitted when debts are liquidated
@@ -137,12 +141,24 @@ contract Liquidator2 is UpgradeableClaimable {
         emit FetchMaxShareChanged(newShare);
     }
 
+    function legacyLiquidate(ILoanToken2Deprecated loan) external override {
+        require(msg.sender == SAFU, "Liquidator: Only SAFU contract can liquidate a loan");
+        require(loanFactory.isLegacyLoanToken(loan), "Liquidator: Unknown loan");
+        require(loan.status() == ILoanToken2Deprecated.Status.Defaulted, "Liquidator: Loan must be defaulted");
+        uint256 defaultedValue = loan.debt().sub(loan.repaid());
+        uint256 withdrawnTru = getLegacyAmountToWithdraw(defaultedValue, loan.pool().oracle());
+        stkTru.withdraw(withdrawnTru);
+        loan.liquidate();
+        tru.safeTransfer(SAFU, withdrawnTru);
+        emit LegacyLiquidated(loan, defaultedValue, withdrawnTru);
+    }
+
     /**
      * @dev Liquidates a defaulted Debt, withdraws a portion of tru from staking pool
      * then transfers tru to TrueFiPool as compensation
      * @param debts Debts to be liquidated
      */
-    function liquidate(IDebtToken[] calldata debts) external {
+    function liquidate(IDebtToken[] calldata debts) external override {
         require(msg.sender == SAFU, "Liquidator: Only SAFU contract can liquidate a debt");
         require(
             allDebtsHaveSameBorrower(debts),
@@ -166,6 +182,13 @@ contract Liquidator2 is UpgradeableClaimable {
         stkTru.withdraw(withdrawnTru);
         tru.safeTransfer(SAFU, withdrawnTru);
         emit Liquidated(debts, totalDefaultedValue, withdrawnTru);
+    }
+
+    function getLegacyAmountToWithdraw(uint256 deficit, ITrueFiPoolOracle oracle) internal view returns (uint256) {
+        uint256 stakingPoolSupply = stkTru.stakeSupply();
+        uint256 maxWithdrawValue = stakingPoolSupply.mul(fetchMaxShare).div(BASIS_RATIO);
+        uint256 deficitInTru = oracle.tokenToTru(deficit);
+        return maxWithdrawValue > deficitInTru ? deficitInTru : maxWithdrawValue;
     }
 
     /**

--- a/contracts/truefi2/LoanFactory2.sol
+++ b/contracts/truefi2/LoanFactory2.sol
@@ -6,6 +6,7 @@ import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 
 import {IFixedTermLoanAgency} from "./interface/IFixedTermLoanAgency.sol";
 import {Initializable} from "../common/Initializable.sol";
+import {ILoanToken2Deprecated} from "./deprecated/ILoanToken2Deprecated.sol";
 import {ILoanToken2} from "./interface/ILoanToken2.sol";
 import {IDebtToken} from "./interface/IDebtToken.sol";
 import {ILoanFactory2} from "./interface/ILoanFactory2.sol";
@@ -32,8 +33,8 @@ contract LoanFactory2 is ILoanFactory2, Initializable {
     // REMOVAL OR REORDER OF VARIABLES WILL RESULT
     // ========= IN STORAGE CORRUPTION ===========
 
-    // @dev Track Valid LoanTokens
-    mapping(ILoanToken2 => bool) public override isLoanToken;
+    // @dev Track legacy LoanTokens
+    mapping(ILoanToken2Deprecated => bool) public override isLegacyLoanToken;
 
     address private DEPRECATED__poolFactory;
     address private DEPRECATED__lender;
@@ -52,6 +53,8 @@ contract LoanFactory2 is ILoanFactory2, Initializable {
     mapping(IDebtToken => bool) public override isDebtToken;
 
     IFixedTermLoanAgency public ftlAgency;
+
+    mapping(ILoanToken2 => bool) public override isLoanToken;
 
     // ======= STORAGE DECLARATION END ============
 

--- a/contracts/truefi2/TrueFiPool2.sol
+++ b/contracts/truefi2/TrueFiPool2.sol
@@ -658,6 +658,16 @@ contract TrueFiPool2 is ITrueFiPool2, IPauseableContract, ERC20, UpgradeableClai
         debtToken.safeTransfer(msg.sender, balance);
     }
 
+    function reclaimLegacyDeficit(ILoanToken2Deprecated loan) external {
+        IDeficiencyToken dToken = safu.legacyDeficiencyToken(loan);
+        require(address(dToken) != address(0), "TrueFiPool2: No deficiency token found for debt");
+        uint256 deficit = dToken.balanceOf(address(this));
+        dToken.safeApprove(address(safu), deficit);
+        safu.legacyReclaim(loan, deficit);
+
+        emit DeficitReclaimed(IDebtToken(address(loan)), deficit);
+    }
+
     /**
      * @dev Function called when debt is repaid to SAFU, pool has a deficit value towards that debt
      */

--- a/contracts/truefi2/TrueFiPool2.sol
+++ b/contracts/truefi2/TrueFiPool2.sol
@@ -11,6 +11,7 @@ import {IFixedTermLoanAgency} from "./interface/IFixedTermLoanAgency.sol";
 import {ITrueStrategy} from "./interface/ITrueStrategy.sol";
 import {ITrueFiPool2, ITrueFiPoolOracle} from "./interface/ITrueFiPool2.sol";
 import {ITrueLender2} from "./interface/ITrueLender2.sol";
+import {ILoanToken2Deprecated} from "./deprecated/ILoanToken2Deprecated.sol";
 import {ILoanToken2} from "./interface/ILoanToken2.sol";
 import {IDebtToken} from "./interface/IDebtToken.sol";
 import {IPauseableContract} from "../common/interface/IPauseableContract.sol";
@@ -627,6 +628,14 @@ contract TrueFiPool2 is ITrueFiPool2, IPauseableContract, ERC20, UpgradeableClai
         }
 
         emit StrategySwitched(newStrategy);
+    }
+
+    /**
+     * @dev Function called by SAFU when liquidation happens. It will transfer all tokens of this loan the SAFU
+     */
+    function liquidateLegacyLoan(ILoanToken2Deprecated loan) external override {
+        require(msg.sender == address(safu), "TrueFiPool: Should be called by SAFU");
+        lender.transferAllLoanTokens(loan, address(safu));
     }
 
     /**

--- a/contracts/truefi2/interface/ILiquidator2.sol
+++ b/contracts/truefi2/interface/ILiquidator2.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.6.10;
 
+import {ILoanToken2Deprecated} from "../deprecated/ILoanToken2Deprecated.sol";
 import {IDebtToken} from "./IDebtToken.sol";
 
 interface ILiquidator2 {
+    function legacyLiquidate(ILoanToken2Deprecated loan) external;
+
     function liquidate(IDebtToken[] calldata debts) external;
 }

--- a/contracts/truefi2/interface/ILoanFactory2.sol
+++ b/contracts/truefi2/interface/ILoanFactory2.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.6.10;
 
+import {ILoanToken2Deprecated} from "../deprecated/ILoanToken2Deprecated.sol";
 import {ILoanToken2} from "./ILoanToken2.sol";
 import {IDebtToken} from "./IDebtToken.sol";
 import {ITrueFiPool2} from "./ITrueFiPool2.sol";
@@ -21,6 +22,8 @@ interface ILoanFactory2 {
     ) external returns (IDebtToken);
 
     function isCreatedByFactory(address) external view returns (bool);
+
+    function isLegacyLoanToken(ILoanToken2Deprecated) external view returns (bool);
 
     function isLoanToken(ILoanToken2) external view returns (bool);
 

--- a/contracts/truefi2/interface/ISAFU.sol
+++ b/contracts/truefi2/interface/ISAFU.sol
@@ -3,11 +3,16 @@ pragma solidity 0.6.10;
 
 import {IDeficiencyToken} from "./IDeficiencyToken.sol";
 import {IDebtToken} from "./IDebtToken.sol";
+import {ILoanToken2Deprecated} from "../deprecated/ILoanToken2Deprecated.sol";
 
 interface ISAFU {
     function poolDeficit(address pool) external view returns (uint256);
 
+    function legacyDeficiencyToken(ILoanToken2Deprecated loan) external view returns (IDeficiencyToken);
+
     function deficiencyToken(IDebtToken debt) external view returns (IDeficiencyToken);
+
+    function legacyReclaim(ILoanToken2Deprecated loan, uint256 amount) external;
 
     function reclaim(IDebtToken debt, uint256 amount) external;
 }

--- a/contracts/truefi2/interface/ITrueFiPool2.sol
+++ b/contracts/truefi2/interface/ITrueFiPool2.sol
@@ -4,6 +4,7 @@ pragma solidity 0.6.10;
 import {ERC20, IERC20} from "../../common/UpgradeableERC20.sol";
 import {ITrueLender2} from "../interface/ITrueLender2.sol";
 import {IFixedTermLoanAgency} from "../interface/IFixedTermLoanAgency.sol";
+import {ILoanToken2Deprecated} from "../deprecated/ILoanToken2Deprecated.sol";
 import {IDebtToken} from "../interface/IDebtToken.sol";
 import {ITrueFiPoolOracle} from "./ITrueFiPoolOracle.sol";
 import {I1Inch3} from "./I1Inch3.sol";
@@ -62,6 +63,8 @@ interface ITrueFiPool2 is IERC20 {
      * 2. Only lending pool should be allowed to call this
      */
     function repay(uint256 currencyAmount) external;
+
+    function liquidateLegacyLoan(ILoanToken2Deprecated loan) external;
 
     /**
      * @dev SAFU buys LoanTokens from the pool

--- a/contracts/truefi2/mocks/TestLoanFactory.sol
+++ b/contracts/truefi2/mocks/TestLoanFactory.sol
@@ -2,8 +2,35 @@
 pragma solidity 0.6.10;
 
 import "../LoanFactory2.sol";
+import {TestLegacyLoanToken2} from "./TestLegacyLoanToken2.sol";
 
 contract TestLoanFactory is LoanFactory2 {
+    event LegacyLoanCreated(TestLegacyLoanToken2 loan);
+
+    function createLegacyLoanToken(
+        ITrueFiPool2 _pool,
+        address _borrower,
+        uint256 _amount,
+        uint256 _term,
+        uint256 _apy
+    ) external {
+        TestLegacyLoanToken2 legacyLoan = new TestLegacyLoanToken2();
+        legacyLoan.initialize(
+            _pool,
+            borrowingMutex,
+            _borrower,
+            IFixedTermLoanAgency(msg.sender),
+            msg.sender,
+            liquidator,
+            address(0),
+            _amount,
+            _term,
+            _apy
+        );
+        isLegacyLoanToken[legacyLoan] = true;
+        emit LegacyLoanCreated(legacyLoan);
+    }
+
     function setIsLoanToken(address loanToken) external {
         isLoanToken[ILoanToken2(loanToken)] = true;
     }

--- a/test/truefi2/Liquidator2.test.ts
+++ b/test/truefi2/Liquidator2.test.ts
@@ -1,38 +1,41 @@
 import { expect, use } from 'chai'
 import {
   BorrowingMutex__factory,
-  Liquidator2,
-  LoanFactory2,
-  TestLegacyLoanToken2,
-  TestLegacyLoanToken2__factory,
-  MockTrueCurrency,
-  MockUsdc,
-  PoolFactory,
-  StkTruToken,
-  TrueFiPool2,
-  FixedTermLoanAgency,
-  TrueFiCreditOracle,
-  PoolFactory__factory,
+  CreditModel,
   DebtToken,
+  FixedTermLoanAgency,
+  Liquidator2,
+  MockTrueCurrency,
   MockTrueFiPoolOracle,
   MockTrueFiPoolOracle__factory,
+  MockUsdc,
+  PoolFactory,
+  PoolFactory__factory,
+  StkTruToken,
+  TestLegacyLoanToken2,
+  TestLegacyLoanToken2__factory,
+  TestLoanFactory,
+  TestLoanFactory__factory,
+  TestTrueLender,
+  TestTrueLender__factory,
+  TrueFiCreditOracle,
   TrueFiCreditOracle__factory,
-  CreditModel,
+  TrueFiPool2,
 } from 'contracts'
 
 import { solidity } from 'ethereum-waffle'
 import { BigNumberish, Wallet } from 'ethers'
 import { setupDeploy } from 'scripts/utils'
-import { DAY, extractLoanTokenAddress } from 'utils'
 import {
   beforeEachWithFixture,
-  createLoan,
+  createDebtToken as _createDebtToken,
+  DAY,
+  extractLegacyLoanToken,
   parseEth,
   parseTRU,
   parseUSDC,
   setupTruefi2,
   timeTravel as _timeTravel,
-  createDebtToken as _createDebtToken,
 } from 'utils'
 import { AddressZero } from '@ethersproject/constants'
 
@@ -46,8 +49,9 @@ describe('Liquidator2', () => {
   let assurance: Wallet
   let borrower: Wallet
 
+  let lender: TestTrueLender
   let liquidator: Liquidator2
-  let loanFactory: LoanFactory2
+  let loanFactory: TestLoanFactory
   let poolFactory: PoolFactory
   let usdc: MockUsdc
   let tusd: MockUsdc
@@ -68,20 +72,20 @@ describe('Liquidator2', () => {
   const YEAR = DAY * 365
   const defaultedLoanCloseTime = YEAR + 3 * DAY
 
-  const withdraw = async (loan: TestLegacyLoanToken2, wallet: Wallet, beneficiary = wallet.address) =>
-    loan.connect(wallet).withdraw(beneficiary)
-
   const createDebtToken = async (pool: TrueFiPool2, debt: BigNumberish) => {
     return _createDebtToken(loanFactory, owner, owner, pool, borrower, debt)
   }
 
   beforeEachWithFixture(async (_wallets, _provider) => {
     [owner, otherWallet, borrower, assurance] = _wallets
+    const deployContract = setupDeploy(owner)
     timeTravel = (time: number) => _timeTravel(_provider, time)
+
+    lender = await deployContract(TestTrueLender__factory)
+    loanFactory = await deployContract(TestLoanFactory__factory)
 
     ; ({
       liquidator,
-      loanFactory,
       poolFactory,
       feeToken: usdc,
       standardToken: tusd,
@@ -93,10 +97,15 @@ describe('Liquidator2', () => {
       creditOracle,
       standardTokenOracle: tusdOracle,
       creditModel,
-    } = await setupTruefi2(owner, _provider))
-    const legacyLoanTokenImpl = await new TestLegacyLoanToken2__factory(owner).deploy()
-    await loanFactory.setLoanTokenImplementation(legacyLoanTokenImpl.address)
-    loan = await createLoan(loanFactory, borrower, usdcPool, parseUSDC(1000), YEAR, 1000) as any
+    } = await setupTruefi2(owner, _provider, { lender, loanFactory }))
+
+    const tx = await loanFactory.createLegacyLoanToken(usdcPool.address, borrower.address, parseUSDC(1000), YEAR, 1000)
+    loan = await extractLegacyLoanToken(tx, owner)
+    await loan.setLender(lender.address)
+    await usdc.mint(lender.address, parseUSDC(1000))
+    await lender.fund(loan.address)
+    await loan.connect(borrower).withdraw(borrower.address)
+
     debtToken1 = await createDebtToken(usdcPool, parseUSDC(1100))
     debtToken2 = await createDebtToken(tusdPool, parseEth(1100))
 
@@ -256,9 +265,6 @@ describe('Liquidator2', () => {
     beforeEach(async () => {
       await usdcPool.connect(owner).join(parseUSDC(1e7))
       await tusdPool.connect(owner).join(parseEth(1e7))
-      const tx = ftlAgency.connect(borrower).borrow(usdcPool.address, parseUSDC(1000), YEAR, 1000)
-      loan = await extractLoanTokenAddress(tx, owner, loanFactory) as any
-      await withdraw(loan, borrower)
     })
 
     describe('reverts if', () => {
@@ -266,40 +272,24 @@ describe('Liquidator2', () => {
         await timeTravel(defaultedLoanCloseTime)
         await loan.enterDefault()
 
-        await expect(liquidator.connect(assurance).liquidate([loan.address]))
+        await expect(liquidator.connect(assurance).legacyLiquidate(loan.address))
           .to.not.be.reverted
 
-        await expect(liquidator.connect(otherWallet).liquidate([loan.address]))
-          .to.be.revertedWith('Liquidator: Only SAFU contract can liquidate a debt')
-      })
-
-      it('debts are not of a single borrower', async () => {
-        await creditOracle.setScore(owner.address, 255)
-        await creditOracle.setMaxBorrowerLimit(owner.address, parseEth(100_000_000))
-        await ftlAgency.allowBorrower(owner.address)
-        const tx = ftlAgency.borrow(usdcPool.address, parseUSDC(1000), YEAR, 1000)
-        const loan2 = await extractLoanTokenAddress(tx, owner, loanFactory)
-
-        await withdraw(loan2 as any, owner)
-
-        await timeTravel(defaultedLoanCloseTime)
-        await loan.enterDefault()
-        await loan2.enterDefault()
-        await expect(liquidator.connect(assurance).liquidate([loan.address, loan2.address]))
-          .to.be.revertedWith('Liquidator: Debts liquidated in a single transaction, have to have the same borrower')
+        await expect(liquidator.connect(otherWallet).legacyLiquidate(loan.address))
+          .to.be.revertedWith('Liquidator: Only SAFU contract can liquidate a loan')
       })
 
       it('loan is not defaulted', async () => {
-        await expect(liquidator.connect(assurance).liquidate([loan.address]))
-          .to.be.revertedWith('Liquidator: Debt must be defaulted')
+        await expect(liquidator.connect(assurance).legacyLiquidate(loan.address))
+          .to.be.revertedWith('Liquidator: Loan must be defaulted')
 
         await timeTravel(defaultedLoanCloseTime)
         await loan.enterDefault()
-        await expect(liquidator.connect(assurance).liquidate([loan.address]))
+        await expect(liquidator.connect(assurance).legacyLiquidate(loan.address))
           .not.to.be.reverted
       })
 
-      it('debts are not created via factory', async () => {
+      it('loan was not created by factory', async () => {
         const deployContract = setupDeploy(owner)
         const borrowingMutex = await deployContract(BorrowingMutex__factory)
         await borrowingMutex.initialize()
@@ -313,23 +303,9 @@ describe('Liquidator2', () => {
         await borrowingMutex.lock(borrower.address, await fakeLoan.address)
         await timeTravel(defaultedLoanCloseTime)
         await fakeLoan.enterDefault()
-        await loan.enterDefault()
 
-        await expect(liquidator.connect(assurance).liquidate([loan.address, fakeLoan.address]))
-          .to.be.revertedWith('Liquidator: Unknown debt')
-      })
-
-      it('all pools have to be supported', async () => {
-        await poolFactory.unsupportPool(usdcPool.address)
-        await expect(liquidator.connect(assurance).liquidate([debtToken1.address, debtToken2.address]))
-          .to.be.revertedWith('Liquidator: Pool not supported for default protection')
-      })
-
-      it('attempting to default the same debt twice', async () => {
-        await timeTravel(defaultedLoanCloseTime)
-        await loan.enterDefault()
-        await expect(liquidator.connect(assurance).liquidate([loan.address, loan.address]))
-          .to.be.revertedWith('Liquidator: Debt must be defaulted')
+        await expect(liquidator.connect(assurance).legacyLiquidate(fakeLoan.address))
+          .to.be.revertedWith('Liquidator: Unknown loan')
       })
     })
 
@@ -340,35 +316,35 @@ describe('Liquidator2', () => {
       })
 
       it('changes status', async () => {
-        await liquidator.connect(assurance).liquidate([loan.address])
+        await liquidator.connect(assurance).legacyLiquidate(loan.address)
         expect(await loan.status()).to.equal(LoanTokenStatus.Liquidated)
       })
 
       it('emits event', async () => {
         await stkTru.stake(parseTRU(1e3))
-        await expect(liquidator.connect(assurance).liquidate([loan.address]))
-          .to.emit(liquidator, 'Liquidated')
-          .withArgs([loan.address], parseEth(1100), parseTRU(100))
+        await expect(liquidator.connect(assurance).legacyLiquidate(loan.address))
+          .to.emit(liquidator, 'LegacyLiquidated')
+          .withArgs(loan.address, parseUSDC(1100), parseTRU(100))
       })
 
       describe('transfers correct amount of tru to assurance contract', () => {
         describe('whole debt has defaulted', () => {
           it('0 tru in staking pool balance', async () => {
-            await liquidator.connect(assurance).liquidate([loan.address])
+            await liquidator.connect(assurance).legacyLiquidate(loan.address)
             expect(await tru.balanceOf(assurance.address)).to.equal(parseTRU(0))
           })
 
           it('returns max fetch share to assurance', async () => {
             await stkTru.stake(parseTRU(1e3))
 
-            await liquidator.connect(assurance).liquidate([loan.address])
+            await liquidator.connect(assurance).legacyLiquidate(loan.address)
             expect(await tru.balanceOf(assurance.address)).to.equal(parseTRU(1e2))
           })
 
           it('returns total defaulted value', async () => {
             await stkTru.stake(parseTRU(1e7))
 
-            await liquidator.connect(assurance).liquidate([loan.address])
+            await liquidator.connect(assurance).legacyLiquidate(loan.address)
             expect(await tru.balanceOf(assurance.address)).to.equal(parseTRU(4400))
           })
         })
@@ -379,21 +355,21 @@ describe('Liquidator2', () => {
           })
 
           it('0 tru in staking pool balance', async () => {
-            await liquidator.connect(assurance).liquidate([loan.address])
+            await liquidator.connect(assurance).legacyLiquidate(loan.address)
             expect(await tru.balanceOf(assurance.address)).to.equal(parseTRU(0))
           })
 
           it('returns max fetch share to assurance', async () => {
             await stkTru.stake(parseTRU(1e3))
 
-            await liquidator.connect(assurance).liquidate([loan.address])
+            await liquidator.connect(assurance).legacyLiquidate(loan.address)
             expect(await tru.balanceOf(assurance.address)).to.equal(parseTRU(100))
           })
 
           it('returns defaulted value', async () => {
             await stkTru.stake(parseTRU(1e7))
 
-            await liquidator.connect(assurance).liquidate([loan.address])
+            await liquidator.connect(assurance).legacyLiquidate(loan.address)
             expect(await tru.balanceOf(assurance.address)).to.equal(parseTRU(22e2))
           })
         })
@@ -401,25 +377,25 @@ describe('Liquidator2', () => {
         describe('half of debt has defaulted and half redeemed', () => {
           beforeEach(async () => {
             await usdc.mint(loan.address, parseUSDC(550))
-            await ftlAgency.reclaim(loan.address, '0x')
+            await lender.reclaim(loan.address, '0x')
           })
 
           it('0 tru in staking pool balance', async () => {
-            await liquidator.connect(assurance).liquidate([loan.address])
+            await liquidator.connect(assurance).legacyLiquidate(loan.address)
             expect(await tru.balanceOf(assurance.address)).to.equal(parseTRU(0))
           })
 
           it('returns max fetch share to assurance', async () => {
             await stkTru.stake(parseTRU(1e3))
 
-            await liquidator.connect(assurance).liquidate([loan.address])
+            await liquidator.connect(assurance).legacyLiquidate(loan.address)
             expect(await tru.balanceOf(assurance.address)).to.equal(parseTRU(100))
           })
 
           it('returns defaulted value', async () => {
             await stkTru.stake(parseTRU(1e7))
 
-            await liquidator.connect(assurance).liquidate([loan.address])
+            await liquidator.connect(assurance).legacyLiquidate(loan.address)
             expect(await tru.balanceOf(assurance.address)).to.equal(parseTRU(22e2))
           })
         })
@@ -435,6 +411,25 @@ describe('Liquidator2', () => {
         await liquidator.connect(assurance).liquidate([debtToken1.address, debtToken2.address])
         expect(await debtToken1.status()).to.equal(LoanTokenStatus.Liquidated)
         expect(await debtToken2.status()).to.equal(LoanTokenStatus.Liquidated)
+      })
+
+      describe('reverts if', () => {
+        it('debts are not of a single borrower', async () => {
+          const otherDebtToken = await _createDebtToken(loanFactory, owner, owner, usdcPool, owner, 100)
+          await expect(liquidator.connect(assurance).liquidate([debtToken1.address, otherDebtToken.address]))
+            .to.be.revertedWith('Liquidator: Debts liquidated in a single transaction, have to have the same borrower')
+        })
+
+        it('attempting to default the same debt twice', async () => {
+          await expect(liquidator.connect(assurance).liquidate([debtToken1.address, debtToken1.address]))
+            .to.be.revertedWith('Liquidator: Debt must be defaulted')
+        })
+      })
+
+      it('all pools have to be supported', async () => {
+        await poolFactory.unsupportPool(usdcPool.address)
+        await expect(liquidator.connect(assurance).liquidate([debtToken1.address, debtToken2.address]))
+          .to.be.revertedWith('Liquidator: Pool not supported for default protection')
       })
 
       describe('transfers correct amount of tru to assurance contract', () => {

--- a/test/utils/extractLoanTokenAddress.ts
+++ b/test/utils/extractLoanTokenAddress.ts
@@ -3,7 +3,13 @@ import {
   DebtToken__factory,
   LoanFactory2,
   LoanToken2__factory,
+  TestLegacyLoanToken2__factory,
 } from 'contracts'
+
+export async function extractLegacyLoanToken (tx: ContractTransaction, owner: Signer) {
+  const receipt = await tx.wait()
+  return TestLegacyLoanToken2__factory.connect(receipt.events[0].args[0], owner)
+}
 
 export async function extractLoanTokenAddress (pendingTx: Promise<ContractTransaction>, owner: Signer, loanFactory: LoanFactory2) {
   const tx = await pendingTx

--- a/test/utils/setupTruefi2.ts
+++ b/test/utils/setupTruefi2.ts
@@ -10,6 +10,7 @@ import {
   LinearTrueDistributor__factory,
   Liquidator2__factory,
   LoanToken2__factory,
+  LoanFactory2,
   LoanFactory2__factory,
   MockTrueCurrency__factory,
   MockTrueFiPoolOracle__factory,
@@ -18,6 +19,7 @@ import {
   Safu__factory,
   StkTruToken__factory,
   TestFixedTermLoanAgency,
+  TestLoanFactory,
   TestTrueLender,
   TimeAveragedBaseRateOracle,
   TimeAveragedBaseRateOracle__factory,
@@ -53,7 +55,7 @@ export const setupTruefi2 = async (owner: Wallet, provider: MockProvider, custom
 
   // ====== DEPLOY ======
   const liquidator = await deployContract(Liquidator2__factory)
-  const loanFactory = await deployContract(LoanFactory2__factory)
+  const loanFactory: LoanFactory2 & TestLoanFactory = customDeployed?.loanFactory ? customDeployed.loanFactory : await deployContract(LoanFactory2__factory)
   const rater: TrueRatingAgencyV2 & TestTrueRatingAgencyV2 = customDeployed?.rater ? customDeployed.rater : await deployContract(TrueRatingAgencyV2__factory)
   const lender: TrueLender2 & TestTrueLender = customDeployed?.lender ? customDeployed.lender : await deployContract(TrueLender2__factory)
   const ftlAgency: FixedTermLoanAgency & TestFixedTermLoanAgency = customDeployed?.ftlAgency ? customDeployed.ftlAgency : await deployContract(FixedTermLoanAgency__factory)


### PR DESCRIPTION
Unit tests for this PR are in the following PRs, which I've broken into pieces for ease of review.
- #1054
  - #1049
  - #1055 
  - #1056

#1054 introduces a new Solidity mock `TestLoanFactory.createLegacyLoanToken()` and a test util `extractLegacyLoanToken()`. That PR relies on changes in this PR to compile, so it must be merged to this branch, not directly to [main](https://github.com/trusttoken/smart-contracts/tree/main).

#1049, #1055, and #1056 all use `TLF.createLegacyLoanToken()` + `extractLegacyLoanToken()` to migrate liquidation unit tests over to legacy loans. For that reason, they're all based on #1054. Once these unit testing PRs are all merged to [main](https://github.com/trusttoken/smart-contracts/tree/main), it should be possible to reopen #1031 (high priority task!) without breaking all these unit tests.

---

I recommend reviewing + merging #1048 and #1054 first.

**_If a requested change can be done in a follow-up PR, please leave a review comment and/or file a task, but don't block merging of these two PRs._**

If you're concerned about the lack of unit tests for new/legacy Solidity code introduced in this PR, you can confirm that testing will eventually get done in PRs #1049, #1055, and #1056. The new/legacy Solidity code should be diffed against [v4.0](https://github.com/trusttoken/smart-contracts/tree/v4.0), which is our most recent release before CreditModel work.

There's no merging order preference between #1049, #1055, and #1056.