### PR TITLE
🧰 Fix skipped integration tests

### DIFF
--- a/test/integration/TrueFiPool2.test.ts
+++ b/test/integration/TrueFiPool2.test.ts
@@ -11,6 +11,7 @@ import {
 import { AddressZero } from '@ethersproject/constants'
 import { expect, use } from 'chai'
 import { solidity } from 'ethereum-waffle'
+import { parseEth } from 'utils'
 
 use(solidity)
 
@@ -19,11 +20,15 @@ describe('TrueFiPool2', () => {
   const TFUSDT_ADDRESS = '0x6002b1dcb26e7b1aa797a17551c6f487923299d7'
   const TFUSDT_STRATEGY_ADDRESS = '0x8D162Caa649e981E2a0b0ba5908A77f2536B11A8'
   const TRU_HOLDER = '0x23696914ca9737466d8553a2d619948f548ee424'
+  const ETH_HOLDER = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
   const OWNER = '0x52bc44d5378309EE2abF1539BF71dE1b7d7bE3b5'
   const PROXY_OWNER = '0x16cea306506c387713c70b9c1205fd5ac997e78e'
-  const provider = forkChain([OWNER, PROXY_OWNER, TRU_HOLDER])
+  const CONFIG_GNOSIS_SAFE = '0xf0aE09d3ABdF3641e2eB4cD45cf56873296a02CB'
+  const provider = forkChain([OWNER, PROXY_OWNER, CONFIG_GNOSIS_SAFE, TRU_HOLDER, ETH_HOLDER])
   const owner = provider.getSigner(OWNER)
   const powner = provider.getSigner(PROXY_OWNER)
+  const configGnosis = provider.getSigner(CONFIG_GNOSIS_SAFE)
+  const holder = provider.getSigner(ETH_HOLDER)
   const deployContract = setupDeploy(owner)
 
   let implementationReference: ImplementationReference
@@ -39,14 +44,15 @@ describe('TrueFiPool2', () => {
     await poolFactory.createPool(usdc.address)
   })
 
-  it('[skip ci] tether flush', async () => {
+  it('tether flush', async () => {
     const usdtPool = TrueFiPool2__factory.connect(TFUSDT_ADDRESS, powner)
     const proxy = OwnedProxyWithReference__factory.connect(TFUSDT_ADDRESS, powner)
     const strategyProxy = OwnedUpgradeabilityProxy__factory.connect(TFUSDT_STRATEGY_ADDRESS, powner)
     await proxy.changeImplementationReference(implementationReference.address)
     const newStrategy = await deployContract(CurveYearnStrategy__factory)
     await strategyProxy.upgradeTo(newStrategy.address)
+    await holder.sendTransaction({ value: parseEth(100), to: CONFIG_GNOSIS_SAFE })
 
-    await expect(usdtPool.flush(10000000)).not.to.be.reverted
+    await expect(usdtPool.connect(configGnosis).flush(10000000)).not.to.be.reverted
   })
 })

--- a/test/integration/poolExchanges.test.ts
+++ b/test/integration/poolExchanges.test.ts
@@ -6,7 +6,7 @@ import { solidity } from 'ethereum-waffle'
 use(solidity)
 
 describe('Pool Curve integration', () => {
-  it('[skip ci] deposit TUSD to Curve', async () => {
+  it('deposit TUSD to Curve', async () => {
     const pool = await upgradeSuite(TrueFiPool__factory, '0xa1e72267084192Db7387c8CC1328fadE470e4149', [])
     const tusdBalance = await pool.currencyBalance()
     await expect(pool.flush(tusdBalance)).to.be.not.reverted


### PR DESCRIPTION
This should (hopefully) fix 'tether flush' integration test. I unskipped it as well as one other test. These are still prone to get timedout though.