### PR TITLE
🕰️ Fix randomly failing TABRO/TATPO tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "eslint-plugin-no-only-tests": "^2.6.0",
     "ethereum-mars": "^0.1.7",
     "ethers": "5.0.18",
-    "ganache-time-traveler": "^1.0.14",
     "hardhat": "^2.2.0",
     "hardhat-typechain": "^0.3.5",
     "openzeppelin-solidity": "^2.4.0",

--- a/test/truefi2/lines-of-credit/TimeAveragedBaseRateOracle.test.ts
+++ b/test/truefi2/lines-of-credit/TimeAveragedBaseRateOracle.test.ts
@@ -1,6 +1,6 @@
 import { expect, use } from 'chai'
 import { solidity, deployMockContract, MockContract, MockProvider } from 'ethereum-waffle'
-import { Wallet } from 'ethers'
+import { BigNumber, Wallet } from 'ethers'
 import { setupDeploy } from 'scripts/utils'
 import { DAY, timeTravel, timeTravelTo, updateRateOracle } from 'utils'
 import { beforeEachWithFixture } from 'utils/beforeEachWithFixture'
@@ -129,7 +129,7 @@ describe('TimeAveragedBaseRateOracle', () => {
       expect(runningTotals[1]).to.eq(8640000)
       await updateBufferRightAfterCooldown(timeBaseRateOracle)
       ;[runningTotals] = await timeBaseRateOracle.getTotalsBuffer()
-      expect(runningTotals[1]).to.eq(77760000)
+      expect(runningTotals[1]).to.be.closeTo(BigNumber.from(77760000), 200)
     })
   })
 

--- a/test/truefi2/lines-of-credit/TimeAveragedTruPriceOracle.test.ts
+++ b/test/truefi2/lines-of-credit/TimeAveragedTruPriceOracle.test.ts
@@ -101,7 +101,7 @@ describe('TimeAveragedTruPriceOracle', () => {
       expect(runningTotals[1]).to.eq(8640000)
       await updateBufferRightAfterCooldown(timeBaseRateOracle)
       ;[runningTotals] = await timeBaseRateOracle.getTotalsBuffer()
-      expect(runningTotals[1]).to.eq(77760000)
+      expect(runningTotals[1]).to.be.closeTo(BigNumber.from(77760000), 200)
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5787,11 +5787,6 @@ ganache-core@^2.13.0, ganache-core@^2.13.2:
     ethereumjs-wallet "0.6.5"
     web3 "1.2.11"
 
-ganache-time-traveler@^1.0.14:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/ganache-time-traveler/-/ganache-time-traveler-1.0.15.tgz#07c575abeb1e110903b76a2181e18598066617e9"
-  integrity sha512-3yoSbvvqSRA13w/SrNGy5tniwdwuRSAMrltGaOZAoqjnhpWkbVlGOVkdiEA/69dN4ZTArwJr1lWpiPzwqTWNCA==
-
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"


### PR DESCRIPTION
These tests failed about 6 times since the merge of TABRO. The problem is that they test calculations on timestamps and sometimes an extra second slips in causing a fail. I suspect it to be a ganache issue, but I'm not sure.

Since they are in 'truefi2' test folder they are required to pass, and we don't want to get blocked on CI for another 20 or so minutes because of some randomness.

Also I stumbled upon this one import "ganache-time-traveler", I don't think it is being used so I removed it.