### PR TITLE
💧 Pay liquidity farming rewards in stkTRU

### DIFF
--- a/contracts/truefi2/TrueMultiFarm.sol
+++ b/contracts/truefi2/TrueMultiFarm.sol
@@ -8,6 +8,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import {UpgradeableClaimable} from "../common/UpgradeableClaimable.sol";
 import {ITrueDistributor} from "../truefi/interface/ITrueDistributor.sol";
 import {ITrueMultiFarm} from "./interface/ITrueMultiFarm.sol";
+import {IStkTruToken} from "../governance/interface/IStkTruToken.sol";
 
 /**
  * @title TrueMultiFarm
@@ -58,6 +59,8 @@ contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
     Stakes public shares;
     // Total rewards per farm
     Rewards public farmRewards;
+
+    IStkTruToken public stkTru;
 
     // ======= STORAGE DECLARATION END ============
 
@@ -111,11 +114,13 @@ contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
      * The distributor contract calculates how much TRU rewards this contract
      * gets, and stores TRU for distribution.
      * @param _trueDistributor Distributor contract
+     * @param _stkTru Staked TrueFi token
      */
-    function initialize(ITrueDistributor _trueDistributor) public initializer {
+    function initialize(ITrueDistributor _trueDistributor, IStkTruToken _stkTru) public initializer {
         UpgradeableClaimable.initialize(msg.sender);
         trueDistributor = _trueDistributor;
         rewardToken = _trueDistributor.trustToken();
+        stkTru = _stkTru;
         require(trueDistributor.farm() == address(this), "TrueMultiFarm: Distributor farm is not set");
     }
 

--- a/contracts/truefi2/TrueMultiFarm.sol
+++ b/contracts/truefi2/TrueMultiFarm.sol
@@ -92,7 +92,7 @@ contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
     }
 
     /**
-     * @dev Is there any reward allocatiion for given token
+     * @dev Is there any reward allocation for given token
      */
     modifier hasShares(IERC20 token) {
         require(shares.staked[address(token)] > 0, "TrueMultiFarm: This token has no shares");

--- a/contracts/truefi2/TrueMultiFarm.sol
+++ b/contracts/truefi2/TrueMultiFarm.sol
@@ -50,7 +50,7 @@ contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
     // REMOVAL OR REORDER OF VARIABLES WILL RESULT
     // ========= IN STORAGE CORRUPTION ===========
 
-    IERC20 public rewardToken;
+    IERC20 public tru;
     ITrueDistributor public override trueDistributor;
 
     mapping(IERC20 => Stakes) public stakes;
@@ -120,7 +120,7 @@ contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
     function initialize(ITrueDistributor _trueDistributor, IStkTruToken _stkTru) public initializer {
         UpgradeableClaimable.initialize(msg.sender);
         trueDistributor = _trueDistributor;
-        rewardToken = _trueDistributor.trustToken();
+        tru = _trueDistributor.trustToken();
         stkTru = _stkTru;
         require(trueDistributor.farm() == address(this), "TrueMultiFarm: Distributor farm is not set");
     }
@@ -238,7 +238,7 @@ contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
         stakerRewards[token].claimableReward[msg.sender] = 0;
         farmRewards.claimableReward[address(token)] = farmRewards.claimableReward[address(token)].sub(rewardToClaim);
 
-        rewardToken.safeApprove(address(stkTru), rewardToClaim);
+        tru.safeApprove(address(stkTru), rewardToClaim);
         stkTru.stake(rewardToClaim);
         stkTru.safeTransfer(msg.sender, rewardToClaim);
         emit Claim(token, msg.sender, rewardToClaim);
@@ -276,9 +276,7 @@ contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
         uint256 pending = trueDistributor.farm() == address(this) ? trueDistributor.nextDistribution() : 0;
 
         // calculate new total rewards ever received by farm
-        uint256 newTotalRewards = rewardToken.balanceOf(address(this)).add(pending).add(farmRewards.totalClaimedRewards).mul(
-            PRECISION
-        );
+        uint256 newTotalRewards = tru.balanceOf(address(this)).add(pending).add(farmRewards.totalClaimedRewards).mul(PRECISION);
         // calculate new rewards that were received since previous distribution
         uint256 totalBlockReward = newTotalRewards.sub(farmRewards.totalRewards);
 
@@ -315,7 +313,7 @@ contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
      */
     function _updateCumulativeRewardPerShare() internal {
         // calculate new total rewards ever received by farm
-        uint256 newTotalRewards = rewardToken.balanceOf(address(this)).add(farmRewards.totalClaimedRewards).mul(PRECISION);
+        uint256 newTotalRewards = tru.balanceOf(address(this)).add(farmRewards.totalClaimedRewards).mul(PRECISION);
         // calculate new rewards that were received since previous distribution
         uint256 rewardSinceLastUpdate = newTotalRewards.sub(farmRewards.totalRewards);
         // update info about total farm rewards

--- a/contracts/truefi2/TrueMultiFarm.sol
+++ b/contracts/truefi2/TrueMultiFarm.sol
@@ -22,6 +22,7 @@ import {IStkTruToken} from "../governance/interface/IStkTruToken.sol";
 contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
+    using SafeERC20 for IStkTruToken;
     uint256 private constant PRECISION = 1e30;
 
     struct Stakes {
@@ -237,7 +238,9 @@ contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
         stakerRewards[token].claimableReward[msg.sender] = 0;
         farmRewards.claimableReward[address(token)] = farmRewards.claimableReward[address(token)].sub(rewardToClaim);
 
-        rewardToken.safeTransfer(msg.sender, rewardToClaim);
+        rewardToken.safeApprove(address(stkTru), rewardToClaim);
+        stkTru.stake(rewardToClaim);
+        stkTru.safeTransfer(msg.sender, rewardToClaim);
         emit Claim(token, msg.sender, rewardToClaim);
     }
 

--- a/contracts/truefi2/TrueMultiFarm.sol
+++ b/contracts/truefi2/TrueMultiFarm.sol
@@ -240,7 +240,7 @@ contract TrueMultiFarm is ITrueMultiFarm, UpgradeableClaimable {
 
         tru.safeApprove(address(stkTru), rewardToClaim);
         stkTru.stake(rewardToClaim);
-        stkTru.safeTransfer(msg.sender, rewardToClaim);
+        stkTru.safeTransfer(msg.sender, stkTru.balanceOf(address(this)));
         emit Claim(token, msg.sender, rewardToClaim);
     }
 

--- a/deploy/farms.ts
+++ b/deploy/farms.ts
@@ -10,6 +10,7 @@ import {
   TrueFiPool,
   TrueMultiFarm,
   TruSushiswapRewarder,
+  StkTruToken,
 } from '../build/artifacts'
 import {
   TRU, TRU_DECIMALS, SUSHI_MASTER_CHEF, SUSHI_REWARD_MULTIPLIER
@@ -32,7 +33,8 @@ deploy({}, (deployer, config) => {
   const trustToken = isMainnet
     ? TRU
     : contract(TestTrustToken)
-  let trueFiPool = proxy(contract(TrueFiPool), () => {})
+  let stkTruToken = proxy(contract(StkTruToken), () => { })
+  let trueFiPool = proxy(contract(TrueFiPool), () => { })
 
   // New contract impls
   const trueFiPool_LinearTrueDistributor_impl = contract('trueFiPool_LinearTrueDistributor', LinearTrueDistributor)
@@ -42,11 +44,11 @@ deploy({}, (deployer, config) => {
   const truSushiswapRewarder_impl = contract(TruSushiswapRewarder)
 
   // New contract proxies
-  const trueFiPool_LinearTrueDistributor = proxy(trueFiPool_LinearTrueDistributor_impl, () => {})
-  const trueFiPool_TrueFarm = proxy(trueFiPool_TrueFarm_impl, () => {})
-  const trueMultiFarm_LinearTrueDistributor = proxy(trueMultiFarm_LinearTrueDistributor_impl, () => {})
-  const trueMultiFarm = proxy(trueMultiFarm_impl, () => {})
-  const truSushiswapRewarder = proxy(truSushiswapRewarder_impl, () => {})
+  const trueFiPool_LinearTrueDistributor = proxy(trueFiPool_LinearTrueDistributor_impl, () => { })
+  const trueFiPool_TrueFarm = proxy(trueFiPool_TrueFarm_impl, () => { })
+  const trueMultiFarm_LinearTrueDistributor = proxy(trueMultiFarm_LinearTrueDistributor_impl, () => { })
+  const trueMultiFarm = proxy(trueMultiFarm_impl, () => { })
+  const truSushiswapRewarder = proxy(truSushiswapRewarder_impl, () => { })
 
   // New bare contracts
   const sushiTimelock = contract(SushiTimelock, [TIMELOCK_ADMIN, TIMELOCK_DELAY])
@@ -68,7 +70,7 @@ deploy({}, (deployer, config) => {
     trueMultiFarm_LinearTrueDistributor.setFarm(trueMultiFarm)
   })
   runIf(trueMultiFarm.isInitialized().not(), () => {
-    trueMultiFarm.initialize(trueMultiFarm_LinearTrueDistributor)
+    trueMultiFarm.initialize(trueMultiFarm_LinearTrueDistributor, stkTruToken)
   })
   runIf(truSushiswapRewarder.isInitialized().not(), () => {
     truSushiswapRewarder.initialize(SUSHI_REWARD_MULTIPLIER, trustToken, SUSHI_MASTER_CHEF)

--- a/test/truefi2/TrueMultiFarm.test.ts
+++ b/test/truefi2/TrueMultiFarm.test.ts
@@ -154,14 +154,14 @@ describe('TrueMultiFarm', () => {
         await farm.connect(staker1).stake(firstToken.address, parseEth(1000), txArgs)
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('yields rewards per staked tokens (using exit)', async () => {
         await farm.connect(staker1).stake(firstToken.address, parseEth(1000), txArgs)
         await timeTravel(provider, DAY)
         await farm.connect(staker1).exit([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('estimate rewards correctly', async () => {
@@ -173,7 +173,7 @@ describe('TrueMultiFarm', () => {
         await farm.connect(staker1).unstake(firstToken.address, 100, txArgs)
         expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), parseTRU(200), 1000))
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(200), 1000))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(200), 1000))
       })
 
       it('rewards when stake increases', async () => {
@@ -183,7 +183,7 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(200)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(200)))
       })
 
       it('sending stake tokens to TrueMultiFarm does not affect calculations', async () => {
@@ -192,7 +192,7 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('staking claims pending rewards', async () => {
@@ -200,7 +200,7 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
         await farm.connect(staker1).stake(firstToken.address, parseEth(500), txArgs)
 
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('claiming sets claimable to 0', async () => {
@@ -230,7 +230,7 @@ describe('TrueMultiFarm', () => {
         await distributor.distribute(txArgs)
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(200)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(200)))
       })
 
       it('owner withdrawing distributes funds', async () => {
@@ -240,7 +240,7 @@ describe('TrueMultiFarm', () => {
         await distributor.connect(owner).empty(txArgs)
         expect(expectScaledCloseTo((await tru.balanceOf(farm.address)), parseTRU(100)))
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
         expect(expectCloseTo((await tru.balanceOf(farm.address)), parseTRU(0), 2e6))
       })
 
@@ -251,7 +251,7 @@ describe('TrueMultiFarm', () => {
         await distributor.connect(owner).setFarm(farm2.address, txArgs)
         expect(expectScaledCloseTo((await tru.balanceOf(farm.address)), parseTRU(100)))
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
         expect(expectCloseTo((await tru.balanceOf(farm.address)), parseTRU(0), 2e6))
       })
 
@@ -259,7 +259,7 @@ describe('TrueMultiFarm', () => {
         await farm.connect(staker1).stake(firstToken.address, parseEth(500), txArgs)
         await timeTravel(provider, DAY * REWARD_DAYS)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), amount))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), amount))
         await timeTravel(provider, DAY)
         await farm.connect(staker1).unstake(firstToken.address, parseEth(500), txArgs)
       })
@@ -282,9 +282,9 @@ describe('TrueMultiFarm', () => {
         await farm.connect(staker1).claim([firstToken.address], txArgs)
         await farm.connect(staker2).claim([firstToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)),
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)),
           dailyReward.mul(days).mul(4).div(5)))
-        expect(expectScaledCloseTo((await tru.balanceOf(staker2.address)),
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker2.address)),
           dailyReward.mul(days).mul(1).div(5)))
       })
 
@@ -297,9 +297,9 @@ describe('TrueMultiFarm', () => {
         await farm.connect(staker1).claim([firstToken.address], txArgs)
         await farm.connect(staker2).claim([firstToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)),
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)),
           totalReward.mul(days).mul(4).div(5)))
