### PR TITLE
🔁 Optimise LOCA.borrow() by not iterating through all of the pools when not necessary

### DIFF
--- a/test/truefi2/StakingVault.test.ts
+++ b/test/truefi2/StakingVault.test.ts
@@ -162,7 +162,8 @@ describe('StakingVault', () => {
         await poolToken.approve(pool.address, parseEth(1e7))
         await pool.join(parseEth(1e7))
         await creditAgency.allowBorrower(borrower.address, true)
-        const borrowLimit = await creditAgency.borrowLimit(pool.address, borrower.address)
+        const totalBorrowed = await creditAgency.totalBorrowed(borrower.address)
+        const borrowLimit = await creditAgency.borrowLimit(pool.address, borrower.address, totalBorrowed)
         await creditAgency.connect(borrower).borrow(pool.address, borrowLimit.sub(parseEth(5)))
       })
 

--- a/test/truefi2/lines-of-credit/LineOfCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/LineOfCreditAgency.test.ts
@@ -400,6 +400,7 @@ describe('LineOfCreditAgency', () => {
     it('borrow limit is 0 if credit limit is below the borrowed amount', async () => {
       await creditOracle.setMaxBorrowerLimit(borrower.address, parseEth(100))
       await creditAgency.connect(borrower).borrow(usdcPool.address, parseUSDC(80))
+      totalBorrowed = await creditAgency.totalBorrowed(borrower.address)
       expect(await creditAgency.borrowLimit(usdcPool.address, borrower.address, totalBorrowed)).to.be.gt(0)
       await creditOracle.setMaxBorrowerLimit(borrower.address, parseEth(95))
       expect(await creditAgency.borrowLimit(usdcPool.address, borrower.address, totalBorrowed)).to.equal(0)


### PR DESCRIPTION
This PR addresses high gas consumption in LOCA.borrow(), specifically in the check below:

https://github.com/trusttoken/smart-contracts/blob/c326802799bf5e58473162ff17c451ce5439068f/contracts/truefi2/LineOfCreditAgency.sol#L390-L392

I profiled 3 different solutions, which may reduce gas usage:
1. Using isAnythingBorrowed(borrower => bool) mapping (requires updates of storage in borrow() and repay())
2. Checking borrowingMutex.isUnlocked(borrower) (change of the logic: now we lock borrower if they are unlocked, instead of if they don't have any debt)
3. Calling totalBorrowed() only once and storing the result in a local variable (there is an indirect totalBorrowed() call inside borrowLimit(), requires change of borrowLimit() function signature)

I implemented option 3 because it turned out to be the cheapest one (being only 1000 gas cheaper than option 2). Option 1 is much more expensive.