### PR TITLE
🔏 Simplify + reorder BorrowingMutex functions

### DIFF
--- a/contracts/truefi2/BorrowingMutex.sol
+++ b/contracts/truefi2/BorrowingMutex.sol
@@ -25,7 +25,7 @@ contract BorrowingMutex is IBorrowingMutex, UpgradeableClaimable {
 
     event BorrowerLocked(address borrower, address locker);
 
-    event BorrowerUnlocked(address borrower, address locker);
+    event BorrowerUnlocked(address borrower);
 
     event BorrowerBanned(address borrower);
 
@@ -48,21 +48,20 @@ contract BorrowingMutex is IBorrowingMutex, UpgradeableClaimable {
         emit LockerAllowed(_locker, isAllowed);
     }
 
-    function ban(address borrower) external override onlyLocker(borrower) {
-        locker[borrower] = BANNED;
-        emit BorrowerBanned(borrower);
-    }
-
-    function lock(address borrower, address _locker) external override onlyAllowedToLock {
+    function lock(address borrower) external override onlyAllowedToLock {
         require(isUnlocked(borrower), "BorrowingMutex: Borrower is already locked");
-        locker[borrower] = _locker;
-        emit BorrowerLocked(borrower, _locker);
+        locker[borrower] = msg.sender;
+        emit BorrowerLocked(borrower, msg.sender);
     }
 
     function unlock(address borrower) external override onlyLocker(borrower) {
-        address _locker = locker[borrower];
         locker[borrower] = UNLOCKED;
-        emit BorrowerUnlocked(borrower, _locker);
+        emit BorrowerUnlocked(borrower);
+    }
+
+    function ban(address borrower) external override onlyLocker(borrower) {
+        locker[borrower] = BANNED;
+        emit BorrowerBanned(borrower);
     }
 
     function isUnlocked(address borrower) public override view returns (bool) {

--- a/contracts/truefi2/FixedTermLoanAgency.sol
+++ b/contracts/truefi2/FixedTermLoanAgency.sol
@@ -357,7 +357,7 @@ contract FixedTermLoanAgency is IFixedTermLoanAgency, UpgradeableClaimable {
 
         IFixedTermLoan loanToken = loanFactory.createLoanToken(pool, borrower, amount, term, apy);
         borrowerLoans[borrower].push(loanToken);
-        borrowingMutex.lock(borrower, address(this));
+        borrowingMutex.lock(borrower);
         poolLoans[pool].push(loanToken);
         pool.borrow(amount);
         pool.token().safeTransfer(borrower, amount);

--- a/contracts/truefi2/LineOfCreditAgency.sol
+++ b/contracts/truefi2/LineOfCreditAgency.sol
@@ -393,7 +393,7 @@ contract LineOfCreditAgency is UpgradeableClaimable, ILineOfCreditAgency {
             "LineOfCreditAgency: Borrow amount cannot exceed borrow limit"
         );
         if (_totalBorrowed == 0) {
-            borrowingMutex.lock(msg.sender, address(this));
+            borrowingMutex.lock(msg.sender);
         }
         require(
             borrowingMutex.locker(msg.sender) == address(this),

--- a/contracts/truefi2/interface/IBorrowingMutex.sol
+++ b/contracts/truefi2/interface/IBorrowingMutex.sol
@@ -2,15 +2,15 @@
 pragma solidity 0.6.10;
 
 interface IBorrowingMutex {
-    function ban(address borrower) external;
-
-    function lock(address borrower, address _locker) external;
+    function lock(address borrower) external;
 
     function unlock(address borrower) external;
 
-    function isUnlocked(address borrower) external view returns (bool);
+    function ban(address borrower) external;
 
     function locker(address borrower) external view returns (address);
+
+    function isUnlocked(address borrower) external view returns (bool);
 
     function isBanned(address borrower) external view returns (bool);
 }

--- a/contracts/truefi2/mocks/MockBorrowingMutex.sol
+++ b/contracts/truefi2/mocks/MockBorrowingMutex.sol
@@ -12,16 +12,16 @@ contract MockBorrowingMutex is IBorrowingMutex, UpgradeableClaimable {
         UpgradeableClaimable.initialize(msg.sender);
     }
 
-    function ban(address borrower) external override {
-        locker[borrower] = address(1);
-    }
-
-    function lock(address borrower, address _locker) external override {
-        locker[borrower] = _locker;
+    function lock(address borrower) external override {
+        locker[borrower] = msg.sender;
     }
 
     function unlock(address borrower) external override {
         locker[borrower] = address(0);
+    }
+
+    function ban(address borrower) external override {
+        locker[borrower] = address(1);
     }
 
     function isUnlocked(address borrower) public override view returns (bool) {

--- a/test/truefi2/BorrowingMutex.test.ts
+++ b/test/truefi2/BorrowingMutex.test.ts
@@ -58,7 +58,7 @@ describe('BorrowingMutex', () => {
     })
 
     it('fails if banner is not the locker', async () => {
-      await mutex.connect(locker).lock(borrower.address, locker.address)
+      await mutex.connect(locker).lock(borrower.address)
 
       await expect(mutex.connect(owner).ban(borrower.address))
         .to.be.revertedWith('BorrowingMutex: Only locker is allowed')
@@ -67,7 +67,7 @@ describe('BorrowingMutex', () => {
     it('changes locker', async () => {
       expect(await mutex.isUnlocked(borrower.address)).to.be.true
       expect(await mutex.isBanned(borrower.address)).to.be.false
-      await mutex.connect(locker).lock(borrower.address, locker.address)
+      await mutex.connect(locker).lock(borrower.address)
       await mutex.connect(locker).ban(borrower.address)
       expect(await mutex.locker(borrower.address)).to.eq(AddressOne)
       expect(await mutex.isUnlocked(borrower.address)).to.be.false
@@ -75,7 +75,7 @@ describe('BorrowingMutex', () => {
     })
 
     it('emits event', async () => {
-      await mutex.connect(locker).lock(borrower.address, locker.address)
+      await mutex.connect(locker).lock(borrower.address)
       await expect(mutex.connect(locker).ban(borrower.address))
         .to.emit(mutex, 'BorrowerBanned')
         .withArgs(borrower.address)
@@ -84,33 +84,33 @@ describe('BorrowingMutex', () => {
 
   describe('lock', () => {
     it('sender not in isAllowedToLock', async () => {
-      await expect(mutex.connect(owner).lock(borrower.address, owner.address))
+      await expect(mutex.connect(owner).lock(borrower.address))
         .to.be.revertedWith('BorrowingMutex: Sender is not allowed to lock borrowers')
 
-      await expect(mutex.connect(locker).lock(borrower.address, owner.address))
+      await expect(mutex.connect(locker).lock(borrower.address))
         .not.to.be.reverted
     })
 
     it('cannot lock already locked borrower', async () => {
       await mutex.allowLocker(owner.address, true)
-      await mutex.connect(locker).lock(borrower.address, owner.address)
+      await mutex.connect(locker).lock(borrower.address)
 
-      await expect(mutex.connect(owner).lock(borrower.address, owner.address))
+      await expect(mutex.connect(owner).lock(borrower.address))
         .to.be.revertedWith('BorrowingMutex: Borrower is already locked')
 
-      await expect(mutex.connect(locker).lock(borrower.address, owner.address))
+      await expect(mutex.connect(locker).lock(borrower.address))
         .to.be.revertedWith('BorrowingMutex: Borrower is already locked')
     })
 
     it('changes locker', async () => {
       expect(await mutex.isUnlocked(borrower.address)).to.be.true
-      await mutex.connect(locker).lock(borrower.address, owner.address)
+      await mutex.connect(locker).lock(borrower.address)
       expect(await mutex.locker(borrower.address)).to.eq(owner.address)
       expect(await mutex.isUnlocked(borrower.address)).to.be.false
     })
 
     it('emits event', async () => {
-      await expect(mutex.connect(locker).lock(borrower.address, owner.address))
+      await expect(mutex.connect(locker).lock(borrower.address))
         .to.emit(mutex, 'BorrowerLocked')
         .withArgs(borrower.address, owner.address)
     })
@@ -118,7 +118,7 @@ describe('BorrowingMutex', () => {
 
   describe('unlock', () => {
     beforeEach(async () => {
-      await mutex.connect(locker).lock(borrower.address, owner.address)
+      await mutex.connect(locker).lock(borrower.address)
     })
 
     it('reverts if other caller tries to unlock', async () => {

--- a/test/truefi2/FixedTermLoan.test.ts
+++ b/test/truefi2/FixedTermLoan.test.ts
@@ -96,7 +96,7 @@ describe('FixedTermLoan', () => {
     )
     const { blockNumber } = await tx.wait()
     creationTimestamp = (await provider.getBlock(blockNumber)).timestamp
-    await borrowingMutex.lock(borrower.address, loanToken.address)
+    await borrowingMutex.lock(borrower.address)
 
     await loanFactory.setIsLoanToken(loanToken.address)
     await token.transfer(borrower.address, parseEth(1000))

--- a/test/truefi2/FixedTermLoanAgency.test.ts
+++ b/test/truefi2/FixedTermLoanAgency.test.ts
@@ -428,7 +428,7 @@ describe('FixedTermLoanAgency', () => {
 
       it('taking new loans is locked by mutex', async () => {
         await borrowingMutex.allowLocker(owner.address, true)
-        await borrowingMutex.lock(borrower.address, owner.address)
+        await borrowingMutex.lock(borrower.address)
         await expect(borrow(borrower, pool1, 100000, YEAR))
           .to.be.revertedWith('FixedTermLoanAgency: There is an ongoing loan or credit line')
       })

--- a/test/truefi2/Liquidator2.test.ts
+++ b/test/truefi2/Liquidator2.test.ts
@@ -339,7 +339,7 @@ describe('Liquidator2', () => {
         await fakeLoan.initialize(usdcPool.address, borrowingMutex.address, borrower.address, borrower.address, owner.address, liquidator.address, creditOracle.address, parseUSDC(1000), YEAR, 1000)
         await usdc.connect(borrower).approve(fakeLoan.address, parseUSDC(1000))
         await fakeLoan.connect(borrower).fund()
-        await borrowingMutex.lock(borrower.address, await fakeLoan.address)
+        await borrowingMutex.lock(borrower.address)
         await timeTravel(defaultedLoanCloseTime)
         await fakeLoan.enterDefault()
 
@@ -481,7 +481,7 @@ describe('Liquidator2', () => {
         await tru.connect(borrower).approve(stakingVault.address, parseTRU(100))
         await stakingVault.connect(borrower).stake(parseTRU(100))
         await borrowingMutex.allowLocker(owner.address, true)
-        await borrowingMutex.lock(borrower.address, owner.address)
+        await borrowingMutex.lock(borrower.address)
         await borrowingMutex.ban(borrower.address)
         await liquidator.connect(assurance).liquidate([debtToken1.address])
         expect(await tru.balanceOf(assurance.address)).to.equal(parseTRU(100))

--- a/test/truefi2/SAFU.test.ts
+++ b/test/truefi2/SAFU.test.ts
@@ -171,7 +171,7 @@ describe('SAFU', () => {
           await stakingVault.connect(borrower).stake(parseTRU(100))
 
           await borrowingMutex.allowLocker(owner.address, true)
-          await borrowingMutex.lock(borrower.address, owner.address)
+          await borrowingMutex.lock(borrower.address)
           await borrowingMutex.ban(borrower.address)
 
           await safu.liquidate([debt.address])
@@ -338,7 +338,7 @@ describe('SAFU', () => {
           await stakingVault.connect(borrower).stake(parseTRU(100))
 
           await borrowingMutex.allowLocker(owner.address, true)
-          await borrowingMutex.lock(borrower.address, owner.address)
+          await borrowingMutex.lock(borrower.address)
           await borrowingMutex.ban(borrower.address)
 
           await safu.liquidate([debt.address])

--- a/test/truefi2/StakingVault.test.ts
+++ b/test/truefi2/StakingVault.test.ts
@@ -98,12 +98,12 @@ describe('StakingVault', () => {
       await expect(stakingVault.connect(borrower).stake(parseTRU(50)))
         .not.to.be.reverted
 
-      await borrowingMutex.lock(borrower.address, owner.address)
+      await borrowingMutex.lock(borrower.address)
       await expect(stakingVault.connect(borrower).stake(parseTRU(100)))
         .to.be.revertedWith('StakingVault: Borrower can only stake when they\'re unlocked or have a line of credit')
 
       await borrowingMutex.unlock(borrower.address)
-      await borrowingMutex.lock(borrower.address, creditAgency.address)
+      await borrowingMutex.lock(borrower.address)
       await expect(stakingVault.connect(borrower).stake(parseTRU(50)))
         .not.to.be.reverted
     })
@@ -150,7 +150,7 @@ describe('StakingVault', () => {
     })
 
     it('is false when locked but not by credit agency', async () => {
-      await borrowingMutex.lock(borrower.address, owner.address)
+      await borrowingMutex.lock(borrower.address)
       expect(await stakingVault.canUnstake(borrower.address, parseTRU(100))).to.be.false
     })
 
@@ -202,7 +202,7 @@ describe('StakingVault', () => {
     })
 
     it('cannot unstake if mutex is locked', async () => {
-      await borrowingMutex.lock(borrower.address, owner.address)
+      await borrowingMutex.lock(borrower.address)
       await expect(stakingVault.connect(borrower).unstake(parseTRU(101)))
         .to.be.revertedWith('StakingVault: Cannot unstake')
     })
@@ -228,7 +228,7 @@ describe('StakingVault', () => {
     beforeEach(async () => {
       await stakingVault.connect(borrower).stake(parseTRU(100))
       debtToken = await createDebtToken(loanFactory, owner, owner, pool, borrower, parseUSDC(1000))
-      await borrowingMutex.lock(borrower.address, owner.address)
+      await borrowingMutex.lock(borrower.address)
     })
 
     describe('reverts if', () => {

--- a/test/truefi2/TrueFiPool2.test.ts
+++ b/test/truefi2/TrueFiPool2.test.ts
@@ -837,7 +837,7 @@ describe('TrueFiPool2', () => {
       await ftlAgency.reclaim(loan.address, '0x')
       await tusdPool.setLender(lender.address)
       const legacyLoan = await createLegacyLoan(loanFactory, tusdPool, lender, owner, borrower, 500000, DAY, 1000)
-      await borrowingMutex.lock(borrower.address, legacyLoan.address)
+      await borrowingMutex.lock(borrower.address)
       await tusd.mint(lender.address, 500000)
       await lender.connect(borrower).fund(legacyLoan.address)
       await timeTravel(DAY)

--- a/test/truefi2/TrueLender2Deprecated.test.ts
+++ b/test/truefi2/TrueLender2Deprecated.test.ts
@@ -239,7 +239,7 @@ describe('TrueLender2Deprecated', () => {
       const debt = await loan.debt()
       await token.mint(loan.address, debt.sub(balance))
       await borrowingMutex.allowLocker(owner.address, true)
-      await borrowingMutex.lock(borrower.address, loan1.address)
+      await borrowingMutex.lock(borrower.address)
     }
 
     beforeEach(async () => {

--- a/test/truefi2/lines-of-credit/LineOfCreditAgency.test.ts
+++ b/test/truefi2/lines-of-credit/LineOfCreditAgency.test.ts
@@ -462,7 +462,7 @@ describe('LineOfCreditAgency', () => {
 
     it('fails if borrower mutex is already locked', async () => {
       await borrowingMutex.allowLocker(owner.address, true)
-      await borrowingMutex.lock(borrower.address, owner.address)
+      await borrowingMutex.lock(borrower.address)
 
       await expect(creditAgency.connect(borrower).borrow(tusdPool.address, 1000))
         .to.be.revertedWith('BorrowingMutex: Borrower is already locked')
@@ -479,7 +479,7 @@ describe('LineOfCreditAgency', () => {
 
       await faultyCreditAgency.connect(borrower).borrow(tusdPool.address, 1000)
       await faultyBorrowingMutex.unlock(borrower.address)
-      await faultyBorrowingMutex.lock(borrower.address, owner.address)
+      await faultyBorrowingMutex.lock(borrower.address)
 
       await expect(faultyCreditAgency.connect(borrower).borrow(tusdPool.address, 1000))
         .to.be.revertedWith('LineOfCreditAgency: Borrower cannot open two simultaneous debt positions')


### PR DESCRIPTION
This POC PR is a final version (😆) of BorrowingMutex, based against @MiksuJak's PR #1132. You can feel free to take over this PR to fix tests, merge it directly into #1132 to continue work there, or close this if it doesn't make sense.

Proposed changes:
1. Remove the `locker` arg of `mutex.lock()`.
2. Remove the `locker` arg of the `BorrowerUnlocked` event to match the `BorrowerBanned` event (it's never ambiguous who this `locker` is because it's always the same as the `locker` set by the previous `BorrowerLocked` event).
3. Reorder the list of functions to be consistent with each other, and to follow an expected order in which we call them:
  a) `allowLocker()`
  b) `lock()`
  c) `unlock()`
  d) `ban()`
This also makes the similarity between `unlock()` and `ban()` much more prominent, since they will be next to each other.