-        expect(expectScaledCloseTo((await tru.balanceOf(staker2.address)),
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker2.address)),
           totalReward.mul(days).mul(1).div(5)))
       })
 
@@ -316,8 +316,8 @@ describe('TrueMultiFarm', () => {
         const staker2Reward = dailyReward.mul(days).mul(1).div(5).add(
           dailyReward.mul(days).mul(1).div(2))
 
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), staker1Reward))
-        expect(expectScaledCloseTo((await tru.balanceOf(staker2.address)), staker2Reward))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), staker1Reward))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker2.address)), staker2Reward))
       })
     })
   })
@@ -399,7 +399,7 @@ describe('TrueMultiFarm', () => {
 
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('yields rewards per staked tokens (using single claims)', async () => {
@@ -408,10 +408,10 @@ describe('TrueMultiFarm', () => {
 
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(25)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(25)))
 
         await farm.connect(staker1).claim([secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('yields rewards per staked tokens (using exit)', async () => {
@@ -420,9 +420,9 @@ describe('TrueMultiFarm', () => {
 
         await timeTravel(provider, DAY)
         await farm.connect(staker1).exit([secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(75)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(75)))
         await farm.connect(staker1).exit([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('estimate rewards correctly', async () => {
@@ -443,7 +443,7 @@ describe('TrueMultiFarm', () => {
         expect(expectScaledCloseTo((await farm.claimable(secondToken.address, staker1.address)), parseTRU(150), 1000))
 
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(200), 1000))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(200), 1000))
       })
 
       it('rewards when stake increases', async () => {
@@ -457,7 +457,7 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(200)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(200)))
       })
 
       it('sending stake tokens to TrueMultiFarm does not affect calculations', async () => {
@@ -466,7 +466,7 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([secondToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(75)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(75)))
       })
 
       it('staking claims pending rewards', async () => {
@@ -475,10 +475,10 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
 
         await farm.connect(staker1).stake(firstToken.address, parseEth(500), txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(25)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(25)))
 
         await farm.connect(staker1).stake(secondToken.address, parseEth(500), txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('claiming sets claimable to 0', async () => {
@@ -512,7 +512,7 @@ describe('TrueMultiFarm', () => {
         await distributor.distribute(txArgs)
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(200)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(200)))
       })
 
       it('owner withdrawing distributes funds', async () => {
@@ -525,7 +525,7 @@ describe('TrueMultiFarm', () => {
         expect(expectScaledCloseTo((await tru.balanceOf(farm.address)), parseTRU(100)))
 
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
         expect(expectCloseTo((await tru.balanceOf(farm.address)), parseTRU(0), 2e6))
 
         await timeTravel(provider, DAY)
@@ -542,7 +542,7 @@ describe('TrueMultiFarm', () => {
         await distributor.connect(owner).setFarm(farm2.address, txArgs)
         expect(expectScaledCloseTo((await tru.balanceOf(farm.address)), parseTRU(100)))
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), parseTRU(100)))
         expect(expectCloseTo((await tru.balanceOf(farm.address)), parseTRU(0), 2e6))
 
         await timeTravel(provider, DAY)
@@ -554,7 +554,7 @@ describe('TrueMultiFarm', () => {
         await farm.connect(staker1).stake(firstToken.address, parseEth(500), txArgs)
         await timeTravel(provider, DAY * REWARD_DAYS)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), amount.div(4)))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), amount.div(4)))
         await timeTravel(provider, DAY)
         await farm.connect(staker1).unstake(firstToken.address, parseEth(500), txArgs)
       })
@@ -580,17 +580,17 @@ describe('TrueMultiFarm', () => {
         await farm.connect(staker2).claim([firstToken.address], txArgs)
 
         // 1st token has 1/4 of shares
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)),
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)),
           dailyReward.mul(days).mul(4).div(5).div(4)))
-        expect(expectScaledCloseTo((await tru.balanceOf(staker2.address)),
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker2.address)),
           dailyReward.mul(days).mul(1).div(5).div(4)))
 
         await farm.connect(staker1).claim([secondToken.address], txArgs)
         await farm.connect(staker2).claim([secondToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)),
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)),
           dailyReward.mul(days).mul(4).div(5)))
