### PR TITLE
📖 [Certik] DTF-03 | Logic of Redemption

### DIFF
--- a/contracts/truefi2/DebtToken.sol
+++ b/contracts/truefi2/DebtToken.sol
@@ -61,7 +61,7 @@ contract DebtToken is IDebtToken, ERC20 {
         require(_amount <= _balance(), "DebtToken: Insufficient repaid amount");
 
         uint256 amountToReturn = _amount;
-        if (_amount == totalSupply() && repaid() > debt) {
+        if (_amount == totalSupply()) {
             amountToReturn = _balance();
         }
         redeemed = redeemed.add(amountToReturn);


### PR DESCRIPTION
IMO CertiK's point here is valid and we can indeed prove that `repaid() >= debt`:

Having 
- `_amount <= balance()` (second require),
- `repaid() = _balance() + redeemed` (repaid() definition),
- `redeemed = debt - totalSupply()`, this holds before all debt tokens are burnt (burning all left tokens can result in redeeming more than debt left)

and assuming that `_amount == totalSupply()` (first part of if condition), after some simplification steps we get `repaid() >= debt`. 

For `repaid() == debt`, the equality `_amount == balance()` holds which altogether renders `repaid > debt` redundant.