-        expect(expectScaledCloseTo((await tru.balanceOf(staker2.address)),
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker2.address)),
           dailyReward.mul(days).mul(1).div(5)))
       })
 
@@ -603,9 +603,9 @@ describe('TrueMultiFarm', () => {
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
         await farm.connect(staker2).claim([firstToken.address, secondToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)),
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)),
           totalReward.mul(days).mul(4).div(5)))
-        expect(expectScaledCloseTo((await tru.balanceOf(staker2.address)),
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker2.address)),
           totalReward.mul(days).mul(1).div(5)))
       })
 
@@ -623,8 +623,8 @@ describe('TrueMultiFarm', () => {
         const staker2Reward = dailyReward.mul(days).mul(1).div(5).add(
           dailyReward.mul(days).mul(1).div(2))
 
-        expect(expectScaledCloseTo((await tru.balanceOf(staker1.address)), staker1Reward))
-        expect(expectScaledCloseTo((await tru.balanceOf(staker2.address)), staker2Reward))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), staker1Reward))
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker2.address)), staker2Reward))
       })
     })
 

--- a/test/truefi2/TrueMultiFarm.test.ts
+++ b/test/truefi2/TrueMultiFarm.test.ts
@@ -1,6 +1,6 @@
 import { expect, use } from 'chai'
 import { MaxUint256 } from '@ethersproject/constants'
-import { Wallet, BigNumber, BigNumberish } from 'ethers'
+import { Wallet, BigNumber } from 'ethers'
 import { MockProvider, solidity } from 'ethereum-waffle'
 
 import {
@@ -42,8 +42,6 @@ describe('TrueMultiFarm', () => {
   const DURATION = REWARD_DAYS * DAY
   const amount = BigNumber.from(1e11) // 1000 TRU = 100/day
   const txArgs = { gasLimit: 6_000_000 }
-
-  const fromTru = (amount: BigNumberish) => BigNumber.from(amount).mul(BigNumber.from(1e8))
 
   const totalStaked = async (token = firstToken) => {
     return farm.stakes(token.address)
@@ -148,26 +146,26 @@ describe('TrueMultiFarm', () => {
         await farm.connect(staker1).stake(firstToken.address, parseEth(1000), txArgs)
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('yields rewards per staked tokens (using exit)', async () => {
         await farm.connect(staker1).stake(firstToken.address, parseEth(1000), txArgs)
         await timeTravel(provider, DAY)
         await farm.connect(staker1).exit([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('estimate rewards correctly', async () => {
         await farm.connect(staker1).stake(firstToken.address, parseEth(1000), txArgs)
         await timeTravel(provider, DAY)
-        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), fromTru(100), 1000))
+        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), parseTRU(100), 1000))
         await timeTravel(provider, DAY)
-        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), fromTru(200), 1000))
+        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), parseTRU(200), 1000))
         await farm.connect(staker1).unstake(firstToken.address, 100, txArgs)
-        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), fromTru(200), 1000))
+        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), parseTRU(200), 1000))
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(200), 1000))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(200), 1000))
       })
 
       it('rewards when stake increases', async () => {
@@ -177,7 +175,7 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(200)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(200)))
       })
 
       it('sending stake tokens to TrueMultiFarm does not affect calculations', async () => {
@@ -186,7 +184,7 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('staking claims pending rewards', async () => {
@@ -194,7 +192,7 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
         await farm.connect(staker1).stake(firstToken.address, parseEth(500), txArgs)
 
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('claiming sets claimable to 0', async () => {
@@ -224,29 +222,29 @@ describe('TrueMultiFarm', () => {
         await distributor.distribute(txArgs)
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(200)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(200)))
       })
 
       it('owner withdrawing distributes funds', async () => {
         await farm.connect(staker1).stake(firstToken.address, parseEth(500), txArgs)
-        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), fromTru(0), 2e6))
+        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(0), 2e6))
         await timeTravel(provider, DAY)
         await distributor.connect(owner).empty(txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(farm.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(100)))
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
-        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), fromTru(0), 2e6))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(0), 2e6))
       })
 
       it('changing farm distributes funds', async () => {
         await farm.connect(staker1).stake(firstToken.address, parseEth(500), txArgs)
-        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), fromTru(0), 2e6))
+        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(0), 2e6))
         await timeTravel(provider, DAY)
         await distributor.connect(owner).setFarm(farm2.address, txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(farm.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(100)))
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
-        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), fromTru(0), 2e6))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(0), 2e6))
       })
 
       it('can withdraw liquidity after all TRU is distributed', async () => {
@@ -263,7 +261,7 @@ describe('TrueMultiFarm', () => {
       const dailyReward = amount.div(REWARD_DAYS)
 
       beforeEach(async () => {
-      // staker1 with 4/5 of stake
+        // staker1 with 4/5 of stake
         await farm.connect(staker1).stake(firstToken.address, parseEth(400), txArgs)
         // staker 2 has 1/5 of stake
         await farm.connect(staker2).stake(firstToken.address, parseEth(100), txArgs)
@@ -284,7 +282,7 @@ describe('TrueMultiFarm', () => {
 
       it('if additional funds are transferred to farm, they are also distributed accordingly to shares', async () => {
         const days = 1
-        const additionalReward = fromTru(100)
+        const additionalReward = parseTRU(100)
         const totalReward = dailyReward.add(additionalReward)
         await timeTravel(provider, DAY * days)
         trustToken.mint(farm.address, additionalReward, txArgs)
@@ -393,7 +391,7 @@ describe('TrueMultiFarm', () => {
 
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('yields rewards per staked tokens (using single claims)', async () => {
@@ -402,10 +400,10 @@ describe('TrueMultiFarm', () => {
 
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(25)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(25)))
 
         await farm.connect(staker1).claim([secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('yields rewards per staked tokens (using exit)', async () => {
@@ -414,9 +412,9 @@ describe('TrueMultiFarm', () => {
 
         await timeTravel(provider, DAY)
         await farm.connect(staker1).exit([secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(75)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(75)))
         await farm.connect(staker1).exit([firstToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('estimate rewards correctly', async () => {
@@ -424,20 +422,20 @@ describe('TrueMultiFarm', () => {
         await farm.connect(staker1).stake(secondToken.address, parseEth(1000), txArgs)
 
         await timeTravel(provider, DAY)
-        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), fromTru(25), 1000))
-        expect(expectScaledCloseTo((await farm.claimable(secondToken.address, staker1.address)), fromTru(75), 1000))
+        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), parseTRU(25), 1000))
+        expect(expectScaledCloseTo((await farm.claimable(secondToken.address, staker1.address)), parseTRU(75), 1000))
 
         await timeTravel(provider, DAY)
-        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), fromTru(50), 1000))
-        expect(expectScaledCloseTo((await farm.claimable(secondToken.address, staker1.address)), fromTru(150), 1000))
+        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), parseTRU(50), 1000))
+        expect(expectScaledCloseTo((await farm.claimable(secondToken.address, staker1.address)), parseTRU(150), 1000))
 
         await farm.connect(staker1).unstake(firstToken.address, 100, txArgs)
 
-        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), fromTru(50), 1000))
-        expect(expectScaledCloseTo((await farm.claimable(secondToken.address, staker1.address)), fromTru(150), 1000))
+        expect(expectScaledCloseTo((await farm.claimable(firstToken.address, staker1.address)), parseTRU(50), 1000))
+        expect(expectScaledCloseTo((await farm.claimable(secondToken.address, staker1.address)), parseTRU(150), 1000))
 
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(200), 1000))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(200), 1000))
       })
 
       it('rewards when stake increases', async () => {
@@ -451,7 +449,7 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(200)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(200)))
       })
 
       it('sending stake tokens to TrueMultiFarm does not affect calculations', async () => {
@@ -460,7 +458,7 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([secondToken.address], txArgs)
 
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(75)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(75)))
       })
 
       it('staking claims pending rewards', async () => {
@@ -469,10 +467,10 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
 
         await farm.connect(staker1).stake(firstToken.address, parseEth(500), txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(25)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(25)))
 
         await farm.connect(staker1).stake(secondToken.address, parseEth(500), txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
       })
 
       it('claiming sets claimable to 0', async () => {
@@ -506,21 +504,21 @@ describe('TrueMultiFarm', () => {
         await distributor.distribute(txArgs)
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(200)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(200)))
       })
 
       it('owner withdrawing distributes funds', async () => {
         await farm.connect(staker1).stake(firstToken.address, parseEth(500), txArgs)
         await farm.connect(staker1).stake(secondToken.address, parseEth(500), txArgs)
-        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), fromTru(0), 2e6))
+        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(0), 2e6))
 
         await timeTravel(provider, DAY)
         await distributor.connect(owner).empty(txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(farm.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(100)))
 
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
-        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), fromTru(0), 2e6))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(0), 2e6))
 
         await timeTravel(provider, DAY)
         expect(await farm.claimable(firstToken.address, staker1.address)).to.equal(0)
@@ -530,14 +528,14 @@ describe('TrueMultiFarm', () => {
       it('changing farm distributes funds', async () => {
         await farm.connect(staker1).stake(firstToken.address, parseEth(500), txArgs)
         await farm.connect(staker1).stake(secondToken.address, parseEth(500), txArgs)
-        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), fromTru(0), 2e6))
+        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(0), 2e6))
 
         await timeTravel(provider, DAY)
         await distributor.connect(owner).setFarm(farm2.address, txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(farm.address)), fromTru(100)))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(100)))
         await farm.connect(staker1).claim([firstToken.address, secondToken.address], txArgs)
-        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), fromTru(100)))
-        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), fromTru(0), 2e6))
+        expect(expectScaledCloseTo((await trustToken.balanceOf(staker1.address)), parseTRU(100)))
+        expect(expectCloseTo((await trustToken.balanceOf(farm.address)), parseTRU(0), 2e6))
 
         await timeTravel(provider, DAY)
         expect(await farm.claimable(firstToken.address, staker1.address)).to.equal(0)
@@ -590,7 +588,7 @@ describe('TrueMultiFarm', () => {
 
       it('if additional funds are transferred to farm, they are also distributed accordingly to shares', async () => {
         const days = 1
-        const additionalReward = fromTru(100)
+        const additionalReward = parseTRU(100)
         const totalReward = dailyReward.add(additionalReward)
         await timeTravel(provider, DAY * days)
         trustToken.mint(farm.address, additionalReward, txArgs)
@@ -640,34 +638,34 @@ describe('TrueMultiFarm', () => {
 
       it('shares change is handled properly', async () => {
         await timeTravel(provider, DAY)
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(25))
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(75))
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(25))
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(75))
 
         await farm.setShares([firstToken.address, secondToken.address], [2, 2], txArgs)
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(25))
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(75))
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(25))
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(75))
 
         await timeTravel(provider, DAY)
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(75))
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(125))
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(75))
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(125))
       })
 
       it('claiming works when shares are changing', async () => {
         await timeTravel(provider, DAY)
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(25))
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(75))
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(25))
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(75))
 
         await farm.connect(staker1).claim([secondToken.address])
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(25))
-        expectCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(0), parseTRU(0.02).toNumber())
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(25))
+        expectCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(0), parseTRU(0.02).toNumber())
 
         await farm.setShares([firstToken.address, secondToken.address], [2, 2], txArgs)
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(25))
-        expectCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(0), parseTRU(0.02).toNumber())
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(25))
+        expectCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(0), parseTRU(0.02).toNumber())
 
         await timeTravel(provider, DAY)
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(75))
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(50))
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(75))
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(50))
       })
 
       it('calculates rewards correctly after new farm was added', async () => {
@@ -679,14 +677,14 @@ describe('TrueMultiFarm', () => {
         await farm.setShares([thirdToken.address], [6], txArgs)
         await farm.connect(staker1).stake(thirdToken.address, parseEth(500), txArgs)
 
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(25))
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(75))
-        expectCloseTo(await farm.claimable(thirdToken.address, staker1.address), fromTru(0), parseTRU(0.02).toNumber())
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(25))
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(75))
+        expectCloseTo(await farm.claimable(thirdToken.address, staker1.address), parseTRU(0), parseTRU(0.02).toNumber())
 
         await timeTravel(provider, DAY)
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(35))
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(105))
-        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), fromTru(60))
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(35))
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(105))
+        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), parseTRU(60))
       })
 
       it('works for complex cases', async () => {
@@ -698,41 +696,41 @@ describe('TrueMultiFarm', () => {
         await farm.setShares([thirdToken.address], [6], txArgs)
         await farm.connect(staker1).stake(thirdToken.address, parseEth(500), txArgs)
 
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(25))
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(75))
-        expectCloseTo(await farm.claimable(thirdToken.address, staker1.address), fromTru(0), parseTRU(0.02).toNumber())
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(25))
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(75))
+        expectCloseTo(await farm.claimable(thirdToken.address, staker1.address), parseTRU(0), parseTRU(0.02).toNumber())
 
         await timeTravel(provider, DAY)
         await farm.connect(staker1).claim([secondToken.address])
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(35))
-        expectCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(0), parseTRU(0.02).toNumber())
-        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), fromTru(60))
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(35))
+        expectCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(0), parseTRU(0.02).toNumber())
+        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), parseTRU(60))
 
         await farm.connect(staker1).unstake(firstToken.address, parseEth(500))
         await timeTravel(provider, DAY)
-        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(35))
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(30))
-        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), fromTru(120))
+        expectScaledCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(35))
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(30))
+        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), parseTRU(120))
 
         await farm.connect(staker1).claim([firstToken.address, secondToken.address])
-        expectCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(0), parseTRU(0.02).toNumber())
-        expectCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(0), parseTRU(0.02).toNumber())
-        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), fromTru(120))
+        expectCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(0), parseTRU(0.02).toNumber())
+        expectCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(0), parseTRU(0.02).toNumber())
+        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), parseTRU(120))
 
         await farm.connect(staker2).stake(secondToken.address, parseEth(1000))
         await timeTravel(provider, DAY)
-        expectCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(0), parseTRU(0.02).toNumber())
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(10))
-        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), fromTru(180))
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker2.address), fromTru(20))
+        expectCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(0), parseTRU(0.02).toNumber())
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(10))
+        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), parseTRU(180))
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker2.address), parseTRU(20))
 
         await farm.setShares([firstToken.address, secondToken.address, thirdToken.address], [0, 3, 1], txArgs)
 
         await timeTravel(provider, DAY)
-        expectCloseTo(await farm.claimable(firstToken.address, staker1.address), fromTru(0), parseTRU(0.02).toNumber())
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), fromTru(35))
-        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), fromTru(205))
-        expectScaledCloseTo(await farm.claimable(secondToken.address, staker2.address), fromTru(70))
+        expectCloseTo(await farm.claimable(firstToken.address, staker1.address), parseTRU(0), parseTRU(0.02).toNumber())
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker1.address), parseTRU(35))
+        expectScaledCloseTo(await farm.claimable(thirdToken.address, staker1.address), parseTRU(205))
+        expectScaledCloseTo(await farm.claimable(secondToken.address, staker2.address), parseTRU(70))
       })
     })
   })

--- a/test/truefi2/TrueMultiFarm.test.ts
+++ b/test/truefi2/TrueMultiFarm.test.ts
@@ -263,6 +263,19 @@ describe('TrueMultiFarm', () => {
         await timeTravel(provider, DAY)
         await farm.connect(staker1).unstake(firstToken.address, parseEth(500), txArgs)
       })
+
+      it('scales withdrawn stkTru after slash', async () => {
+        await tru.mint(owner.address, parseTRU(1000))
+        await tru.approve(stkTru.address, parseTRU(1000))
+        await stkTru.stake(parseTRU(1000))
+        await stkTru.setLiquidator(owner.address)
+        await stkTru.withdraw(parseTRU(100))
+
+        await farm.connect(staker1).stake(firstToken.address, parseEth(500), txArgs)
+        await timeTravel(provider, DAY * REWARD_DAYS)
+        await farm.connect(staker1).claim([firstToken.address], txArgs)
+        expect(expectScaledCloseTo((await stkTru.balanceOf(staker1.address)), amount.mul(10).div(9)))
+      })
     })
 
     describe('with two stakers', function () {


### PR DESCRIPTION
This unfortunately increases `claim` cost from `141401` to `340174`.